### PR TITLE
Removing uses of PowerCollections where possible.

### DIFF
--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/NetTopologySuite.IO.GeoTools.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/NetTopologySuite.IO.GeoTools.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NeedsPowerCollections Condition=" '$(NeedsPowerCollections)' == '' ">False</NeedsPowerCollections>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -95,7 +96,7 @@
       <Project>{5770DAA9-84E5-4770-AF43-F6B815894368}</Project>
       <Name>NetTopologySuite</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\PowerCollections\Source\PowerCollections\PowerCollections.csproj">
+    <ProjectReference Condition=" '$(NeedsPowerCollections)' != 'False' " Include="..\..\PowerCollections\Source\PowerCollections\PowerCollections.csproj">
       <Project>{5821977d-ac2c-4912-bcd0-6e6b1a756167}</Project>
       <Name>PowerCollections</Name>
     </ProjectReference>

--- a/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
+++ b/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
@@ -45,13 +45,14 @@
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NeedsPowerCollections Condition=" '$(NeedsPowerCollections)' == '' ">False</NeedsPowerCollections>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>$(SolutionDir)$(Configuration)\$(TargetFrameworkIdentifier)$(TargetFrameworkVersion)\$(Platform)\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;NET20;NET35;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -60,7 +61,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>$(SolutionDir)$(Configuration)\$(TargetFrameworkIdentifier)$(TargetFrameworkVersion)\$(Platform)\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET20;NET35;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -258,7 +259,7 @@
       <Project>{5770DAA9-84E5-4770-AF43-F6B815894368}</Project>
       <Name>NetTopologySuite</Name>
     </ProjectReference>
-    <ProjectReference Include="..\PowerCollections\Source\PowerCollections\PowerCollections.csproj">
+    <ProjectReference Condition=" '$(NeedsPowerCollections)' != 'False' " Include="..\PowerCollections\Source\PowerCollections\PowerCollections.csproj">
       <Project>{5821977d-ac2c-4912-bcd0-6e6b1a756167}</Project>
       <Name>PowerCollections</Name>
     </ProjectReference>

--- a/NetTopologySuite.Samples.Console/Tests/Various/Issue174TestFixture.cs
+++ b/NetTopologySuite.Samples.Console/Tests/Various/Issue174TestFixture.cs
@@ -5,7 +5,6 @@ using NetTopologySuite.IO;
 using NetTopologySuite.Triangulate;
 using NUnit.Framework;
 using ProjNet.CoordinateSystems;
-using Wintellect.PowerCollections;
 using Assert = NUnit.Framework.Assert;
 
 namespace NetTopologySuite.Samples.Tests.Various
@@ -33,11 +32,13 @@ namespace NetTopologySuite.Samples.Tests.Various
             AssertStronglyNamedAssembly(typeof(Datum));
         }
 
+#if !NET35
         [Test, Category("Issue174")]
         public void ensure_PowerCollections_assembly_is_strongly_named()
         {
-            AssertStronglyNamedAssembly(typeof(OrderedSet<object>));
+            AssertStronglyNamedAssembly(typeof(Wintellect.PowerCollections.OrderedSet<object>));
         }
+#endif
 
         [Test, Category("Issue174")]
         public void ensure_NetTopologySuite_assembly_is_strongly_named()

--- a/NetTopologySuite/Algorithm/ConvexHull.cs
+++ b/NetTopologySuite/Algorithm/ConvexHull.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Utilities;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Algorithm
 {
@@ -117,7 +116,11 @@ namespace NetTopologySuite.Algorithm
                 return pts;
             
             // add points defining polygon
-            var reducedSet = new OrderedSet<Coordinate>();
+#if NET35
+            var reducedSet = new HashSet<Coordinate>();
+#else
+            var reducedSet = new Wintellect.PowerCollections.Set<Coordinate>();
+#endif
             for (int i = 0; i < polyPts.Length; i++)
                 reducedSet.Add(polyPts[i]);
             
@@ -132,6 +135,7 @@ namespace NetTopologySuite.Algorithm
                     reducedSet.Add(pts[i]);
 
             var reducedPts = CoordinateArrays.ToCoordinateArray((ICollection<Coordinate>)reducedSet);// new Coordinate[reducedSet.Count];
+            Array.Sort(reducedPts);
 
             // ensure that computed array has at least 3 points (not necessarily unique)  
             if (reducedPts.Length < 3)

--- a/NetTopologySuite/GeometriesGraph/EdgeEndStar.cs
+++ b/NetTopologySuite/GeometriesGraph/EdgeEndStar.cs
@@ -6,7 +6,6 @@ using NetTopologySuite.Algorithm;
 using NetTopologySuite.Algorithm.Locate;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Utilities;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.GeometriesGraph
 {
@@ -20,7 +19,11 @@ namespace NetTopologySuite.GeometriesGraph
         /// <summary>
         /// A map which maintains the edges in sorted order around the node.
         /// </summary>
-        protected IDictionary<EdgeEnd, EdgeEnd> edgeMap = new OrderedDictionary<EdgeEnd, EdgeEnd>();
+#if NET20
+        protected IDictionary<EdgeEnd, EdgeEnd> edgeMap = new SortedDictionary<EdgeEnd, EdgeEnd>();
+#else
+        protected IDictionary<EdgeEnd, EdgeEnd> edgeMap = new Wintellect.PowerCollections.OrderedDictionary<EdgeEnd, EdgeEnd>();
+#endif
 
         /// <summary> 
         /// A list of all outgoing edges in the result, in CCW order.

--- a/NetTopologySuite/GeometriesGraph/EdgeIntersectionList.cs
+++ b/NetTopologySuite/GeometriesGraph/EdgeIntersectionList.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.GeometriesGraph
 {
@@ -12,7 +11,11 @@ namespace NetTopologySuite.GeometriesGraph
     public class EdgeIntersectionList
     {
         // a list of EdgeIntersections      
-        private readonly IDictionary<EdgeIntersection, EdgeIntersection> nodeMap = new OrderedDictionary<EdgeIntersection, EdgeIntersection>();
+#if NET20
+        private readonly IDictionary<EdgeIntersection, EdgeIntersection> nodeMap = new SortedDictionary<EdgeIntersection, EdgeIntersection>();
+#else
+        private readonly IDictionary<EdgeIntersection, EdgeIntersection> nodeMap = new Wintellect.PowerCollections.OrderedDictionary<EdgeIntersection, EdgeIntersection>();
+#endif
         private readonly Edge edge;  // the parent edge
 
         /// <summary>

--- a/NetTopologySuite/GeometriesGraph/EdgeList.cs
+++ b/NetTopologySuite/GeometriesGraph/EdgeList.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using NetTopologySuite.Noding;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.GeometriesGraph
 {
@@ -21,7 +20,11 @@ namespace NetTopologySuite.GeometriesGraph
         ///// of the edge coordinates.
         /// </summary>
         ////private readonly ISpatialIndex<Edge> _index = new Quadtree<Edge>();
-        private readonly OrderedDictionary<OrientedCoordinateArray, Edge> _ocaMap = new OrderedDictionary<OrientedCoordinateArray, Edge>();
+#if NET20
+        private readonly IDictionary<OrientedCoordinateArray, Edge> _ocaMap = new SortedDictionary<OrientedCoordinateArray, Edge>();
+#else
+        private readonly IDictionary<OrientedCoordinateArray, Edge> _ocaMap = new Wintellect.PowerCollections.OrderedDictionary<OrientedCoordinateArray, Edge>();
+#endif
 
 
         /// <summary>

--- a/NetTopologySuite/GeometriesGraph/NodeMap.cs
+++ b/NetTopologySuite/GeometriesGraph/NodeMap.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using GeoAPI.Geometries;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.GeometriesGraph
 {
@@ -9,8 +8,12 @@ namespace NetTopologySuite.GeometriesGraph
     /// A map of nodes, indexed by the coordinate of the node.
     /// </summary>
     public class NodeMap
-    {        
-        private readonly IDictionary<Coordinate, Node > _nodeMap = new OrderedDictionary<Coordinate, Node>();
+    {
+#if NET20
+        private readonly IDictionary<Coordinate, Node > _nodeMap = new SortedDictionary<Coordinate, Node>();
+#else
+        private readonly IDictionary<Coordinate, Node > _nodeMap = new Wintellect.PowerCollections.OrderedDictionary<Coordinate, Node>();
+#endif
         private readonly NodeFactory _nodeFact;
 
         /// <summary>

--- a/NetTopologySuite/NetTopologySuite.csproj
+++ b/NetTopologySuite/NetTopologySuite.csproj
@@ -46,13 +46,14 @@
     <BootstrapperEnabled>false</BootstrapperEnabled>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <RestorePackages>true</RestorePackages>
+    <NeedsPowerCollections Condition=" '$(NeedsPowerCollections)' == '' ">False</NeedsPowerCollections>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>$(SolutionDir)$(Configuration)\$(TargetFrameworkIdentifier)$(TargetFrameworkVersion)\$(Platform)\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NET20;NET35</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;NET20;NET35;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunFxCop>false</RunFxCop>
@@ -63,7 +64,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>$(SolutionDir)$(Configuration)\$(TargetFrameworkIdentifier)$(TargetFrameworkVersion)\$(Platform)\</OutputPath>
-    <DefineConstants>TRACE;NET20;NET35</DefineConstants>
+    <DefineConstants>TRACE;NET20;NET35;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\Release\v4.0\AnyCPU\NetTopologySuite.xml</DocumentationFile>
@@ -584,7 +585,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\PowerCollections\Source\PowerCollections\PowerCollections.csproj">
+    <ProjectReference Condition=" '$(NeedsPowerCollections)' != 'False' " Include="..\PowerCollections\Source\PowerCollections\PowerCollections.csproj">
       <Project>{5821977d-ac2c-4912-bcd0-6e6b1a756167}</Project>
       <Name>PowerCollections</Name>
     </ProjectReference>

--- a/NetTopologySuite/Noding/SegmentNodeList.cs
+++ b/NetTopologySuite/Noding/SegmentNodeList.cs
@@ -4,7 +4,6 @@ using System.IO;
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Utilities;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Noding
 {
@@ -13,7 +12,11 @@ namespace NetTopologySuite.Noding
     /// </summary>
     public class SegmentNodeList : IEnumerable<object>
     {
-        private readonly IDictionary<SegmentNode, Object> _nodeMap = new OrderedDictionary<SegmentNode, Object>();
+#if NET20
+        private readonly IDictionary<SegmentNode, Object> _nodeMap = new SortedDictionary<SegmentNode, Object>();
+#else
+        private readonly IDictionary<SegmentNode, Object> _nodeMap = new Wintellect.PowerCollections.OrderedDictionary<SegmentNode, Object>();
+#endif
         private readonly NodedSegmentString _edge;  // the parent edge
 
         /// <summary>

--- a/NetTopologySuite/Noding/SegmentStringDissolver.cs
+++ b/NetTopologySuite/Noding/SegmentStringDissolver.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using NetTopologySuite.Geometries;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Noding
 {
@@ -45,9 +44,13 @@ namespace NetTopologySuite.Noding
         }
 
         private readonly ISegmentStringMerger _merger;
-        private readonly IDictionary<OrientedCoordinateArray, ISegmentString> _ocaMap = 
-            new OrderedDictionary<OrientedCoordinateArray, ISegmentString>();
-        
+        private readonly IDictionary<OrientedCoordinateArray, ISegmentString> _ocaMap =
+#if NET20
+            new SortedDictionary<OrientedCoordinateArray, ISegmentString>();
+#else
+            new Wintellect.PowerCollections.OrderedDictionary<OrientedCoordinateArray, ISegmentString>();
+#endif
+
         /// <summary>
         /// Creates a dissolver with a user-defined merge strategy.
         /// </summary>

--- a/NetTopologySuite/Operation/BoundaryOp.cs
+++ b/NetTopologySuite/Operation/BoundaryOp.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using GeoAPI.Geometries;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Operation
 {
@@ -95,7 +94,11 @@ namespace NetTopologySuite.Operation
         private Coordinate[] ComputeBoundaryCoordinates(IMultiLineString mLine)
         {
             IList<Coordinate> bdyPts = new List<Coordinate>();
-            _endpointMap = new OrderedDictionary<Coordinate, Counter>();
+#if NET20
+            _endpointMap = new SortedDictionary<Coordinate, Counter>();
+#else
+            _endpointMap = new Wintellect.PowerCollections.OrderedDictionary<Coordinate, Counter>();
+#endif
             for (int i = 0; i < mLine.NumGeometries; i++)
             {
                 ILineString line = (ILineString)mLine.GetGeometryN(i);

--- a/NetTopologySuite/Operation/Buffer/BufferSubgraph.cs
+++ b/NetTopologySuite/Operation/Buffer/BufferSubgraph.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.GeometriesGraph;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Operation.Buffer
 {
@@ -145,7 +144,11 @@ namespace NetTopologySuite.Operation.Buffer
         // <FIX> MD - use iteration & queue rather than recursion, for speed and robustness
         private static void ComputeDepths(DirectedEdge startEdge)
         {
-            Set<Node> nodesVisited = new Set<Node>();
+#if NET35
+            HashSet<Node> nodesVisited = new HashSet<Node>();
+#else
+            Wintellect.PowerCollections.Set<Node> nodesVisited = new Wintellect.PowerCollections.Set<Node>();
+#endif
             Queue<Node> nodeQueue = new Queue<Node>();
             Node startNode = startEdge.Node;                 
             nodeQueue.Enqueue(startNode);   

--- a/NetTopologySuite/Operation/IsSimpleOp.cs
+++ b/NetTopologySuite/Operation/IsSimpleOp.cs
@@ -5,7 +5,6 @@ using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries.Utilities;
 using NetTopologySuite.GeometriesGraph;
 using NetTopologySuite.GeometriesGraph.Index;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Operation
 {
@@ -152,8 +151,12 @@ namespace NetTopologySuite.Operation
         {
             if (mp.IsEmpty) 
                 return true;
-            
-            Set<Coordinate> points = new Set<Coordinate>();
+
+#if NET35
+            HashSet<Coordinate> points = new HashSet<Coordinate>();
+#else
+            Wintellect.PowerCollections.Set<Coordinate> points = new Wintellect.PowerCollections.Set<Coordinate>();
+#endif
             for (int i = 0; i < mp.NumGeometries; i++)
             {
                 IPoint pt = (IPoint)mp.GetGeometryN(i);
@@ -283,7 +286,11 @@ namespace NetTopologySuite.Operation
         /// </summary>
         private bool HasClosedEndpointIntersection(GeometryGraph graph)
         {
-            IDictionary<Coordinate, EndpointInfo> endPoints = new OrderedDictionary<Coordinate, EndpointInfo>();
+#if NET20
+            IDictionary<Coordinate, EndpointInfo> endPoints = new SortedDictionary<Coordinate, EndpointInfo>();
+#else
+            IDictionary<Coordinate, EndpointInfo> endPoints = new Wintellect.PowerCollections.OrderedDictionary<Coordinate, EndpointInfo>();
+#endif
             foreach (Edge e in graph.Edges)
             {
                 //int maxSegmentIndex = e.MaximumSegmentIndex;

--- a/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
+++ b/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
@@ -6,7 +6,6 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.Planargraph;
 using NetTopologySuite.Planargraph.Algorithm;
 using NetTopologySuite.Utilities;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Operation.Linemerge
 {
@@ -66,7 +65,11 @@ namespace NetTopologySuite.Operation.Linemerge
             IMultiLineString mls = geom as IMultiLineString;
 
             // The nodes in all subgraphs which have been completely scanned
-            OrderedSet<Coordinate> prevSubgraphNodes = new OrderedSet<Coordinate>();
+#if NET35
+            var prevSubgraphNodes = new HashSet<Coordinate>();
+#else
+            var prevSubgraphNodes = new Wintellect.PowerCollections.Set<Coordinate>();
+#endif
 
             Coordinate lastNode = null;
             IList<Coordinate> currNodes = new List<Coordinate>();
@@ -87,7 +90,11 @@ namespace NetTopologySuite.Operation.Linemerge
                 if (lastNode != null && !startNode.Equals(lastNode)) 
                 {
                     // start new connected sequence
+#if NET35
+                    prevSubgraphNodes.UnionWith(currNodes);
+#else
                     prevSubgraphNodes.AddMany(currNodes);
+#endif
                     currNodes.Clear();
                 }                
 

--- a/NetTopologySuite/Operation/Overlay/Snap/GeometrySnapper.cs
+++ b/NetTopologySuite/Operation/Overlay/Snap/GeometrySnapper.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Collections.Generic;
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries.Utilities;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Operation.Overlay.Snap
 {
@@ -172,9 +172,15 @@ namespace NetTopologySuite.Operation.Overlay.Snap
         private Coordinate[] ExtractTargetCoordinates(IGeometry g)
         {
             // TODO: should do this more efficiently.  Use CoordSeq filter to get points, KDTree for uniqueness & queries
-            OrderedSet<Coordinate> ptSet = new OrderedSet<Coordinate>(g.Coordinates);
+#if NET35
+            var ptSet = new HashSet<Coordinate>(g.Coordinates);
+#else
+            var ptSet = new Wintellect.PowerCollections.Set<Coordinate>(g.Coordinates);
+#endif
+
             Coordinate[] result = new Coordinate[ptSet.Count];
             ptSet.CopyTo(result, 0);
+            Array.Sort(result);
             return result;
         }
 

--- a/NetTopologySuite/Operation/Polygonize/PolygonizeGraph.cs
+++ b/NetTopologySuite/Operation/Polygonize/PolygonizeGraph.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Planargraph;
 using NetTopologySuite.Utilities;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Operation.Polygonize
 {
@@ -383,7 +383,11 @@ namespace NetTopologySuite.Operation.Polygonize
         public ICollection<ILineString> DeleteDangles()
         {
             var nodesToRemove = FindNodesOfDegree(1);
-            Set<ILineString> dangleLines = new Set<ILineString>();
+#if NET35
+            HashSet<ILineString> dangleLines = new HashSet<ILineString>();
+#else
+            Wintellect.PowerCollections.Set<ILineString> dangleLines = new Wintellect.PowerCollections.Set<ILineString>();
+#endif
 
             Stack<Node> nodeStack = new Stack<Node>();
             foreach (Node node in nodesToRemove)
@@ -412,7 +416,10 @@ namespace NetTopologySuite.Operation.Polygonize
                         nodeStack.Push(toNode);
                 }
             }
-            return dangleLines.AsReadOnly();
+
+            var dangleArray = new ILineString[dangleLines.Count];
+            dangleLines.CopyTo(dangleArray, 0);
+            return new ReadOnlyCollection<ILineString>(dangleArray);
                 //new ArrayList(dangleLines.CastPlatform());
         }
 

--- a/NetTopologySuite/Operation/Union/PointGeometryUnion.cs
+++ b/NetTopologySuite/Operation/Union/PointGeometryUnion.cs
@@ -1,7 +1,8 @@
+using System;
+using System.Collections.Generic;
 using GeoAPI.Geometries;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries.Utilities;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Operation.Union
 {
@@ -36,7 +37,11 @@ namespace NetTopologySuite.Operation.Union
         {
             PointLocator locater = new PointLocator();
             // use a set to eliminate duplicates, as required for union
-            var exteriorCoords = new OrderedSet<Coordinate>();
+#if NET35
+            var exteriorCoords = new HashSet<Coordinate>();
+#else
+            var exteriorCoords = new Wintellect.PowerCollections.Set<Coordinate>();
+#endif
 
             foreach (IPoint point in PointExtracter.GetPoints(_pointGeom))
             {
@@ -56,7 +61,10 @@ namespace NetTopologySuite.Operation.Union
             }
 
             // make a puntal geometry of appropriate size
-            ICoordinateSequence coords = _geomFact.CoordinateSequenceFactory.Create(exteriorCoords.ToArray());
+            var exteriorCoordsArray = new Coordinate[exteriorCoords.Count];
+            exteriorCoords.CopyTo(exteriorCoordsArray, 0);
+            Array.Sort(exteriorCoordsArray);
+            ICoordinateSequence coords = _geomFact.CoordinateSequenceFactory.Create(exteriorCoordsArray);
             IGeometry ptComp = coords.Count == 1 ? (IGeometry)_geomFact.CreatePoint(coords.GetCoordinate(0)) : _geomFact.CreateMultiPoint(coords);
 
             // add point component to the other geometry

--- a/NetTopologySuite/Operation/Valid/IsValidOp.cs
+++ b/NetTopologySuite/Operation/Valid/IsValidOp.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using GeoAPI.Geometries;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.GeometriesGraph;
 using NetTopologySuite.Utilities;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Operation.Valid
 {
@@ -403,7 +403,11 @@ namespace NetTopologySuite.Operation.Valid
         /// </summary>
         private void CheckNoSelfIntersectingRing(EdgeIntersectionList eiList)
         {
-            Set<Coordinate> nodeSet = new Set<Coordinate>();    
+#if NET35
+            HashSet<Coordinate> nodeSet = new HashSet<Coordinate>();
+#else
+            Wintellect.PowerCollections.Set<Coordinate> nodeSet = new Wintellect.PowerCollections.Set<Coordinate>();
+#endif
             bool isFirst = true;
             foreach(EdgeIntersection ei in eiList)
             {                

--- a/NetTopologySuite/Planargraph/DirectedEdgeStar.cs
+++ b/NetTopologySuite/Planargraph/DirectedEdgeStar.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
+#if NET35
+using System.Linq;
+#endif
 using GeoAPI.Geometries;
-using Wintellect.PowerCollections;
+using NetTopologySuite.Utilities;
 
 namespace NetTopologySuite.Planargraph
 {
@@ -13,7 +16,7 @@ namespace NetTopologySuite.Planargraph
         /// <summary>
         /// The underlying list of outgoing DirectedEdges.
         /// </summary>
-        private readonly BigList<DirectedEdge> _outEdges = new BigList<DirectedEdge>();
+        private readonly List<DirectedEdge> _outEdges = new List<DirectedEdge>();
 
         private bool _sorted;
 
@@ -94,7 +97,14 @@ namespace NetTopologySuite.Planargraph
         {
             if (!_sorted)
             {
-                _outEdges.Sort();
+                // JTS does a stable sort here.  List<T>.Sort is not stable.
+#if NET35
+                var inSortedOrder = new List<DirectedEdge>(_outEdges.OrderBy(x => x));
+#else
+                var inSortedOrder = Wintellect.PowerCollections.Algorithms.StableSort(_outEdges, Comparer<DirectedEdge>.Default);
+#endif
+                _outEdges.Clear();
+                _outEdges.AddRange(inSortedOrder);
                 _sorted = true;                
             }
         }

--- a/NetTopologySuite/Planargraph/Node.cs
+++ b/NetTopologySuite/Planargraph/Node.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using GeoAPI.Geometries;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Planargraph
 {
@@ -22,9 +21,18 @@ namespace NetTopologySuite.Planargraph
         public static IList<DirectedEdge> GetEdgesBetween(Node node0, Node node1)
         {
             IList<Edge> edges0 = DirectedEdge.ToEdges(node0.OutEdges.Edges);
-            var commonEdges = new Set<DirectedEdge>(Utilities.Caster.Cast<DirectedEdge>(edges0));
+#if NET35
+            var commonEdges = new HashSet<DirectedEdge>(Utilities.Caster.Cast<DirectedEdge>(edges0));
+#else
+            var commonEdges = new Wintellect.PowerCollections.Set<DirectedEdge>(Utilities.Caster.Cast<DirectedEdge>(edges0));
+#endif
             IList<Edge> edges1 = DirectedEdge.ToEdges(node1.OutEdges.Edges);
+
+#if NET35
+            commonEdges.ExceptWith(Utilities.Caster.Cast<DirectedEdge>(edges1));
+#else
             commonEdges.RemoveMany(Utilities.Caster.Cast<DirectedEdge>(edges1));
+#endif
             return new List<DirectedEdge>(commonEdges);
         }
 

--- a/NetTopologySuite/Planargraph/NodeMap.cs
+++ b/NetTopologySuite/Planargraph/NodeMap.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Wintellect.PowerCollections;
 using GeoAPI.Geometries;
 
 namespace NetTopologySuite.Planargraph
@@ -9,7 +8,11 @@ namespace NetTopologySuite.Planargraph
     /// </summary>   
     public class NodeMap
     {
-        private readonly IDictionary<Coordinate, Node> _nodeMap = new OrderedDictionary<Coordinate, Node>();
+#if NET20
+        private readonly IDictionary<Coordinate, Node> _nodeMap = new SortedDictionary<Coordinate, Node>();
+#else
+        private readonly IDictionary<Coordinate, Node> _nodeMap = new Wintellect.PowerCollections.OrderedDictionary<Coordinate, Node>();
+#endif
         /*
         /// <summary>
         /// Constructs a NodeMap without any Nodes.

--- a/NetTopologySuite/Planargraph/Subgraph.cs
+++ b/NetTopologySuite/Planargraph/Subgraph.cs
@@ -1,6 +1,5 @@
 //using System.Collections;
 using System.Collections.Generic;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Planargraph
 {
@@ -24,8 +23,12 @@ namespace NetTopologySuite.Planargraph
         /// <summary>
         /// 
         /// </summary>
-        protected Set<Edge> edges = new Set<Edge>();
-        
+#if NET35
+        protected HashSet<Edge> edges = new HashSet<Edge>();
+#else
+        protected Wintellect.PowerCollections.Set<Edge> edges = new Wintellect.PowerCollections.Set<Edge>();
+#endif
+
         /// <summary>
         /// 
         /// </summary>

--- a/NetTopologySuite/Triangulate/ConformingDelaunayTriangulationBuilder.cs
+++ b/NetTopologySuite/Triangulate/ConformingDelaunayTriangulationBuilder.cs
@@ -3,7 +3,6 @@ using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Utilities;
 using NetTopologySuite.Triangulate.QuadEdge;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Triangulate
 {
@@ -20,7 +19,11 @@ namespace NetTopologySuite.Triangulate
         private double _tolerance;
         private QuadEdgeSubdivision _subdiv;
 
-        private readonly IDictionary<Coordinate, Vertex> _constraintVertexMap = new OrderedDictionary<Coordinate, Vertex>();
+#if NET20
+        private readonly IDictionary<Coordinate, Vertex> _constraintVertexMap = new SortedDictionary<Coordinate, Vertex>();
+#else
+        private readonly IDictionary<Coordinate, Vertex> _constraintVertexMap = new Wintellect.PowerCollections.OrderedDictionary<Coordinate, Vertex>();
+#endif
 
         /// <summary>
         /// Sets the sites (point or vertices) which will be triangulated.

--- a/NetTopologySuite/Triangulate/QuadEdge/QuadEdgeSubdivision.cs
+++ b/NetTopologySuite/Triangulate/QuadEdge/QuadEdgeSubdivision.cs
@@ -1,4 +1,3 @@
-//#define NET40
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,12 +6,10 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using NetTopologySuite.Utilities;
 
-#if NET40
-using ISet = System.Collections.Generic.ISet<NetTopologySuite.Triangulate.QuadEdge.QuadEdge>;
+#if NET35
 using HashSetQ = System.Collections.Generic.HashSet<NetTopologySuite.Triangulate.QuadEdge.QuadEdge>;
 using HashSetV = System.Collections.Generic.HashSet<NetTopologySuite.Triangulate.QuadEdge.Vertex>;
 #else
-using ISet = Wintellect.PowerCollections.Set<NetTopologySuite.Triangulate.QuadEdge.QuadEdge>;
 using HashSetQ = Wintellect.PowerCollections.Set<NetTopologySuite.Triangulate.QuadEdge.QuadEdge>;
 using HashSetV = Wintellect.PowerCollections.Set<NetTopologySuite.Triangulate.QuadEdge.Vertex>;
 #endif
@@ -691,7 +688,7 @@ namespace NetTopologySuite.Triangulate.QuadEdge
         /// or <value>null</value> if the triangle should not be visited (for instance, if it is outer)
         /// </returns>
         private QuadEdge[] FetchTriangleToVisit(QuadEdge edge, Stack<QuadEdge> edgeStack, bool includeFrame,
-            ISet visitedEdges)
+            HashSetQ visitedEdges)
         {
             QuadEdge curr = edge;
             int edgeCount = 0;

--- a/NetTopologySuite/Triangulate/QuadEdge/TrianglePredicate.cs
+++ b/NetTopologySuite/Triangulate/QuadEdge/TrianglePredicate.cs
@@ -5,7 +5,6 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Implementation;
 using NetTopologySuite.IO;
 using NetTopologySuite.Mathematics;
-using Wintellect;
 
 namespace NetTopologySuite.Triangulate.QuadEdge
 {

--- a/NetTopologySuite/Triangulate/VertexTaggedGeometryDataMapper.cs
+++ b/NetTopologySuite/Triangulate/VertexTaggedGeometryDataMapper.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
-using Wintellect.PowerCollections;
 
 namespace NetTopologySuite.Triangulate
 {
@@ -20,7 +19,11 @@ namespace NetTopologySuite.Triangulate
     /// <see cref="VoronoiDiagramBuilder"/>
     public class VertexTaggedGeometryDataMapper
     {
-        private readonly IDictionary<Coordinate, object> _coordDataMap = new OrderedDictionary<Coordinate, object>();
+#if NET20
+        private readonly IDictionary<Coordinate, object> _coordDataMap = new SortedDictionary<Coordinate, object>();
+#else
+        private readonly IDictionary<Coordinate, object> _coordDataMap = new Wintellect.PowerCollections.OrderedDictionary<Coordinate, object>();
+#endif
 
         public void LoadSourceGeometries(IGeometry geoms)
         {

--- a/TeamCity.targets
+++ b/TeamCity.targets
@@ -64,7 +64,7 @@
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v2.0" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
              Targets="PowerCollections;NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v2.0;TargetFrameworkProfile=;DefineConstants=TRACE,NET20;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v2.0\;" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v2.0;TargetFrameworkProfile=;DefineConstants=TRACE,NET20;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v2.0\;NeedsPowerCollections=True;" 
              RunEachTargetSeparately="true" 
 			 ContinueOnError="true" 
              />		
@@ -75,8 +75,8 @@
 		</PropertyGroup>
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v3.5" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
-             Targets="PowerCollections;NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v3.5;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v3.5\;" 
+             Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v3.5;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v3.5\;NeedsPowerCollections=False;" 
              RunEachTargetSeparately="true" 
              ContinueOnError="true" />
 	</Target>
@@ -86,8 +86,8 @@
 		</PropertyGroup>
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v4.0" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
-             Targets="PowerCollections;NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.0;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.0\;" 
+             Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.0;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.0\;NeedsPowerCollections=False;" 
              RunEachTargetSeparately="true" 
              ContinueOnError="true" 
              />
@@ -98,8 +98,8 @@
 		</PropertyGroup>
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v4.0.3" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
-             Targets="PowerCollections;NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.0.3;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.0.3\;" 
+             Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.0.3;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.0.3\;NeedsPowerCollections=False;" 
              RunEachTargetSeparately="true" 
              ContinueOnError="true" 
              />		
@@ -110,8 +110,8 @@
 		</PropertyGroup>
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v4.5" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
-             Targets="PowerCollections;NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.5;TargetFrameworkProfile=;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.5\" 
+             Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.5;TargetFrameworkProfile=;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.5\;NeedsPowerCollections=False;" 
              RunEachTargetSeparately="true" 
              ContinueOnError="true" 
              />


### PR DESCRIPTION
This is related to #73.
.NET 3.5 and above can get rid of it completely.
.NET 2.0 only needs it for a hash-based set type.
PCL can even get away from some of it with simple changes.

I previously did a "dummy" PR (#74) to get the build server to test this and let me refine it so it's easier to look at.  This is the "real" PR.

Specific considerations worthy of mention:

1. `SortedSet<T>`, the direct replacement for `OrderedSet<T>` from PowerCollections, is .NET 4.0+ only.  However, everything that uses it could have used a hash-based set instead and sorted at the end (which may be faster or marginally slower than before, depending on the number of duplicates).  In one case, it didn't even care about the order, so this is a strict improvement.
    1. This is probably the most controversial code change, so I'll explain more about performance.
    2. Specifically, using `OrderedSet<T>` and then copying the results to an array is O((n + m) * log(n)), where "n" is the number of unique items and "m" is the number of items that are also found in "n".  This is because testing each element, whether it's in "m" or "n", requires an O(log(n)) lookup into the red-black tree.  Elements of "m" are not added.  Copying to an array only requires O(n) time.
    3. On the other hand, using a hash-based set, then copying the results to an array, then sorting it is O(n * log(n)) + O(n + m), for the same definitions of "n" and "m".  Now, testing each element only requires an O(1) lookup into the hash-based set, which we do (n + m) times.  So we inserted everything in O(n + m) time, then we copy everything in O(n) time (because duplicates are already excluded), then we sort in O(n * log(n)) time.
    4. For "m" large, this change is an improvement on the asymptotic execution time.  For "m" small, it's a wash.
    5. The memory layout properties of a hash-based set (especially the built-in `HashSet<T>`), compared to a red/black tree, lead me to believe that this is likely to be faster overall, but I haven't really done aggressive testing on it.
    6. **NOTE**: this change is only valid if the element has its `IComparable` / `IComparable<T>` semantics be consistent with its `Equals` / `GetHashCode` semantics such that two objects with a comparison of 0 from `CompareTo` are also considered equal by `Equals` and have identical hash codes from `GetHashCode`.  Fortunately, NTS only uses `Coordinate` as the "`T`" for its `OrderedSet<T>`, which is self-consistent in this regard.  For many `TKey` types in `OrderedDictionary<TKey, TValue>`, this is not the case, so a similar change would not be a valid way to "fix" those cases.
2. The two places that used `BigList<T>` actually seemed to just be depending on its sorting semantics (specifically, how PowerCollections determines the relative order of items that are equal).  In those places, the equivalent JTS code uses a sort that is guaranteed to be stable, so we're free to change those as long as we also do stable sort.  `OrderBy<T, TItem>` from LINQ (.NET 3.5+) is guaranteed stable.  For other targets, PowerCollections happens to have a `StableSort<T, TItem>` available to us with nearly identical semantics.
    1. For what it's worth, `BigList<T>` claims to use QuickSort, which is typically not stable.  I did not continue down this road to see whether or not there's actually a bug that this change fixes.
3. The default build for NetTopologySuite didn't define `NET40`, even though it builds for .NET 4 Client.
4. Along with removing the PowerCollections target from the builds where it's not needed, we also need to have that "NeedsPowerCollections" conditional to avoid the PowerCollections stuff getting copied to the output directory anyway.

For the future, here are the things keeping .NET 2.0 and PCL from dropping it entirely:

1. We need a hash-based set type.  It's possible to emulate `HashSet<T>` by wrapping a `Dictionary<T, bool>`.  I didn't want to do this right away.
2. We need a way to do a stable-sort.  One way to do it would be to add a utility method that wraps each element of an `IEnumerable<T>` in an `ItemWithIndex<T>` whose comparison implementation uses the original `T`'s comparison, and then uses the index from the original sequence as a tiebreaker, then sort it and select the `T` elements of the sorted set back out.
    1. Of course, another way would be to just go ahead and implement a stable sort within NTS, which is not very appealing either.
3. We need an ordered dictionary type.  As mentioned above, it's not actually all that easy to do this.  I have some ideas, but certainly none of them are worth me holding up this PR for.  Even if it looks utterly obvious that [EdgeList](https://github.com/NetTopologySuite/NetTopologySuite/blob/0f56e478f91a0a40e4b75203ade55908990fc4ce/NetTopologySuite/GeometriesGraph/EdgeList.cs#L24), for example, **should** be OK with using a hash-based dictionary, it's not.  Because [OrientedCoordinateArray](https://github.com/NetTopologySuite/NetTopologySuite/blob/0f56e478f91a0a40e4b75203ade55908990fc4ce/NetTopologySuite/Noding/OrientedCoordinateArray.cs) does not have `Equals` / `GetHashCode` overrides that are consistent with its comparison behavior.