### PR TITLE
Optimizing the big-endian binary reader/writer.

### DIFF
--- a/NetTopologySuite/IO/BEBinaryReader.cs
+++ b/NetTopologySuite/IO/BEBinaryReader.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 using GeoAPI.IO;
+using NetTopologySuite.Utilities;
 
 namespace NetTopologySuite.IO
 {
@@ -46,12 +46,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
         public override short ReadInt16()
         {
-            byte[] byteArray = new byte[2];
-            int iBytesRead = Read(byteArray, 0, 2);
-            Debug.Assert(iBytesRead == 2);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToInt16(byteArray, 0);
+            return BitTweaks.ReverseByteOrder(base.ReadInt16());
         }
 
         /// <summary>
@@ -67,12 +62,7 @@ namespace NetTopologySuite.IO
         [CLSCompliant(false)]
         public override ushort ReadUInt16()
         {
-            byte[] byteArray = new byte[2];
-            int iBytesRead = Read(byteArray, 0, 2);
-            Debug.Assert(iBytesRead == 2);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToUInt16(byteArray, 0);
+            return BitTweaks.ReverseByteOrder(base.ReadUInt16());
         }
 
         /// <summary>
@@ -86,13 +76,8 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
         public override int ReadInt32()
-        {            
-            byte[] byteArray = new byte[4];
-            int iBytesRead = Read(byteArray, 0, 4);
-            Debug.Assert(iBytesRead == 4);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToInt32(byteArray, 0);
+        {
+            return BitTweaks.ReverseByteOrder(base.ReadInt32());
         }
 
         /// <summary>
@@ -108,12 +93,7 @@ namespace NetTopologySuite.IO
         [CLSCompliant(false)]
         public override uint ReadUInt32()
         {
-            byte[] byteArray = new byte[4];
-            int iBytesRead = Read(byteArray, 0, 4);
-            Debug.Assert(iBytesRead == 4);
-
-            Array.Reverse(byteArray);                        
-            return BitConverter.ToUInt32(byteArray, 0);
+            return BitTweaks.ReverseByteOrder(base.ReadUInt32());
         }
 
         /// <summary>
@@ -128,12 +108,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
         public override long ReadInt64()
         {
-            byte[] byteArray = new byte[8];
-            int iBytesRead = Read(byteArray, 0, 8);
-            Debug.Assert(iBytesRead == 8);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToInt64(byteArray, 0);
+            return BitTweaks.ReverseByteOrder(base.ReadInt64());
         }
 
 
@@ -150,12 +125,7 @@ namespace NetTopologySuite.IO
         [CLSCompliant(false)]
         public override ulong ReadUInt64()
         {
-            byte[] byteArray = new byte[8];
-            int iBytesRead = Read(byteArray, 0, 8);
-            Debug.Assert(iBytesRead == 8);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToUInt64(byteArray, 0);
+            return BitTweaks.ReverseByteOrder(base.ReadUInt64());
         }
 
         /// <summary>
@@ -170,12 +140,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
         public override float ReadSingle()
         {
-            byte[] byteArray = new byte[4];
-            int iBytesRead = Read(byteArray, 0, 4);
-            Debug.Assert(iBytesRead == 4);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToSingle(byteArray, 0);   
+            return BitTweaks.ReverseByteOrder(base.ReadSingle());
         }
 
         /// <summary>
@@ -189,13 +154,8 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
         public override double ReadDouble()
-        {            
-            byte[] byteArray = new byte[8];
-            int iBytesRead = Read(byteArray, 0, 8);
-            Debug.Assert(iBytesRead == 8);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToDouble(byteArray, 0);
+        {
+            return BitTweaks.ReverseByteOrder(base.ReadDouble());
         }
 
         /// <summary>

--- a/NetTopologySuite/IO/BEBinaryWriter.cs
+++ b/NetTopologySuite/IO/BEBinaryWriter.cs
@@ -1,7 +1,8 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
+
+using NetTopologySuite.Utilities;
 
 namespace NetTopologySuite.IO
 {
@@ -53,11 +54,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         public override void Write(short value)
         {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 2);
-
-            Array.Reverse(bytes, 0, 2);
-            Write(bytes);
+            base.Write(BitTweaks.ReverseByteOrder(value));
         }
 
         /// <summary>
@@ -69,12 +66,8 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         [CLSCompliant(false)]
         public override void Write(ushort value)
-        {            
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 2);
-
-            Array.Reverse(bytes, 0, 2);
-            Write(bytes);
+        {
+            base.Write(BitTweaks.ReverseByteOrder(value));
         }
 
         /// <summary>
@@ -86,11 +79,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         public override void Write(int value)
         {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 4);
-
-            Array.Reverse(bytes, 0, 4);
-            Write(bytes);
+            base.Write(BitTweaks.ReverseByteOrder(value));
         }
 
         /// <summary>
@@ -103,11 +92,7 @@ namespace NetTopologySuite.IO
         [CLSCompliant(false)]
         public override void Write(uint value)
         {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 4);
-
-            Array.Reverse(bytes, 0, 4);
-            Write(bytes);
+            base.Write(BitTweaks.ReverseByteOrder(value));
         }
 
         /// <summary>
@@ -119,11 +104,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         public override void Write(long value)
         {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 8);
-
-            Array.Reverse(bytes, 0, 8);
-            Write(bytes);
+            base.Write(BitTweaks.ReverseByteOrder(value));
         }
 
         /// <summary>
@@ -136,11 +117,7 @@ namespace NetTopologySuite.IO
         [CLSCompliant(false)]
         public override void Write(ulong value)
         {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 8);
-
-            Array.Reverse(bytes, 0, 8);
-            Write(bytes);
+            base.Write(BitTweaks.ReverseByteOrder(value));
         }
 
         /// <summary>
@@ -152,11 +129,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         public override void Write(float value)
         {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 4);
-
-            Array.Reverse(bytes, 0, 4);
-            Write(bytes);
+            base.Write(BitTweaks.ReverseByteOrder(value));
         }
 
         /// <summary>
@@ -168,11 +141,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         public override void Write(double value)
         {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 8);
-
-            Array.Reverse(bytes, 0, 8);
-            Write(bytes);
+            base.Write(BitTweaks.ReverseByteOrder(value));
         }
 
         /// <summary>

--- a/NetTopologySuite/NetTopologySuite.csproj
+++ b/NetTopologySuite/NetTopologySuite.csproj
@@ -491,6 +491,7 @@
     <Compile Include="Utilities\Assert.cs" />
     <Compile Include="Utilities\AssertionFailedException.cs" />
     <Compile Include="Utilities\BitConverter.cs" />
+    <Compile Include="Utilities\BitTweaks.cs" />
     <Compile Include="Utilities\Caster.cs" />
     <Compile Include="Utilities\CollectionUtil.cs" />
     <Compile Include="Utilities\CoordinateArrayFilter.cs" />

--- a/NetTopologySuite/Utilities/BitTweaks.cs
+++ b/NetTopologySuite/Utilities/BitTweaks.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Diagnostics;
+
+#if PCL
+using DoubleBitsConverter = NetTopologySuite.Utilities.BitConverter;
+#else
+using DoubleBitsConverter = System.BitConverter;
+#endif
+
+namespace NetTopologySuite.Utilities
+{
+    internal static class BitTweaks
+    {
+        internal static short ReverseByteOrder(short value)
+        {
+            unchecked
+            {
+                return (short)ReverseByteOrder((ushort)value);
+            }
+        }
+
+        internal static int ReverseByteOrder(int value)
+        {
+            unchecked
+            {
+                return (int)ReverseByteOrder((uint)value);
+            }
+        }
+
+        internal static long ReverseByteOrder(long value)
+        {
+            unchecked
+            {
+                return (long)ReverseByteOrder((ulong)value);
+            }
+        }
+
+        internal static float ReverseByteOrder(float value)
+        {
+            // TODO: BitConverter.SingleToInt32Bits will exist eventually
+            // see https://github.com/dotnet/coreclr/pull/833
+            byte[] bytes = System.BitConverter.GetBytes(value);
+            Debug.Assert(bytes.Length == 4);
+
+            Array.Reverse(bytes, 0, 4);
+            return System.BitConverter.ToSingle(bytes, 0);
+        }
+
+        internal static double ReverseByteOrder(double value)
+        {
+            return DoubleBitsConverter.Int64BitsToDouble(ReverseByteOrder(DoubleBitsConverter.DoubleToInt64Bits(value)));
+        }
+
+        internal static ushort ReverseByteOrder(ushort value)
+        {
+            unchecked
+            {
+                return (ushort)((value & 0x00FF) << 8 |
+                                (value & 0xFF00) >> 8);
+            }
+        }
+
+        internal static uint ReverseByteOrder(uint value)
+        {
+            return (value & 0x000000FF) << 24 |
+                   (value & 0x0000FF00) << 8 |
+                   (value & 0x00FF0000) >> 8 |
+                   (value & 0xFF000000) >> 24;
+        }
+
+        internal static ulong ReverseByteOrder(ulong value)
+        {
+            return (value & 0x00000000000000FF) << 56 |
+                   (value & 0x000000000000FF00) << 40 |
+                   (value & 0x0000000000FF0000) << 24 |
+                   (value & 0x00000000FF000000) << 8 |
+                   (value & 0x000000FF00000000) >> 8 |
+                   (value & 0x0000FF0000000000) >> 24 |
+                   (value & 0x00FF000000000000) >> 40 |
+                   (value & 0xFF00000000000000) >> 56;
+        }
+    }
+}

--- a/PortableClassLibrary/NetTopologySuite.Pcl/NetTopologySuite.Pcl.csproj
+++ b/PortableClassLibrary/NetTopologySuite.Pcl/NetTopologySuite.Pcl.csproj
@@ -1271,6 +1271,9 @@
     <Compile Include="..\..\NetTopologySuite\Utilities\BitConverter.cs">
       <Link>Utilities\BitConverter.cs</Link>
     </Compile>
+    <Compile Include="..\..\NetTopologySuite\Utilities\BitTweaks.cs">
+      <Link>Utilities\BitTweaks.cs</Link>
+    </Compile>
     <Compile Include="..\..\NetTopologySuite\Utilities\Caster.cs">
       <Link>Utilities\Caster.cs</Link>
     </Compile>


### PR DESCRIPTION
Currently, BEBinaryReader and BEBinaryWriter do byte order reversing for each value read (edit: or, of course, written) by allocating a new byte array on the heap, reversing the bytes in that array, and then using BitConverter to interpret the data in that array.  At least on my machine, doing this extra intermediate array allocation for every single value we read is costly (according to some measurements).

The way [JTS](http://sourceforge.net/p/jts-topo-suite/code/1118/tree/trunk/jts/java/src/com/vividsolutions/jts/io/ByteOrderDataInStream.java) deals with this [problem](http://sourceforge.net/p/jts-topo-suite/code/1118/tree/trunk/jts/java/src/com/vividsolutions/jts/io/ByteOrderValues.java) is each reader and [writer](http://sourceforge.net/p/jts-topo-suite/code/1118/tree/trunk/jts/java/src/com/vividsolutions/jts/io/WKBWriter.java) allocates a fixed number of byte buffers so that there's a fixed number of byte array allocations throughout the lifetime of a particular reader instead of one per value read.

The approach I took was to just create helper methods that reverse the byte order of the primitive value type given to it using regular ol' shifting and masking... for all but `float` / `System.Single`, which would require either `BitConverter.SingleToInt32Bits` / `BitConverter.Int32BitsToSingle` such as what coreclr pull request [#833](https://github.com/dotnet/coreclr/pull/833) would add, or turning off the guard to allow unsafe blocks and reimplementing the same.  Since I don't think anything in NTS currently uses the `float` methods, I think just continuing to do what we were doing before should be fine.