### PR TITLE
Optimizing OverlayOp considerably in some cases.

### DIFF
--- a/NetTopologySuite.Samples.Console/Lab/Clean/InvalidHoleRemoverTest.cs
+++ b/NetTopologySuite.Samples.Console/Lab/Clean/InvalidHoleRemoverTest.cs
@@ -57,7 +57,6 @@ namespace NetTopologySuite.Samples.Lab.Clean
                 "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9)), LINESTRING (15 9, 19 5))");
         }
 
-        [Test]
         private void CheckHolesRemoved(string inputWKT, string expectedWKT)
         {
             IGeometry input = read(inputWKT);


### PR DESCRIPTION
Now uses IndexedPointInAreaLocator to speed up LineBuilder's and PointBuilder's area coverage checks, at the cost of a very temporary increase in memory usage.
Also removing an inappropriate [Test] attribute that causes a helper method to look like a test that always fails.

#71 was about optimizing `PointLocator`.  The reason this came on my radar was because that class is called a *lot* during `OverlayOp` on my datasets... specifically from `PointBuilder`.

When faced with many point-in-poly checks for the same few polygons, the fastest way to handle them is to use `IndexedPointInAreaLocator`, which builds a tree of the polygons' segments indexed by their y-interval.  Since `RayCrossingCounter` is implemented using a ray that's parallel to the x-axis, the index allows the point-in-poly check to safely and quickly skip calling it for segments that the ray can't possibly touch, leaving just those that cross the y-value of the coordinate.

Long story short, here are the numbers I got for running the same gist from #71 (https://gist.github.com/airbreather/72a044104a4d44014235) except with `WholeCountry` instead of `BigState`:

Before 6a7ce8f: 58097.3 seconds (968.3 minutes, or 16.1 hours)
With 6a7ce8f: 5433.7 seconds (90.6 minutes, or 1.5 hours)
With this change: 811.8 seconds (13.5 minutes, or 0.2255 hours)

I'm actually not sure if this is something that would be applicable to JTS, and I'm not particularly keen on figuring out how to do performance testing on Java stuff.  I mean, yeah, the code would **work**, but [JTS's version of PointBuilder](https://sourceforge.net/p/jts-topo-suite/code/1125/tree/trunk/jts/java/src/com/vividsolutions/jts/operation/overlay/PointBuilder.java) appears to do additional pre-filtering on the nodes from the graph.  I don't immediately know what that pre-filtering does, but it likely makes JTS skip `IsCoveredByLA` in cases where NTS would, in fact, call it.  Depending on how much of a reduction it is, this may actually **harm** performance when applied to JTS, because it may wind up building a whole index just for 1 or 2 points.

Full disclosure, it perhaps may be a really good idea to research whether or not porting the additional checks from JTS's `PointBuilder` would render this PR obsolete.  That's outside my area of expertise, and this change is sufficient to move NTS's `PointBuilder` off my radar of things that desperately want to be improved, so I'm not going to jump on it anytime soon, myself.