### PR TITLE
serializing geojson FeatureCollection with deep properties

### DIFF
--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/Converters/AttributesTableConverter.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/Converters/AttributesTableConverter.cs
@@ -24,7 +24,8 @@ namespace NetTopologySuite.IO.Converters
             if (attributes == null)
                 return;
 
-            writer.WritePropertyName("properties");
+            if (!writer.Path.Contains("properties"))
+                writer.WritePropertyName("properties");
 
             writer.WriteStartObject();
             string[] names = attributes.GetNames();

--- a/NetTopologySuite.Samples.Console/Tests/Github/Issue58Fixture.cs
+++ b/NetTopologySuite.Samples.Console/Tests/Github/Issue58Fixture.cs
@@ -40,6 +40,9 @@ namespace NetTopologySuite.Samples.Tests.Github
 
             Assert.IsNotNull(feature);
             Assert.AreEqual(1, feature.Attributes.Count);
+
+            var gjs = new GeoJsonWriter();
+            gjs.Write(coll);
         }
     }
 }


### PR DESCRIPTION
The problem is with recursively serializing geojson properties. So the test is actually in serializing what has been previously read in.

Solution seems pretty simple. Only try to add 'properties' attribute the once.

This pull request is more about me trying a simple change so that I can do more complicated once in the future.