### PR TITLE
Optimizing PointLocator a bit.

### DIFF
--- a/NetTopologySuite.Tests.NUnit/Algorithm/LocatePointInRingTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Algorithm/LocatePointInRingTest.cs
@@ -16,7 +16,11 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm
         {
             IGeometry geom = reader.Read(wkt);
             Assert.AreEqual(expectedLoc, CGAlgorithms.LocatePointInRing(pt, geom.Coordinates));
+            IPolygon poly = geom as IPolygon;
+            if (poly == null)
+                return;
 
+            Assert.AreEqual(expectedLoc, CGAlgorithms.LocatePointInRing(pt, poly.ExteriorRing.CoordinateSequence));
         }
 
     }

--- a/NetTopologySuite.Tests.NUnit/Algorithm/PointInRingTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Algorithm/PointInRingTest.cs
@@ -21,6 +21,11 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm
             IGeometry geom = reader.Read(wkt);
             bool expected = expectedLoc == Location.Interior;
             Assert.AreEqual(expected, CGAlgorithms.IsPointInRing(pt, geom.Coordinates));
+            IPolygon poly = geom as IPolygon;
+            if (poly == null)
+                return;
+
+            Assert.AreEqual(expected, CGAlgorithms.IsPointInRing(pt, poly.ExteriorRing.CoordinateSequence));
         }
 
     }

--- a/NetTopologySuite.Tests.NUnit/Algorithm/RayCrossingCounterTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Algorithm/RayCrossingCounterTest.cs
@@ -16,6 +16,11 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm
         {
             IGeometry geom = reader.Read(wkt);
             Assert.AreEqual(expectedLoc, RayCrossingCounter.LocatePointInRing(pt, geom.Coordinates));
+            IPolygon poly = geom as IPolygon;
+            if (poly == null)
+                return;
+
+            Assert.AreEqual(expectedLoc, RayCrossingCounter.LocatePointInRing(pt, poly.ExteriorRing.CoordinateSequence));
         }
 
     }

--- a/NetTopologySuite/Algorithm/CGAlgorithms.cs
+++ b/NetTopologySuite/Algorithm/CGAlgorithms.cs
@@ -106,6 +106,24 @@ namespace NetTopologySuite.Algorithm
             return LocatePointInRing(p, ring) != Location.Exterior;
         }
 
+        /// <summary> 
+        /// Tests whether a point lies inside or on a ring.
+        /// </summary>
+        /// <remarks>
+        /// <para>The ring may be oriented in either direction.</para>
+        /// <para>A point lying exactly on the ring boundary is considered to be inside the ring.</para>
+        /// <para>This method does <i>not</i> first check the point against the envelope
+        /// of the ring.</para>
+        /// </remarks>
+        /// <param name="p">Point to check for ring inclusion.</param>
+        /// <param name="ring">A sequence of <see cref="Coordinate"/>s representing the ring (which must have first point identical to last point)</param>
+        /// <returns>true if p is inside ring.</returns>
+        /// <see cref="IPointInRing"/>
+        public static bool IsPointInRing(Coordinate p, ICoordinateSequence ring)
+        {
+            return LocatePointInRing(p, ring) != Location.Exterior;
+        }
+
         ///<summary>
         /// Determines whether a point lies in the interior, on the boundary, or in the exterior of a ring.
         ///</summary>
@@ -117,6 +135,21 @@ namespace NetTopologySuite.Algorithm
         /// <param name="ring">An array of coordinates representing the ring (which must have first point identical to last point)</param>
         /// <returns>The <see cref="Location"/> of p relative to the ring</returns>
         public static Location LocatePointInRing(Coordinate p, Coordinate[] ring)
+        {
+            return RayCrossingCounter.LocatePointInRing(p, ring);
+        }
+
+        ///<summary>
+        /// Determines whether a point lies in the interior, on the boundary, or in the exterior of a ring.
+        ///</summary>
+        /// <remarks>
+        /// <para>The ring may be oriented in either direction.</para>
+        /// <para>This method does <i>not</i> first check the point against the envelope of the ring.</para>
+        /// </remarks>
+        /// <param name="p">Point to check for ring inclusion</param>
+        /// <param name="ring">A sequence of coordinates representing the ring (which must have first point identical to last point)</param>
+        /// <returns>The <see cref="Location"/> of p relative to the ring</returns>
+        public static Location LocatePointInRing(Coordinate p, ICoordinateSequence ring)
         {
             return RayCrossingCounter.LocatePointInRing(p, ring);
         }

--- a/NetTopologySuite/Algorithm/PointLocator.cs
+++ b/NetTopologySuite/Algorithm/PointLocator.cs
@@ -169,7 +169,7 @@ namespace NetTopologySuite.Algorithm
   	        // bounding-box check
   	        if (! ring.EnvelopeInternal.Intersects(p)) return Location.Exterior;
 
-  	        return CGAlgorithms.LocatePointInRing(p, ring.Coordinates);
+  	        return CGAlgorithms.LocatePointInRing(p, ring.CoordinateSequence);
         }
 
         /// <summary>

--- a/NetTopologySuite/Algorithm/RayCrossingCounter.cs
+++ b/NetTopologySuite/Algorithm/RayCrossingCounter.cs
@@ -62,7 +62,8 @@ namespace NetTopologySuite.Algorithm
 
             var p1 = new Coordinate();
             var p2 = new Coordinate();
-            for (var i = 1; i < ring.Count; i++)
+            int count = ring.Count;
+            for (var i = 1; i < count; i++)
             {
                 ring.GetCoordinate(i, p1);
                 ring.GetCoordinate(i - 1, p2);


### PR DESCRIPTION
Now tests with the underlying ICoordinateSequence, which is much nicer to the GC for sequence types other than CoordinateArraySequence (for which there's effectively no change).
Also hoisting the ICoordinateSequence.Count property accessor outside of the loop.

I used this for testing: https://gist.github.com/airbreather/72a044104a4d44014235 (follow the link in the source for where the testing data came from).
That `ICoordinateSequence` implementation is defined over here if you really need to see it (you probably don't): https://gist.github.com/airbreather/d227a19c74799c6b45e4

Before: 188.4 seconds.
After: 64.5 seconds.

I only did one run because I'm impatient.  I probably should have done a few and averaged, but I made an educated guess that the message isn't going to change by doing so.