### PR TITLE
ReadJson not working properly when reading null value

### DIFF
--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/Converters/FeatureCollectionConverter.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/Converters/FeatureCollectionConverter.cs
@@ -36,6 +36,8 @@ namespace NetTopologySuite.IO.Converters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
+            if (reader.TokenType == JsonToken.Null) return null;
+
             reader.Read();
             FeatureCollection fc = new FeatureCollection();
             while (reader.TokenType != JsonToken.EndObject)


### PR DESCRIPTION
When a property of type FeatureCollection is null, deserialization was
failing or reading incorrect values.
