### PR TITLE
Optimizing VWLineSimplifier Using a Priority Queue

### DIFF
--- a/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj
+++ b/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Triangulate\DelaunayPerformanceTest.cs" />
     <Compile Include="Triangulate\DelaunayTest.cs" />
     <Compile Include="Triangulate\VoronoiTest.cs" />
+    <Compile Include="Utilities\AlternativePriorityQueueTest.cs" />
     <Compile Include="Utilities\PriorityQueueTest.cs" />
     <Compile Include="Utilities\SerializationUtility.cs" />
   </ItemGroup>

--- a/NetTopologySuite.Tests.NUnit/Utilities/AlternativePriorityQueueTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Utilities/AlternativePriorityQueueTest.cs
@@ -30,25 +30,25 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
         [Test]
         public void TestLongSequenceOfOperations()
         {
-            AlternativePriorityQueue<double, int> q = new AlternativePriorityQueue<double, int>();
+            AlternativePriorityQueue<int, int> q = new AlternativePriorityQueue<int, int>();
             addRandomItems(q, 15);
             CheckOrder(q, nodesToKeep: 3);
             addRandomItems(q, 33);
             CheckOrder(q);
             q.Clear();
             addRandomItems(q, 13);
-            q.ChangePriority(q.Head, 1.1);
-            q.ChangePriority(q.Head, 1.2);
-            q.ChangePriority(q.Head, 1.3);
+            q.ChangePriority(q.Head, 6);
+            q.ChangePriority(q.Head, 7);
+            q.ChangePriority(q.Head, 8);
             CheckOrder(q, nodesToKeep: 0);
         }
 
         [Test]
         public void TestCopiedQueue()
         {
-            AlternativePriorityQueue<double, int> q1 = new AlternativePriorityQueue<double, int>();
+            AlternativePriorityQueue<int, int> q1 = new AlternativePriorityQueue<int, int>();
             addRandomItems(q1, 178);
-            AlternativePriorityQueue<double, int> q2 = new AlternativePriorityQueue<double, int>(q1);
+            AlternativePriorityQueue<int, int> q2 = new AlternativePriorityQueue<int, int>(q1);
             addRandomItems(q2, 28);
             CheckOrder(q1, nodesToKeep: 42);
             addRandomItems(q1, 39);
@@ -62,8 +62,8 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
         [Test]
         public void TestDifferentComparer()
         {
-            IComparer<double> comparer = new BackwardsDoubleComparer();
-            AlternativePriorityQueue<double, int> q = new AlternativePriorityQueue<double, int>(comparer);
+            IComparer<int> comparer = new BackwardsInt32Comparer();
+            AlternativePriorityQueue<int, int> q = new AlternativePriorityQueue<int, int>(comparer);
             addRandomItems(q, 15);
             CheckOrder(q, reversed: true);
         }
@@ -71,12 +71,12 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
         [Test]
         public void TestContainsConsistency()
         {
-            AlternativePriorityQueue<double, int> q = new AlternativePriorityQueue<double, int>();
+            AlternativePriorityQueue<int, int> q = new AlternativePriorityQueue<int, int>();
             addRandomItems(q, 150);
 
-            PriorityQueueNode<double, int> missingNode = new PriorityQueueNode<double, int>(14);
-            PriorityQueueNode<double, int> presentNode = new PriorityQueueNode<double, int>(14);
-            q.Enqueue(presentNode, 0.5);
+            PriorityQueueNode<int, int> missingNode = new PriorityQueueNode<int, int>(14);
+            PriorityQueueNode<int, int> presentNode = new PriorityQueueNode<int, int>(14);
+            q.Enqueue(presentNode, 75);
 
             Assert.True(q.Contains(presentNode));
             Assert.False(q.Contains(missingNode));
@@ -90,13 +90,13 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
         [Test]
         public void TestOrder1()
         {
-            AlternativePriorityQueue<double, double> q = new AlternativePriorityQueue<double, double>();
+            AlternativePriorityQueue<int, int> q = new AlternativePriorityQueue<int, int>();
 
-            q.Enqueue(new PriorityQueueNode<double, double>(1), 1);
-            q.Enqueue(new PriorityQueueNode<double, double>(10), 10);
-            q.Enqueue(new PriorityQueueNode<double, double>(5), 5);
-            q.Enqueue(new PriorityQueueNode<double, double>(8), 8);
-            q.Enqueue(new PriorityQueueNode<double, double>(-1), -1);
+            q.Enqueue(new PriorityQueueNode<int, int>(1), 1);
+            q.Enqueue(new PriorityQueueNode<int, int>(10), 10);
+            q.Enqueue(new PriorityQueueNode<int, int>(5), 5);
+            q.Enqueue(new PriorityQueueNode<int, int>(8), 8);
+            q.Enqueue(new PriorityQueueNode<int, int>(-1), -1);
             CheckOrder(q);
         }
 
@@ -104,32 +104,36 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
         [Test]
         public void TestOrderRandom1()
         {
-            AlternativePriorityQueue<double, int> q = new AlternativePriorityQueue<double, int>();
+            AlternativePriorityQueue<int, int> q = new AlternativePriorityQueue<int, int>();
             addRandomItems(q, 100);
             CheckOrder(q);
         }
 
         // Copied from PriorityQueueTest, to ensure consistency.
-        private void addRandomItems<TData>(AlternativePriorityQueue<double, TData> q, int num)
+        private void addRandomItems<TData>(AlternativePriorityQueue<int, TData> q, int num)
         {
             var random = new Random();
 
             for (int i = 0; i < num; i++)
             {
-                double priority = random.NextDouble();
-                q.Enqueue(new PriorityQueueNode<double, TData>(default(TData)), priority);
+                // This usually inserts lots of duplicate values in an order
+                // that *tends* to be increasing, but usually has some values
+                // that should bubble up near the top of the heap.
+                int priority = (int) (num * random.NextDouble());
+
+                q.Enqueue(new PriorityQueueNode<int, TData>(default(TData)), priority);
             }
         }
 
         // Copied from PriorityQueueTest, to ensure consistency.
-        private void CheckOrder<TData>(AlternativePriorityQueue<double, TData> q, int nodesToKeep = 0, bool reversed = false)
+        private void CheckOrder<TData>(AlternativePriorityQueue<int, TData> q, int nodesToKeep = 0, bool reversed = false)
         {
-            double curr = 0;
+            int curr = 0;
             bool first = true;
 
             while (q.Count > nodesToKeep)
             {
-                double next = q.Dequeue().Priority;
+                int next = q.Dequeue().Priority;
                 Console.WriteLine(next);
                 if (!first)
                 {
@@ -149,9 +153,9 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
             }
         }
 
-        private class BackwardsDoubleComparer : Comparer<double>
+        private class BackwardsInt32Comparer : Comparer<int>
         {
-            public override int Compare(double x, double y)
+            public override int Compare(int x, int y)
             {
                 return y.CompareTo(x);
             }

--- a/NetTopologySuite.Tests.NUnit/Utilities/AlternativePriorityQueueTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Utilities/AlternativePriorityQueueTest.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using NetTopologySuite.Utilities;
+using Assert = NUnit.Framework.Assert;
+
+namespace NetTopologySuite.Tests.NUnit.Utilities
+{
+    [TestFixture]
+    public class AlternativePriorityQueueTest
+    {
+        [Test]
+        public void TestEnumeration()
+        {
+            const int NodeCount = 18;
+            AlternativePriorityQueue<double, object> q = new AlternativePriorityQueue<double, object>(NodeCount);
+
+            var random = new Random();
+            var nodes = new PriorityQueueNode<double, object>[NodeCount];
+
+            for (int i = 0; i < NodeCount; i++)
+            {
+                nodes[i] = new PriorityQueueNode<double, object>(null);
+                q.Enqueue(nodes[i], random.NextDouble());
+            }
+
+            CollectionAssert.AreEquivalent(nodes, q);
+        }
+
+        [Test]
+        public void TestLongSequenceOfOperations()
+        {
+            AlternativePriorityQueue<double, int> q = new AlternativePriorityQueue<double, int>();
+            addRandomItems(q, 15);
+            CheckOrder(q, nodesToKeep: 3);
+            addRandomItems(q, 33);
+            CheckOrder(q);
+            q.Clear();
+            addRandomItems(q, 13);
+            q.ChangePriority(q.Head, 1.1);
+            q.ChangePriority(q.Head, 1.2);
+            q.ChangePriority(q.Head, 1.3);
+            CheckOrder(q, nodesToKeep: 0);
+        }
+
+        [Test]
+        public void TestCopiedQueue()
+        {
+            AlternativePriorityQueue<double, int> q1 = new AlternativePriorityQueue<double, int>();
+            addRandomItems(q1, 178);
+            AlternativePriorityQueue<double, int> q2 = new AlternativePriorityQueue<double, int>(q1);
+            addRandomItems(q2, 28);
+            CheckOrder(q1, nodesToKeep: 42);
+            addRandomItems(q1, 39);
+            CheckOrder(q2, nodesToKeep: 2);
+            addRandomItems(q2, 18);
+
+            CheckOrder(q1);
+            CheckOrder(q2);
+        }
+
+        [Test]
+        public void TestDifferentComparer()
+        {
+            IComparer<double> comparer = new BackwardsDoubleComparer();
+            AlternativePriorityQueue<double, int> q = new AlternativePriorityQueue<double, int>(comparer);
+            addRandomItems(q, 15);
+            CheckOrder(q, reversed: true);
+        }
+
+        [Test]
+        public void TestContainsConsistency()
+        {
+            AlternativePriorityQueue<double, int> q = new AlternativePriorityQueue<double, int>();
+            addRandomItems(q, 150);
+
+            PriorityQueueNode<double, int> missingNode = new PriorityQueueNode<double, int>(14);
+            PriorityQueueNode<double, int> presentNode = new PriorityQueueNode<double, int>(14);
+            q.Enqueue(presentNode, 0.5);
+
+            Assert.True(q.Contains(presentNode));
+            Assert.False(q.Contains(missingNode));
+
+            q.Remove(presentNode);
+            Assert.False(q.Contains(presentNode));
+            CheckOrder(q);
+        }
+
+        // Copied from PriorityQueueTest, to ensure consistency.
+        [Test]
+        public void TestOrder1()
+        {
+            AlternativePriorityQueue<double, double> q = new AlternativePriorityQueue<double, double>();
+
+            q.Enqueue(new PriorityQueueNode<double, double>(1), 1);
+            q.Enqueue(new PriorityQueueNode<double, double>(10), 10);
+            q.Enqueue(new PriorityQueueNode<double, double>(5), 5);
+            q.Enqueue(new PriorityQueueNode<double, double>(8), 8);
+            q.Enqueue(new PriorityQueueNode<double, double>(-1), -1);
+            CheckOrder(q);
+        }
+
+        // Copied from PriorityQueueTest, to ensure consistency.
+        [Test]
+        public void TestOrderRandom1()
+        {
+            AlternativePriorityQueue<double, int> q = new AlternativePriorityQueue<double, int>();
+            addRandomItems(q, 100);
+            CheckOrder(q);
+        }
+
+        // Copied from PriorityQueueTest, to ensure consistency.
+        private void addRandomItems<TData>(AlternativePriorityQueue<double, TData> q, int num)
+        {
+            var random = new Random();
+
+            for (int i = 0; i < num; i++)
+            {
+                double priority = random.NextDouble();
+                q.Enqueue(new PriorityQueueNode<double, TData>(default(TData)), priority);
+            }
+        }
+
+        // Copied from PriorityQueueTest, to ensure consistency.
+        private void CheckOrder<TData>(AlternativePriorityQueue<double, TData> q, int nodesToKeep = 0, bool reversed = false)
+        {
+            double curr = 0;
+            bool first = true;
+
+            while (q.Count > nodesToKeep)
+            {
+                double next = q.Dequeue().Priority;
+                Console.WriteLine(next);
+                if (!first)
+                {
+                    int comparison = next.CompareTo(curr);
+                    if (reversed)
+                    {
+                        Assert.LessOrEqual(comparison, 0);
+                    }
+                    else
+                    {
+                        Assert.GreaterOrEqual(comparison, 0);
+                    }
+                }
+
+                first = false;
+                curr = next;
+            }
+        }
+
+        private class BackwardsDoubleComparer : Comparer<double>
+        {
+            public override int Compare(double x, double y)
+            {
+                return y.CompareTo(x);
+            }
+        }
+    }
+}

--- a/NetTopologySuite.Tests.NUnit/Utilities/PriorityQueueTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Utilities/PriorityQueueTest.cs
@@ -23,18 +23,21 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
         [Test]
         public void TestOrderRandom1()
         {
-            PriorityQueue<double> q = new PriorityQueue<double>();
+            PriorityQueue<int> q = new PriorityQueue<int>();
             addRandomItems(q, 100);
             CheckOrder(q);
         }
 
-        private void addRandomItems(PriorityQueue<double> q, int num)
+        private void addRandomItems(PriorityQueue<int> q, int num)
         {
             var random = new Random();
 
             for (int i = 0; i < num; i++)
             {
-                q.Add(random.NextDouble());
+                // This usually inserts lots of duplicate values in an order
+                // that *tends* to be increasing, but usually has some values
+                // that should bubble up near the top of the heap.
+                q.Add((int)(num * random.NextDouble()));
             }
         }
 

--- a/NetTopologySuite.Tests.NUnit/Utilities/PriorityQueueTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Utilities/PriorityQueueTest.cs
@@ -5,10 +5,10 @@ using Assert = NUnit.Framework.Assert;
 
 namespace NetTopologySuite.Tests.NUnit.Utilities
 {
-    [TestFixtureAttribute]
+    [TestFixture]
     public class PriorityQueueTest
     {
-        [TestAttribute]
+        [Test]
         public void TestOrder1()
         {
             PriorityQueue<int> q = new PriorityQueue<int>();
@@ -20,37 +20,41 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
             CheckOrder(q);
         }
 
-        [TestAttribute]
+        [Test]
         public void TestOrderRandom1()
         {
-            PriorityQueue<int> q = new PriorityQueue<int>();
+            PriorityQueue<double> q = new PriorityQueue<double>();
             addRandomItems(q, 100);
             CheckOrder(q);
         }
 
-        private void addRandomItems(PriorityQueue<int> q, int num)
+        private void addRandomItems(PriorityQueue<double> q, int num)
         {
             var random = new Random();
 
             for (int i = 0; i < num; i++)
             {
-                q.Add((int)(num * random.NextDouble()));
+                q.Add(random.NextDouble());
             }
         }
 
         private void CheckOrder<T>(PriorityQueue<T> q)
-            where T: IComparable<T>
+            where T: struct, IComparable<T>
         {
-            IComparable<T> curr = null;
+            T curr = default(T);
+            bool first = true;
 
             while (!q.IsEmpty())
             {
-                IComparable<T> next = (IComparable<T>)q.Poll();
+                T next = q.Poll();
                 Console.WriteLine(next);
-                if (curr == null)
-                    curr = next;
-                else
-                    Assert.IsTrue(next.CompareTo((T)curr) >= 0);
+                if (!first)
+                {
+                    Assert.IsTrue(next.CompareTo(curr) >= 0);
+                }
+
+                first = false;
+                curr = next;
             }
         }
     }

--- a/NetTopologySuite/NetTopologySuite.csproj
+++ b/NetTopologySuite/NetTopologySuite.csproj
@@ -457,6 +457,7 @@
     <Compile Include="Simplify\DouglasPeuckerLineSimplifier.cs" />
     <Compile Include="Simplify\DouglasPeuckerSimplifier.cs" />
     <Compile Include="Simplify\LineSegmentIndex.cs" />
+    <Compile Include="Simplify\OldVWLineSimplifier.cs" />
     <Compile Include="Simplify\TaggedLineSegment.cs" />
     <Compile Include="Simplify\TaggedLinesSimplifier.cs" />
     <Compile Include="Simplify\TaggedLineString.cs" />
@@ -490,6 +491,8 @@
     <Compile Include="Triangulate\SplitSegment.cs" />
     <Compile Include="Triangulate\VertexTaggedGeometryDataMapper.cs" />
     <Compile Include="Triangulate\VoronoiDiagramBuilder.cs" />
+    <Compile Include="Utilities\AlternativePriorityQueue.cs" />
+    <Compile Include="Utilities\PriorityQueueNode.cs" />
     <Compile Include="Utilities\Assert.cs" />
     <Compile Include="Utilities\AssertionFailedException.cs" />
     <Compile Include="Utilities\BitConverter.cs" />

--- a/NetTopologySuite/Simplify/OldVWLineSimplifier.cs
+++ b/NetTopologySuite/Simplify/OldVWLineSimplifier.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using GeoAPI.Geometries;
+using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Simplify
+{
+    /// <summary>
+    /// Simplifies a linestring (sequence of points) using the 
+    /// Visvalingam-Whyatt algorithm.
+    /// The Visvalingam-Whyatt algorithm simplifies geometry 
+    /// by removing vertices while trying to minimize the area changed.
+    /// </summary>
+    /// <version>1.7</version>
+    public class OldVWLineSimplifier
+    {
+        public static Coordinate[] Simplify(Coordinate[] pts, double distanceTolerance)
+        {
+            OldVWLineSimplifier simp = new OldVWLineSimplifier(pts, distanceTolerance);
+            return simp.Simplify();
+        }
+
+        private readonly Coordinate[] _pts;
+        private readonly double _tolerance;
+
+        public OldVWLineSimplifier(Coordinate[] pts, double distanceTolerance)
+        {
+            _pts = pts;
+            _tolerance = distanceTolerance * distanceTolerance;
+        }
+
+        public Coordinate[] Simplify()
+        {
+            VWVertex vwLine = VWVertex.BuildLine(_pts);
+            double minArea = _tolerance;
+            do
+            {
+                minArea = SimplifyVertex(vwLine);
+            }
+            while (minArea < _tolerance);
+            Coordinate[] simp = vwLine.GetCoordinates();
+            // ensure computed value is a valid line
+            if (simp.Length >= 2)
+                return simp;
+            return new[] { simp[0], new Coordinate(simp[0]) };
+        }
+
+        private double SimplifyVertex(VWVertex vwLine)
+        {
+            // Scan vertices in line and remove the one with smallest effective area.
+            // TODO: use an appropriate data structure to optimize finding the smallest area vertex
+            VWVertex curr = vwLine;
+            double minArea = curr.GetArea();
+            VWVertex minVertex = null;
+            while (curr != null)
+            {
+                double area = curr.GetArea();
+                if (area < minArea)
+                {
+                    minArea = area;
+                    minVertex = curr;
+                }
+                curr = curr.Next;
+            }
+            if (minVertex != null && minArea < _tolerance)
+                minVertex.Remove();
+            if (!vwLine.IsLive)
+                return -1;
+            return minArea;
+        }
+
+        internal class VWVertex
+        {
+            public static VWVertex BuildLine(Coordinate[] pts)
+            {
+                VWVertex first = null;
+                VWVertex prev = null;
+                foreach (Coordinate c in pts)
+                {
+                    VWVertex v = new VWVertex(c);
+                    if (first == null)
+                        first = v;
+                    v.Prev = prev;
+                    if (prev != null)
+                    {
+                        prev.Next = v;
+                        prev.UpdateArea();
+                    }
+                    prev = v;
+                }
+                return first;
+            }
+
+            private const double MaxArea = Double.MaxValue;
+
+            private readonly Coordinate _pt;
+            private VWVertex _prev;
+            private VWVertex _next;
+            private double _area = MaxArea;
+            private bool _isLive = true;
+
+            public VWVertex(Coordinate pt)
+            {
+                this._pt = pt;
+            }
+
+            public VWVertex Prev
+            {
+                get { return _prev; }
+                set { _prev = value; }
+            }
+
+            public VWVertex Next
+            {
+                get { return _next; }
+                set { _next = value; }
+            }
+
+            public void UpdateArea()
+            {
+                if (Prev == null || Next == null)
+                {
+                    _area = MaxArea;
+                    return;
+                }
+                double d = Triangle.Area(Prev._pt, _pt, Next._pt);
+                _area = Math.Abs(d);
+            }
+
+            public double GetArea()
+            {
+                return _area;
+            }
+
+            public bool IsLive
+            {
+                get { return _isLive; }
+            }
+
+            public VWVertex Remove()
+            {
+                VWVertex tmpPrev = Prev;
+                var tmpNext = Next;
+                VWVertex result = null;
+                if (Prev != null)
+                {
+                    Prev.Next = tmpNext;
+                    Prev.UpdateArea();
+                    result = Prev;
+                }
+                if (Next != null)
+                {
+                    Next.Prev = tmpPrev;
+                    Next.UpdateArea();
+                    if (result == null)
+                        result = Next;
+                }
+                _isLive = false;
+                return result;
+            }
+
+            public Coordinate[] GetCoordinates()
+            {
+                CoordinateList coords = new CoordinateList();
+                VWVertex curr = this;
+                do
+                {
+                    coords.Add(curr._pt, false);
+                    curr = curr.Next;
+                }
+                while (curr != null);
+                return coords.ToCoordinateArray();
+            }
+        }
+    }
+}

--- a/NetTopologySuite/Simplify/VWLineSimplifier.cs
+++ b/NetTopologySuite/Simplify/VWLineSimplifier.cs
@@ -33,12 +33,14 @@ namespace NetTopologySuite.Simplify
         public Coordinate[] Simplify()
         {
             // Put every coordinate index into an AlternativePriorityQueueNode.
-            // this array doubles as a way to check which coordinates are excluded.
+            // this array doubles as a way to check which coordinates are
+            // excluded.
             var nodes = new PriorityQueueNode<IndexWithArea, int>[_pts.Length];
 
             // Store the coordinates, with their effective areas, in a min heap.
-            // Visvalingam-Whyatt repeatedly deletes the coordinate with the min
-            // effective area so a structure with efficient delete-min is ideal.
+            // Visvalingam-Whyatt repeatedly deletes the coordinate with the
+            // min effective area so a structure with efficient delete-min is
+            // ideal.
             var queue = new AlternativePriorityQueue<IndexWithArea, int>(_pts.Length);
 
             // First and last coordinates are included automatically.
@@ -84,7 +86,7 @@ namespace NetTopologySuite.Simplify
                     while (prev2 > 0 && nodes[prev2] == null) { --prev2; }
 
                     double area = Triangle.Area(_pts[prev2], _pts[prev], _pts[next]);
-                    queue.UpdatePriority(nodes[prev], new IndexWithArea(prev, area));
+                    queue.ChangePriority(nodes[prev], new IndexWithArea(prev, area));
                 }
 
                 // Same idea as what we did above for prev.
@@ -98,7 +100,7 @@ namespace NetTopologySuite.Simplify
                     while (next2 < _pts.Length - 1 && nodes[next2] == null) { ++next2; }
 
                     double area = Triangle.Area(_pts[prev], _pts[next], _pts[next2]);
-                    queue.UpdatePriority(nodes[next], new IndexWithArea(next, area));
+                    queue.ChangePriority(nodes[next], new IndexWithArea(next, area));
                 }
             }
 
@@ -121,9 +123,10 @@ namespace NetTopologySuite.Simplify
             }
 
             // Special-case: we want to make sure that we don't return a 1-
-            // element array, as the outputs of this are typically used to build
-            // an ILineString.  So if there's just one coordinate, we output it
-            // twice, mainly just to ensure parity with JTS / old NTS.
+            // element array, as the outputs of this are typically used to
+            // build an ILineString.  So if there's just one coordinate, we
+            // output it twice, mainly just to ensure equivalence to JTS / old
+            // NTS.
             list.Add(_pts[_pts.Length - 1], list.Count == 1);
 
             return list.ToArray();
@@ -146,6 +149,9 @@ namespace NetTopologySuite.Simplify
             public int CompareTo(IndexWithArea other)
             {
                 int areaComparison = this.area.CompareTo(other.area);
+
+                // Do the index comparison if areas are equal, to ensure
+                // equivalence with JTS / old NTS.
                 return areaComparison == 0
                            ? this.index.CompareTo(other.index)
                            : areaComparison;

--- a/NetTopologySuite/Utilities/AlternativePriorityQueue.cs
+++ b/NetTopologySuite/Utilities/AlternativePriorityQueue.cs
@@ -1,22 +1,113 @@
-﻿using System;
+﻿// Derived from BlueRaja's "High Speed Priority Queue for C#",
+// which has the following license text:
+/*
+The MIT License (MIT)
+
+Copyright (c) 2013 Daniel "BlueRaja" Pflughoeft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NetTopologySuite.Utilities
 {
+    /// <summary>
+    /// An alternative implementation of the priority queue abstract data type.
+    /// This allows us to do more than <see cref="PriorityQueue{T}"/>, which we
+    /// got from JTS.  Ultimately, this queue enables scenarios that have more
+    /// favorable execution speed characteristics at the cost of less favorable
+    /// memory and usability characteristics.
+    /// </summary>
+    /// <typeparam name="TPriority">
+    /// The type of the priority for each queue node.
+    /// </typeparam>
+    /// <typeparam name="TData">
+    /// The type of data stored in the queue.
+    /// </typeparam>
+    /// <remarks>
+    /// When enumerating over the queue, note that the elements will not be in
+    /// sorted order.  To get at the elements in sorted order, use the copy
+    /// constructor and repeatedly <see cref="Dequeue"/> elements from it.
+    /// </remarks>
     public sealed class AlternativePriorityQueue<TPriority, TData> : IEnumerable<PriorityQueueNode<TPriority, TData>>
     {
-        private readonly PriorityQueueNode<TPriority, TData>[] nodes;
+        private const int DefaultCapacity = 4;
+
+        private readonly List<PriorityQueueNode<TPriority, TData>> nodes;
 
         private readonly IComparer<TPriority> priorityComparer;
 
-        private int version;
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="AlternativePriorityQueue{TPriority, TData}"/> class.
+        /// </summary>
+        public AlternativePriorityQueue()
+            : this(DefaultCapacity)
+        {
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="AlternativePriorityQueue{TPriority, TData}"/> class.
+        /// </summary>
+        /// <param name="capacity">
+        /// The initial queue capacity.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="capacity"/> is less than 1.
+        /// </exception>
         public AlternativePriorityQueue(int capacity)
             : this(capacity, null)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="AlternativePriorityQueue{TPriority, TData}"/> class.
+        /// </summary>
+        /// <param name="priorityComparer">
+        /// The <see cref="IComparer{T}"/> to use to compare priority values,
+        /// or <see langword="null"/> to use the default comparer for the type.
+        /// </param>
+        public AlternativePriorityQueue(IComparer<TPriority> priorityComparer)
+            : this(DefaultCapacity, priorityComparer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="AlternativePriorityQueue{TPriority, TData}"/> class.
+        /// </summary>
+        /// <param name="capacity">
+        /// The initial queue capacity.
+        /// </param>
+        /// <param name="priorityComparer">
+        /// The <see cref="IComparer{T}"/> to use to compare priority values,
+        /// or <see langword="null"/> to use the default comparer for the type.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="capacity"/> is less than 1.
+        /// </exception>
         public AlternativePriorityQueue(int capacity, IComparer<TPriority> priorityComparer)
         {
             if (capacity < 1)
@@ -24,103 +115,181 @@ namespace NetTopologySuite.Utilities
                 throw new ArgumentOutOfRangeException("capacity", "Capacity must be greater than zero.");
             }
 
-            this.nodes = new PriorityQueueNode<TPriority, TData>[capacity + 1];
+            this.nodes = new List<PriorityQueueNode<TPriority, TData>>(capacity + 1);
+            for (int i = 0; i <= capacity; i++)
+            {
+                this.nodes.Add(null);
+            }
+
             this.Count = 0;
             this.priorityComparer = priorityComparer ?? Comparer<TPriority>.Default;
         }
 
-        public int Count { get; private set; }
-
-        public int Capacity { get { return this.nodes.Length - 1; } }
-
-        public PriorityQueueNode<TPriority, TData> Head { get { return this.nodes[1]; } }
-
-#if DEBUG
-        public bool IsValid
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="AlternativePriorityQueue{TPriority, TData}"/> class.
+        /// </summary>
+        /// <param name="copyFrom">
+        /// The <see cref="AlternativePriorityQueue{TPriority, TData}"/> to
+        /// copy from.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="copyFrom"/> is <see langword="null"/>.
+        /// </exception>
+        public AlternativePriorityQueue(AlternativePriorityQueue<TPriority, TData> copyFrom)
         {
-            get
+            if (copyFrom == null)
             {
-                for (int i = 1; i < this.nodes.Length; i++)
-                {
-                    if (this.nodes[i] == null)
-                    {
-                        continue;
-                    }
+                throw new ArgumentNullException("copyFrom");
+            }
 
-                    int childLeftIndex = 2 * i;
-                    if (childLeftIndex < this.nodes.Length &&
-                        this.nodes[childLeftIndex] != null &&
-                        this.HasHigherPriority(this.nodes[childLeftIndex], this.nodes[i]))
-                    {
-                        return false;
-                    }
+            this.nodes = new List<PriorityQueueNode<TPriority, TData>>(copyFrom.nodes.Count);
+            this.priorityComparer = copyFrom.priorityComparer;
 
-                    int childRightIndex = childLeftIndex + 1;
-                    if (childRightIndex < this.nodes.Length &&
-                        this.nodes[childRightIndex] != null &&
-                        this.HasHigherPriority(this.nodes[childRightIndex], this.nodes[i]))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
+            // We need to copy the nodes, because they store queue state that
+            // will change in one queue but not in the other.
+            for (int i = 0; i < copyFrom.nodes.Count; i++)
+            {
+                var nodeToCopy = copyFrom.nodes[i];
+                var copiedNode = nodeToCopy == null
+                    ? null
+                    : new PriorityQueueNode<TPriority, TData>(nodeToCopy);
+                this.nodes.Add(copiedNode);
             }
         }
-#endif
 
+        /// <summary>
+        /// Gets the number of nodes currently stored in this queue.
+        /// </summary>
+        public int Count { get; private set; }
+
+        /// <summary>
+        /// Gets the node at the head of the queue.
+        /// This is the node whose <typeparamref name="TPriority"/> compares
+        /// less than or equal to the priority of all other nodes in the queue.
+        /// </summary>
+        public PriorityQueueNode<TPriority, TData> Head { get { return this.nodes[1]; } }
+
+        /// <summary>
+        /// Removes all nodes from this queue.
+        /// </summary>
         public void Clear()
         {
-            Array.Clear(this.nodes, 0, this.nodes.Length);
+            this.nodes.Clear();
+
+            // There must always be a slot for the sentinel at the top, plus a
+            // slot for the head (even if the head is null).
+            this.nodes.Add(null);
+            this.nodes.Add(null);
+
             this.Count = 0;
-            ++this.version;
         }
 
+        /// <summary>
+        /// Determines whether the given node is contained within this queue.
+        /// </summary>
+        /// <param name="node">
+        /// The node to locate in the queue.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="node"/> is found in the
+        /// queue, otherwise <see langword="false"/>.
+        /// </returns>
         public bool Contains(PriorityQueueNode<TPriority, TData> node)
         {
-            return this.nodes[node.QueueIndex] == node;
+            return node != null &&
+                   node.QueueIndex < this.nodes.Count &&
+                   this.nodes[node.QueueIndex] == node;
         }
 
+        /// <summary>
+        /// Adds a given node to the queue with the given priority.
+        /// </summary>
+        /// <param name="node">
+        /// The node to add to the queue.
+        /// </param>
+        /// <param name="priority">
+        /// The priority for the node.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="node"/> is <see langword="null"/>.
+        /// </exception>
         public void Enqueue(PriorityQueueNode<TPriority, TData> node, TPriority priority)
         {
+            if (node == null)
+            {
+                throw new ArgumentNullException("node");
+            }
+
             node.Priority = priority;
             node.QueueIndex = ++this.Count;
 
-            this.nodes[node.QueueIndex] = node;
+            if (this.nodes.Count <= this.Count)
+            {
+                this.nodes.Add(null);
+            }
+
+            this.nodes[this.Count] = node;
             this.HeapifyUp(this.nodes[this.Count]);
-            ++this.version;
         }
 
+        /// <summary>
+        /// Removes and returns the head of the queue.
+        /// </summary>
+        /// <returns>
+        /// The removed element.
+        /// </returns>
         public PriorityQueueNode<TPriority, TData> Dequeue()
         {
             var result = this.Head;
             this.Remove(result);
-
-            // Remove() updates our version for us.
-            ////++this.version;
             return result;
         }
 
-        public void UpdatePriority(PriorityQueueNode<TPriority, TData> node, TPriority priority)
+        /// <summary>
+        /// Changes the priority of the given node.
+        /// </summary>
+        /// <param name="node">
+        /// The node whose priority to change.
+        /// </param>
+        /// <param name="priority">
+        /// The new priority for the node.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="node"/> is <see langword="null"/>.
+        /// </exception>
+        public void ChangePriority(PriorityQueueNode<TPriority, TData> node, TPriority priority)
         {
+            if (node == null)
+            {
+                throw new ArgumentNullException("node");
+            }
+
             node.Priority = priority;
             this.OnNodeUpdated(node);
-            ++this.version;
         }
 
-        public void Remove(PriorityQueueNode<TPriority, TData> node)
+        /// <summary>
+        /// Removes the given node from this queue if it is present.
+        /// </summary>
+        /// <param name="node">
+        /// The node to remove if present.
+        /// </param>
+        /// <returns>
+        /// A value indicating whether the node was removed.
+        /// </returns>
+        public bool Remove(PriorityQueueNode<TPriority, TData> node)
         {
             if (!this.Contains(node))
             {
-                return;
+                return false;
             }
 
             if (this.Count <= 1)
             {
                 this.nodes[1] = null;
                 this.Count = 0;
-                ++this.version;
-                return;
+                return true;
             }
 
             bool wasSwapped = false;
@@ -139,23 +308,19 @@ namespace NetTopologySuite.Utilities
                 this.OnNodeUpdated(formerLastNode);
             }
 
-            ++this.version;
+            return true;
         }
 
+        /// <inheritdoc />
         public IEnumerator<PriorityQueueNode<TPriority, TData>> GetEnumerator()
         {
-            int originalVersion = this.version;
-            for (int i = 0; i < this.Count; i++)
-            {
-                if (originalVersion != this.version)
-                {
-                    throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
-                }
-
-                yield return this.nodes[i + 1];
-            }
+            return this.nodes
+                       .Skip(1)
+                       .Take(this.Count)
+                       .GetEnumerator();
         }
 
+        /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();
@@ -253,7 +418,9 @@ namespace NetTopologySuite.Utilities
 
         private bool HasHigherPriority(PriorityQueueNode<TPriority, TData> higher, PriorityQueueNode<TPriority, TData> lower)
         {
-            return this.priorityComparer.Compare(higher.Priority, lower.Priority) <= 0;
+            // The "higher-priority" item is actually the item whose priority
+            // compares *lower*, because this is a min-heap.
+            return this.priorityComparer.Compare(higher.Priority, lower.Priority) < 0;
         }
     }
 }

--- a/NetTopologySuite/Utilities/AlternativePriorityQueue.cs
+++ b/NetTopologySuite/Utilities/AlternativePriorityQueue.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Utilities
+{
+    public sealed class AlternativePriorityQueue<TPriority, TData> : IEnumerable<PriorityQueueNode<TPriority, TData>>
+    {
+        private readonly PriorityQueueNode<TPriority, TData>[] nodes;
+
+        private readonly IComparer<TPriority> priorityComparer;
+
+        private int version;
+
+        public AlternativePriorityQueue(int capacity)
+            : this(capacity, null)
+        {
+        }
+
+        public AlternativePriorityQueue(int capacity, IComparer<TPriority> priorityComparer)
+        {
+            if (capacity < 1)
+            {
+                throw new ArgumentOutOfRangeException("capacity", "Capacity must be greater than zero.");
+            }
+
+            this.nodes = new PriorityQueueNode<TPriority, TData>[capacity + 1];
+            this.Count = 0;
+            this.priorityComparer = priorityComparer ?? Comparer<TPriority>.Default;
+        }
+
+        public int Count { get; private set; }
+
+        public int Capacity { get { return this.nodes.Length - 1; } }
+
+        public PriorityQueueNode<TPriority, TData> Head { get { return this.nodes[1]; } }
+
+#if DEBUG
+        public bool IsValid
+        {
+            get
+            {
+                for (int i = 1; i < this.nodes.Length; i++)
+                {
+                    if (this.nodes[i] == null)
+                    {
+                        continue;
+                    }
+
+                    int childLeftIndex = 2 * i;
+                    if (childLeftIndex < this.nodes.Length &&
+                        this.nodes[childLeftIndex] != null &&
+                        this.HasHigherPriority(this.nodes[childLeftIndex], this.nodes[i]))
+                    {
+                        return false;
+                    }
+
+                    int childRightIndex = childLeftIndex + 1;
+                    if (childRightIndex < this.nodes.Length &&
+                        this.nodes[childRightIndex] != null &&
+                        this.HasHigherPriority(this.nodes[childRightIndex], this.nodes[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+#endif
+
+        public void Clear()
+        {
+            Array.Clear(this.nodes, 0, this.nodes.Length);
+            this.Count = 0;
+            ++this.version;
+        }
+
+        public bool Contains(PriorityQueueNode<TPriority, TData> node)
+        {
+            return this.nodes[node.QueueIndex] == node;
+        }
+
+        public void Enqueue(PriorityQueueNode<TPriority, TData> node, TPriority priority)
+        {
+            node.Priority = priority;
+            node.QueueIndex = ++this.Count;
+
+            this.nodes[node.QueueIndex] = node;
+            this.HeapifyUp(this.nodes[this.Count]);
+            ++this.version;
+        }
+
+        public PriorityQueueNode<TPriority, TData> Dequeue()
+        {
+            var result = this.Head;
+            this.Remove(result);
+
+            // Remove() updates our version for us.
+            ////++this.version;
+            return result;
+        }
+
+        public void UpdatePriority(PriorityQueueNode<TPriority, TData> node, TPriority priority)
+        {
+            node.Priority = priority;
+            this.OnNodeUpdated(node);
+            ++this.version;
+        }
+
+        public void Remove(PriorityQueueNode<TPriority, TData> node)
+        {
+            if (!this.Contains(node))
+            {
+                return;
+            }
+
+            if (this.Count <= 1)
+            {
+                this.nodes[1] = null;
+                this.Count = 0;
+                ++this.version;
+                return;
+            }
+
+            bool wasSwapped = false;
+            var formerLastNode = this.nodes[this.Count];
+            if (node.QueueIndex != this.Count)
+            {
+                this.Swap(node, formerLastNode);
+                wasSwapped = true;
+            }
+
+            --this.Count;
+            this.nodes[node.QueueIndex] = null;
+
+            if (wasSwapped)
+            {
+                this.OnNodeUpdated(formerLastNode);
+            }
+
+            ++this.version;
+        }
+
+        public IEnumerator<PriorityQueueNode<TPriority, TData>> GetEnumerator()
+        {
+            int originalVersion = this.version;
+            for (int i = 0; i < this.Count; i++)
+            {
+                if (originalVersion != this.version)
+                {
+                    throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+                }
+
+                yield return this.nodes[i + 1];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        private void HeapifyUp(PriorityQueueNode<TPriority, TData> node)
+        {
+            int parent = node.QueueIndex / 2;
+            while (parent >= 1)
+            {
+                var parentNode = this.nodes[parent];
+                if (this.HasHigherPriority(parentNode, node))
+                {
+                    break;
+                }
+
+                this.Swap(node, parentNode);
+
+                parent = node.QueueIndex / 2;
+            }
+        }
+
+        private void HeapifyDown(PriorityQueueNode<TPriority, TData> node)
+        {
+            int finalQueueIndex = node.QueueIndex;
+            while (true)
+            {
+                var newParent = node;
+                int childLeftIndex = 2 * finalQueueIndex;
+
+                if (childLeftIndex > this.Count)
+                {
+                    node.QueueIndex = finalQueueIndex;
+                    this.nodes[finalQueueIndex] = node;
+                    break;
+                }
+
+                var childLeft = this.nodes[childLeftIndex];
+                if (this.HasHigherPriority(childLeft, newParent))
+                {
+                    newParent = childLeft;
+                }
+
+                int childRightIndex = childLeftIndex + 1;
+                if (childRightIndex <= this.Count)
+                {
+                    var childRight = this.nodes[childRightIndex];
+                    if (this.HasHigherPriority(childRight, newParent))
+                    {
+                        newParent = childRight;
+                    }
+                }
+
+                if (newParent != node)
+                {
+                    this.nodes[finalQueueIndex] = newParent;
+
+                    int temp = newParent.QueueIndex;
+                    newParent.QueueIndex = finalQueueIndex;
+                    finalQueueIndex = temp;
+                }
+                else
+                {
+                    node.QueueIndex = finalQueueIndex;
+                    this.nodes[finalQueueIndex] = node;
+                    break;
+                }
+            }
+        }
+
+        private void OnNodeUpdated(PriorityQueueNode<TPriority, TData> node)
+        {
+            int parentIndex = node.QueueIndex / 2;
+            var parentNode = this.nodes[parentIndex];
+
+            if (parentIndex > 0 && this.HasHigherPriority(node, parentNode))
+            {
+                this.HeapifyUp(node);
+            }
+            else
+            {
+                this.HeapifyDown(node);
+            }
+        }
+
+        private void Swap(PriorityQueueNode<TPriority, TData> node1, PriorityQueueNode<TPriority, TData> node2)
+        {
+            this.nodes[node1.QueueIndex] = node2;
+            this.nodes[node2.QueueIndex] = node1;
+
+            int temp = node1.QueueIndex;
+            node1.QueueIndex = node2.QueueIndex;
+            node2.QueueIndex = temp;
+        }
+
+        private bool HasHigherPriority(PriorityQueueNode<TPriority, TData> higher, PriorityQueueNode<TPriority, TData> lower)
+        {
+            return this.priorityComparer.Compare(higher.Priority, lower.Priority) <= 0;
+        }
+    }
+}

--- a/NetTopologySuite/Utilities/PriorityQueue.cs
+++ b/NetTopologySuite/Utilities/PriorityQueue.cs
@@ -1,10 +1,8 @@
-#define Original
 using System;
 using System.Collections.Generic;
 
 namespace NetTopologySuite.Utilities
 {
-#if Original
     ///<summary>
     /// A priority queue over a set of <see cref="IComparable{T}"/> objects.
     ///</summary>
@@ -13,52 +11,16 @@ namespace NetTopologySuite.Utilities
     public class PriorityQueue<T>
         where T : IComparable<T>
     {
-        private int _size; // Number of elements in queue
-        private readonly List<T> _items; // The queue binary heap array
-
-        ///<summary>
-        /// Creates a new empty priority queue
-        ///</summary>
-        public PriorityQueue()
-        {
-            _size = 0;
-            _items = new List<T>();
-            // create space for sentinel
-            _items.Add(default(T));
-        }
+        private readonly AlternativePriorityQueue<T, T> queue = new AlternativePriorityQueue<T, T>();
 
         ///<summary>Insert into the priority queue. Duplicates are allowed.
         ///</summary>
         /// <param name="x">The item to insert.</param>
         public void Add(T x)
         {
-            // increase the size of the items heap to create a hole for the new item
-            _items.Add(default(T));
-
-            // Insert item at end of heap and then re-establish ordering
-            _size += 1;
-            int hole = _size;
-            // set the item as a sentinel at the base of the heap
-            _items[0] = x;
-
-            // move the item up from the hole position to its correct place
-            for (; x.CompareTo(_items[hole / 2]) < 0; hole /= 2)
-            {
-                _items[hole] = _items[hole / 2];
-            }
-            // insert the new item in the correct place
-            _items[hole] = x;
+            var node = new PriorityQueueNode<T, T>(x);
+            this.queue.Enqueue(node, x);
         }
-
-        /**
-         * Establish heap from an arbitrary arrangement of items. 
-         */
-        /*
-         private void buildHeap( ) {
-         for( int i = currentSize / 2; i > 0; i-- )
-         reorder( i );
-         }
-         */
 
         ///<summary>
         /// Test if the priority queue is logically empty.
@@ -66,7 +28,7 @@ namespace NetTopologySuite.Utilities
         /// <returns><c>true</c> if empty, <c>false</c> otherwise.</returns>
         public bool IsEmpty()
         {
-            return _size == 0;
+            return this.queue.Count == 0;
         }
 
         ///<summary>
@@ -74,7 +36,7 @@ namespace NetTopologySuite.Utilities
         ///</summary>
         public int Size
         {
-            get { return _size; }
+            get { return this.queue.Count; }
         }
 
         ///<summary>
@@ -82,8 +44,7 @@ namespace NetTopologySuite.Utilities
         ///</summary>
         public void Clear()
         {
-            _size = 0;
-            _items.Clear();
+            this.queue.Clear();
         }
 
         ///<summary>
@@ -92,125 +53,10 @@ namespace NetTopologySuite.Utilities
         /// <remarks>The smallest item, or <value>default(T)</value> if empty.</remarks>
         public T Poll()
         {
-            if (IsEmpty())
-                return default(T);
-            T minItem = _items[1];
-            _items[1] = _items[_size];
-            _size -= 1;
-            Reorder(1);
-
-            return minItem;
-        }
-
-        ///<summary>
-        /// Private method to percolate down in the heap.
-        ///</summary>
-        /// <param name="hole">The index at which the percolate begins.</param>
-        private void Reorder(int hole)
-        {
-            int child;
-            T tmp = _items[hole];
-
-            for (; hole * 2 <= _size; hole = child)
-            {
-                child = hole * 2;
-                if (child != _size
-                    && (_items[child + 1]).CompareTo(_items[child]) < 0)
-                    child++;
-                if ((_items[child]).CompareTo(tmp) < 0)
-                    _items[hole] = _items[child];
-                else
-                    break;
-            }
-            _items[hole] = tmp;
+            var node = this.queue.Dequeue();
+            return node == null
+                ? default(T)
+                : node.Data;
         }
     }
-
-#elif Alternative
-    public class PriorityQueue<T> where T : IComparable<T>
-    {
-        private List<T> data;
-
-        public PriorityQueue()
-        {
-            this.data = new List<T>();
-        }
-
-        public void Add(T item) { Enqueue(item);}
-        public T Poll() { return Dequeue(); }
-        public bool IsEmpty() { return data.Count == 0;}
-        public void Enqueue(T item)
-        {
-            data.Add(item);
-            int ci = data.Count - 1; // child index; start at end
-            while (ci > 0)
-            {
-                int pi = (ci - 1) / 2; // parent index
-                if (data[ci].CompareTo(data[pi]) >= 0) break; // child item is larger than (or equal) parent so we're done
-                T tmp = data[ci]; data[ci] = data[pi]; data[pi] = tmp;
-                ci = pi;
-            }
-        }
-
-        public T Dequeue()
-        {
-            // assumes pq is not empty; up to calling code
-            int li = data.Count - 1; // last index (before removal)
-            T frontItem = data[0];   // fetch the front
-            data[0] = data[li];
-            data.RemoveAt(li);
-
-            --li; // last index (after removal)
-            int pi = 0; // parent index. start at front of pq
-            while (true)
-            {
-                int ci = pi * 2 + 1; // left child index of parent
-                if (ci > li) break;  // no children so done
-                int rc = ci + 1;     // right child
-                if (rc <= li && data[rc].CompareTo(data[ci]) < 0) // if there is a rc (ci + 1), and it is smaller than left child, use the rc instead
-                    ci = rc;
-                if (data[pi].CompareTo(data[ci]) <= 0) break; // parent is smaller than (or equal to) smallest child so done
-                T tmp = data[pi]; data[pi] = data[ci]; data[ci] = tmp; // swap parent and child
-                pi = ci;
-            }
-            return frontItem;
-        }
-
-        public T Peek()
-        {
-            T frontItem = data[0];
-            return frontItem;
-        }
-
-        public int Count()
-        {
-            return data.Count;
-        }
-
-        public override string ToString()
-        {
-            string s = "";
-            for (int i = 0; i < data.Count; ++i)
-                s += data[i].ToString() + " ";
-            s += "count = " + data.Count;
-            return s;
-        }
-
-        public bool IsConsistent()
-        {
-            // is the heap property true for all data?
-            if (data.Count == 0) return true;
-            int li = data.Count - 1; // last index
-            for (int pi = 0; pi < data.Count; ++pi) // each parent index
-            {
-                int lci = 2 * pi + 1; // left child index
-                int rci = 2 * pi + 2; // right child index
-
-                if (lci <= li && data[pi].CompareTo(data[lci]) > 0) return false; // if lc exists and it's greater than parent then bad.
-                if (rci <= li && data[pi].CompareTo(data[rci]) > 0) return false; // check the right child too.
-            }
-            return true; // passed all checks
-        } // IsConsistent
-    } // PriorityQueue
-#endif
 }

--- a/NetTopologySuite/Utilities/PriorityQueueNode.cs
+++ b/NetTopologySuite/Utilities/PriorityQueueNode.cs
@@ -1,0 +1,18 @@
+﻿namespace NetTopologySuite.Utilities
+{
+    public sealed class PriorityQueueNode<TPriority, TData>
+    {
+        private readonly TData data;
+
+        public PriorityQueueNode(TData data)
+        {
+            this.data = data;
+        }
+
+        public TData Data { get { return this.data; } }
+
+        // These should only be updated by the queue itself.
+        public TPriority Priority { get; internal set; }
+        public int QueueIndex { get; internal set; }
+    }
+}

--- a/NetTopologySuite/Utilities/PriorityQueueNode.cs
+++ b/NetTopologySuite/Utilities/PriorityQueueNode.cs
@@ -1,18 +1,83 @@
-﻿namespace NetTopologySuite.Utilities
+﻿// Derived from BlueRaja's "High Speed Priority Queue for C#",
+// which has the following license text:
+/*
+The MIT License (MIT)
+
+Copyright (c) 2013 Daniel "BlueRaja" Pflughoeft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+namespace NetTopologySuite.Utilities
 {
+    /// <summary>
+    /// A container for a prioritized node that sites in an
+    /// <see cref="AlternativePriorityQueue{TPriority, TData}"/>.
+    /// </summary>
+    /// <typeparam name="TPriority">
+    /// The type to use for the priority of the node in the queue.
+    /// </typeparam>
+    /// <typeparam name="TData">
+    /// The type to use for the data stored by the node in the queue.
+    /// </typeparam>
     public sealed class PriorityQueueNode<TPriority, TData>
     {
         private readonly TData data;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PriorityQueueNode{TPriority, TData}"/> class.
+        /// </summary>
+        /// <param name="data">
+        /// The <typeparamref name="TData"/> to store in this node.
+        /// </param>
         public PriorityQueueNode(TData data)
         {
             this.data = data;
         }
 
+        internal PriorityQueueNode(PriorityQueueNode<TPriority, TData> copyFrom)
+        {
+            this.data = copyFrom.data;
+            this.Priority = copyFrom.Priority;
+            this.QueueIndex = copyFrom.QueueIndex;
+        }
+
+        /// <summary>
+        /// Gets the <typeparamref name="TData"/> that is stored in this node.
+        /// </summary>
         public TData Data { get { return this.data; } }
 
-        // These should only be updated by the queue itself.
+        /// <summary>
+        /// Gets the <typeparamref name="TPriority"/> of this node in the queue.
+        /// </summary>
+        /// <remarks>
+        /// The queue may update this priority while the node is still in the queue.
+        /// </remarks>
         public TPriority Priority { get; internal set; }
-        public int QueueIndex { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the index of this node in the queue.
+        /// </summary>
+        /// <remarks>
+        /// This should only be read and written by the queue itself.
+        /// It has no "real" meaning to anyone else.
+        /// </remarks>
+        internal int QueueIndex { get; set; }
     }
 }

--- a/PortableClassLibrary/NetTopologySuite.Pcl/NetTopologySuite.Pcl.csproj
+++ b/PortableClassLibrary/NetTopologySuite.Pcl/NetTopologySuite.Pcl.csproj
@@ -93,11 +93,20 @@
     <Compile Include="..\..\NetTopologySuite\Noding\InteriorIntersectionFinderAdder.cs">
       <Link>Noding\InteriorIntersectionFinderAdder.cs</Link>
     </Compile>
+    <Compile Include="..\..\NetTopologySuite\Simplify\OldVWLineSimplifier.cs">
+      <Link>Simplify\OldVWLineSimplifier.cs</Link>
+    </Compile>
     <Compile Include="..\..\NetTopologySuite\Simplify\VWLineSimplifier.cs">
       <Link>Simplify\VWLineSimplifier.cs</Link>
     </Compile>
     <Compile Include="..\..\NetTopologySuite\Simplify\VWSimplifier.cs">
       <Link>Simplify\VWSimplifier.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NetTopologySuite\Utilities\AlternativePriorityQueue.cs">
+      <Link>Utilities\AlternativePriorityQueue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NetTopologySuite\Utilities\PriorityQueueNode.cs">
+      <Link>Utilities\PriorityQueueNode.cs</Link>
     </Compile>
     <Compile Include="..\..\NetTopologySuite\Utilities\RToolsUtil\Token.cs">
       <Link>Utilities\RToolsUtil\Token.cs</Link>

--- a/PortableClassLibrary/NetTopologySuite.Tests.NUnit.Pcl/NetTopologySuite.Tests.NUnit.Pcl.csproj
+++ b/PortableClassLibrary/NetTopologySuite.Tests.NUnit.Pcl/NetTopologySuite.Tests.NUnit.Pcl.csproj
@@ -430,6 +430,9 @@
     <Compile Include="..\..\NetTopologySuite.Tests.NUnit\Triangulate\VoronoiTest.cs">
       <Link>Triangulate\VoronoiTest.cs</Link>
     </Compile>
+    <Compile Include="..\..\NetTopologySuite.Tests.NUnit\Utilities\AlternativePriorityQueueTest.cs">
+      <Link>Utilities\AlternativePriorityQueueTest.cs</Link>
+    </Compile>
     <Compile Include="..\..\NetTopologySuite.Tests.NUnit\Utilities\PriorityQueueTest.cs">
       <Link>Utilities\PriorityQueueTest.cs</Link>
     </Compile>


### PR DESCRIPTION
This is what we discussed in #33.

Some notes:

1. AlternativePriorityQueue<TPriority, TData> is _derived from_ BlueRaja's implementation, but it makes a lot of tiny speed tradeoffs in exchange for reliability and user-friendliness.
2. 3036ada is completely optional.  I think it will have the tendency to perform worse than what's there now, but it does get rid of a lot of now-redundant code.
3. PriorityQueueTest.cs changes seem to make it better than what's there now.  Before, CheckOrder would do a lot of boxing / unboxing, and all it would do is just make sure that everything after the first Poll() is greater than or equal to what the first Poll() returned.  Now, it makes sure that all values are returned in the correct order relative to one another.
4. TestNewResultsIdenticalToOldResults uses what I eyeballed to be the data from the TestData folder that should most clearly demonstrate the execution time benefits.  The new version is an 86% execution time reduction from the old version.  The new version will do even better relative to the old version when the input lines are much longer than these.
5. Since this queue implementation is derived from BlueRaja's implementation, I think versions of NTS based on this would need to distribute some extra license file to ensure compliance.  I didn't do anything here in consideration of that, I figured you guys would be able to work it out easily enough since you're distributing a modified PowerCollections as well, which has what looks like a less permissive license.

Have at it!