### PR TITLE
CascadedPolygonUnion Performance Improvement

### DIFF
--- a/NetTopologySuite/Index/Strtree/AbstractSTRtree.cs
+++ b/NetTopologySuite/Index/Strtree/AbstractSTRtree.cs
@@ -317,17 +317,17 @@ namespace NetTopologySuite.Index.Strtree
         /// Builds the tree if necessary.
         /// </summary>
         /// <returns>a List of items and/or Lists</returns>
-        public IList<TItem> ItemsTree()
+        public IList ItemsTree()
         {
             Build();
 
             var valuesTree = ItemsTree(_root);
-            return valuesTree ?? new List<TItem>();
+            return valuesTree ?? new List<object>();
         }
 
-        private static IList<TItem> ItemsTree(AbstractNode<T, TItem> node)
+        private static IList ItemsTree(AbstractNode<T, TItem> node)
         {
-            var valuesTreeForNode = new List<TItem>();
+            var valuesTreeForNode = new List<object>();
 
             foreach (var childBoundable in node.ChildBoundables)
             {
@@ -336,7 +336,7 @@ namespace NetTopologySuite.Index.Strtree
                     var valuesTreeForChild = ItemsTree((AbstractNode<T, TItem>)childBoundable);
                     // only add if not null (which indicates an item somewhere in this tree
                     if (valuesTreeForChild != null)
-                        valuesTreeForNode.AddRange(valuesTreeForChild);
+                        valuesTreeForNode.Add(valuesTreeForChild);
                 }
                 else if (childBoundable is ItemBoundable<T, TItem>)
                     valuesTreeForNode.Add(((ItemBoundable<T, TItem>)childBoundable).Item);

--- a/NetTopologySuite/Operation/Union/CascadedPolygonUnion.cs
+++ b/NetTopologySuite/Operation/Union/CascadedPolygonUnion.cs
@@ -287,7 +287,7 @@ namespace NetTopologySuite.Operation.Union
             foreach (var o in geomTree)
             {
                 IGeometry geom = null;
-                if (o is IList<IGeometry>)
+                if (o is IList)
                     geom = UnionTree((IList)o);
                 else if (o is IGeometry)
                     geom = (IGeometry)o;


### PR DESCRIPTION
JTS's version of CascadedPolygonUnion puts everything into an STRTree with a maximum node capacity of 4, and then unions up each node separately.  That way, each step of the cascaded union handles unioning together up to 4 polygons at a time, all of which are "close" to one another.

As of de89f7c, NTS now puts all the polygons into one big list and unions each half of the list recursively, using STRTree only as a means of sorting the list.  This often causes the earlier rounds to remove fewer vertices than JTS would, leaving later rounds to have to deal with more complex polygons than otherwise.

On my machine, this change makes unioning tl_2014_06_tract.zip from ftp://ftp2.census.gov/geo/tiger/TIGER2014/TRACT/ go from 358.6 seconds to 331.9 seconds.  Admittedly not as dramatic as I'd hoped, but still a noticeable improvement, and it's more like the way that JTS does it.
