### PR TITLE
Remove remaining mentions of PowerCollections

### DIFF
--- a/NTS.nuspec
+++ b/NTS.nuspec
@@ -11,7 +11,7 @@
 		<requireLicenseAcceptance>true</requireLicenseAcceptance>
 		<description>
       The NTS Topology Suite is an API for modelling and manipulating 2-dimensional linear geometry. It provides numerous geometric predicates and functions. NTS conforms to the Simple Features Specification.
-      This package contains Wintellect's PowerCollections and references GeoAPI.
+      This package references GeoAPI.
 		</description>
 		<summary>NTS Topology Suite is a direct-port of all the functionalities offered by JTS Topology Suite</summary>
 		<tags>NTS Topology OGC SFS</tags>
@@ -30,37 +30,22 @@
 		<file src="Release\v2.0\AnyCPU\NetTopologySuite.dll" target="lib\net20" />
 		<file src="Release\v2.0\AnyCPU\NetTopologySuite.pdb" target="lib\net20" />
 		<file src="Release\v2.0\AnyCPU\NetTopologySuite.xml" target="lib\net20" />
-		<file src="Release\v2.0\AnyCPU\PowerCollections.dll" target="lib\net20" />
-		<file src="Release\v2.0\AnyCPU\PowerCollections.pdb" target="lib\net20" />
-		<file src="Release\v2.0\AnyCPU\PowerCollections.xml" target="lib\net20" />
 
 		<file src="Release\v3.5\AnyCPU\NetTopologySuite.dll" target="lib\net35-client" />
 		<file src="Release\v3.5\AnyCPU\NetTopologySuite.pdb" target="lib\net35-client" />
 		<file src="Release\v3.5\AnyCPU\NetTopologySuite.xml" target="lib\net35-client" />
-		<file src="Release\v3.5\AnyCPU\PowerCollections.dll" target="lib\net35-client" />
-		<file src="Release\v3.5\AnyCPU\PowerCollections.pdb" target="lib\net35-client" />
-		<file src="Release\v3.5\AnyCPU\PowerCollections.xml" target="lib\net35-client" />
 
 		<file src="Release\v4.0\AnyCPU\NetTopologySuite.dll" target="lib\net40-client" />
 		<file src="Release\v4.0\AnyCPU\NetTopologySuite.pdb" target="lib\net40-client" />
 		<file src="Release\v4.0\AnyCPU\NetTopologySuite.xml" target="lib\net40-client" />
-		<file src="Release\v4.0\AnyCPU\PowerCollections.dll" target="lib\net40-client" />
-		<file src="Release\v4.0\AnyCPU\PowerCollections.pdb" target="lib\net40-client" />
-		<file src="Release\v4.0\AnyCPU\PowerCollections.xml" target="lib\net40-client" />
 
 		<file src="Release\v4.0.3\AnyCPU\NetTopologySuite.dll" target="lib\net403-client" />
 		<file src="Release\v4.0.3\AnyCPU\NetTopologySuite.pdb" target="lib\net403-client" />
 		<file src="Release\v4.0.3\AnyCPU\NetTopologySuite.xml" target="lib\net403-client" />
-		<file src="Release\v4.0.3\AnyCPU\PowerCollections.dll" target="lib\net403-client" />
-		<file src="Release\v4.0.3\AnyCPU\PowerCollections.pdb" target="lib\net403-client" />
-		<file src="Release\v4.0.3\AnyCPU\PowerCollections.xml" target="lib\net403-client" />
 
 		<file src="Release\v4.5\AnyCPU\NetTopologySuite.dll" target="lib\net45" />
 		<file src="Release\v4.5\AnyCPU\NetTopologySuite.pdb" target="lib\net45" />
 		<file src="Release\v4.5\AnyCPU\NetTopologySuite.xml" target="lib\net45" />
-		<file src="Release\v4.5\AnyCPU\PowerCollections.dll" target="lib\net45" />
-		<file src="Release\v4.5\AnyCPU\PowerCollections.pdb" target="lib\net45" />
-		<file src="Release\v4.5\AnyCPU\PowerCollections.xml" target="lib\net45" />
 
 		<file src="Release\PCL\AnyCPU\NetTopologySuite.dll" target="lib\portable-net403+sl5+netcore45+wpa81+wp8+MonoAndroid10+XamariniOS10+MonoTouch10" />
 		<file src="Release\PCL\AnyCPU\NetTopologySuite.pdb" target="lib\portable-net403+sl5+netcore45+wpa81+wp8+MonoAndroid10+XamariniOS10+MonoTouch10" />
@@ -68,8 +53,5 @@
 		<file src="Release\PCL\AnyCPU\GeoAPI.Bootstrapper.NetTopologySuite.dll" target="lib\portable-net403+sl5+netcore45+wpa81+wp8+MonoAndroid10+XamariniOS10+MonoTouch10" />
 		<file src="Release\PCL\AnyCPU\GeoAPI.Bootstrapper.NetTopologySuite.pdb" target="lib\portable-net403+sl5+netcore45+wpa81+wp8+MonoAndroid10+XamariniOS10+MonoTouch10" />
 		<file src="Release\PCL\AnyCPU\GeoAPI.Bootstrapper.NetTopologySuite.xml" target="lib\portable-net403+sl5+netcore45+wpa81+wp8+MonoAndroid10+XamariniOS10+MonoTouch10" />
-		<file src="Release\PCL\AnyCPU\PowerCollections.dll" target="lib\portable-net403+sl5+netcore45+wpa81+wp8+MonoAndroid10+XamariniOS10+MonoTouch10" />
-		<file src="Release\PCL\AnyCPU\PowerCollections.pdb" target="lib\portable-net403+sl5+netcore45+wpa81+wp8+MonoAndroid10+XamariniOS10+MonoTouch10" />
-		<file src="Release\PCL\AnyCPU\PowerCollections.xml" target="lib\portable-net403+sl5+netcore45+wpa81+wp8+MonoAndroid10+XamariniOS10+MonoTouch10" />
 	</files>
 </package>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/Handlers/PolygonHandler.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/Handlers/PolygonHandler.cs
@@ -4,14 +4,6 @@ using System.IO;
 using GeoAPI.Geometries;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
-/*
-#if !NET35
-using HS = Wintellect.PowerCollections.Set<int>;
-#else
-using HS = System.Collections.Generic.HashSet<int>;
-#endif
-*/
-using HS = System.Collections.Generic.HashSet<int>;
 
 namespace NetTopologySuite.IO.Handlers
 {
@@ -59,7 +51,7 @@ namespace NetTopologySuite.IO.Handlers
             for (var i = 0; i < numParts; i++)
                 partOffsets[i] = ReadInt32(file, totalRecordLength, ref totalRead);
 
-            var skippedList = new HS();
+            var skippedList = new HashSet<int>();
 
             //var allPoints = new List<Coordinate>();
             var buffer = new CoordinateBuffer(numPoints, NoDataBorderValue, true);

--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/Handlers/ShapeHandler.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/Handlers/ShapeHandler.cs
@@ -4,7 +4,6 @@ using System.IO;
 #if NET35
 using System.Linq;
 #endif
-using HS = System.Collections.Generic.HashSet<int>;
 using GeoAPI.Geometries;
 
 namespace NetTopologySuite.IO.Handlers
@@ -443,10 +442,10 @@ namespace NetTopologySuite.IO.Handlers
         /// <param name="currentlyReadBytes">How many bytes are read from this record</param>
         /// <param name="buffer">The coordinate buffer</param>
         /// <param name="skippedList">A list of indices which have not been added to the buffer</param>     
-        protected void GetZMValues(BigEndianBinaryReader file, int totalRecordLength, ref int currentlyReadBytes, ICoordinateBuffer buffer, HS skippedList = null)
+        protected void GetZMValues(BigEndianBinaryReader file, int totalRecordLength, ref int currentlyReadBytes, ICoordinateBuffer buffer, HashSet<int> skippedList = null)
         {
             if (skippedList == null)
-                skippedList = new HS();
+                skippedList = new HashSet<int>();
 
             var numPoints = buffer.Capacity;
 

--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/NetTopologySuite.IO.GeoTools.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/NetTopologySuite.IO.GeoTools.csproj
@@ -17,7 +17,6 @@
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NeedsPowerCollections Condition=" '$(NeedsPowerCollections)' == '' ">False</NeedsPowerCollections>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
+++ b/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
@@ -45,7 +45,6 @@
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NeedsPowerCollections Condition=" '$(NeedsPowerCollections)' == '' ">False</NeedsPowerCollections>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/NetTopologySuite.Samples.Console/Tests/Various/Issue174TestFixture.cs
+++ b/NetTopologySuite.Samples.Console/Tests/Various/Issue174TestFixture.cs
@@ -32,14 +32,6 @@ namespace NetTopologySuite.Samples.Tests.Various
             AssertStronglyNamedAssembly(typeof(Datum));
         }
 
-#if !NET35
-        [Test, Category("Issue174")]
-        public void ensure_PowerCollections_assembly_is_strongly_named()
-        {
-            AssertStronglyNamedAssembly(typeof(Wintellect.PowerCollections.OrderedSet<object>));
-        }
-#endif
-
         [Test, Category("Issue174")]
         public void ensure_NetTopologySuite_assembly_is_strongly_named()
         {

--- a/NetTopologySuite/NetTopologySuite.csproj
+++ b/NetTopologySuite/NetTopologySuite.csproj
@@ -46,7 +46,6 @@
     <BootstrapperEnabled>false</BootstrapperEnabled>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <RestorePackages>true</RestorePackages>
-    <NeedsPowerCollections Condition=" '$(NeedsPowerCollections)' == '' ">False</NeedsPowerCollections>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFrameworkVersion)' == 'v2.0' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/NetTopologySuite/Triangulate/QuadEdge/QuadEdgeSubdivision.cs
+++ b/NetTopologySuite/Triangulate/QuadEdge/QuadEdgeSubdivision.cs
@@ -6,9 +6,6 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using NetTopologySuite.Utilities;
 
-using HashSetQ = System.Collections.Generic.HashSet<NetTopologySuite.Triangulate.QuadEdge.QuadEdge>;
-using HashSetV = System.Collections.Generic.HashSet<NetTopologySuite.Triangulate.QuadEdge.Vertex>;
-
 namespace NetTopologySuite.Triangulate.QuadEdge
 {
     /// <summary>
@@ -494,7 +491,7 @@ namespace NetTopologySuite.Triangulate.QuadEdge
         /// <see cref="GetVertexUniqueEdges"/>
         public IEnumerable<Vertex> GetVertices(bool includeFrame)
         {
-            var vertices = new HashSetV();
+            var vertices = new HashSet<Vertex>();
 
             foreach (var qe in _quadEdges)
             {
@@ -536,7 +533,7 @@ namespace NetTopologySuite.Triangulate.QuadEdge
         public IList<QuadEdge> GetVertexUniqueEdges(bool includeFrame)
         {
             var edges = new List<QuadEdge>();
-            var visitedVertices = new HashSetV();
+            var visitedVertices = new HashSet<Vertex>();
 
             foreach (var qe in _quadEdges)
             {
@@ -587,7 +584,7 @@ namespace NetTopologySuite.Triangulate.QuadEdge
             var edgeStack = new Stack<QuadEdge>();
             edgeStack.Push(_startingEdge);
 
-            var visitedEdges = new HashSetQ();
+            var visitedEdges = new HashSet<QuadEdge>();
 
             while (edgeStack.Count > 0)
             {
@@ -648,7 +645,7 @@ namespace NetTopologySuite.Triangulate.QuadEdge
             var edgeStack = new Stack<QuadEdge>();
             edgeStack.Push(_startingEdge);
 
-            var visitedEdges = new HashSetQ();
+            var visitedEdges = new HashSet<QuadEdge>();
 
             while (edgeStack.Count > 0)
             {
@@ -683,7 +680,7 @@ namespace NetTopologySuite.Triangulate.QuadEdge
         /// or <value>null</value> if the triangle should not be visited (for instance, if it is outer)
         /// </returns>
         private QuadEdge[] FetchTriangleToVisit(QuadEdge edge, Stack<QuadEdge> edgeStack, bool includeFrame,
-            HashSetQ visitedEdges)
+            HashSet<QuadEdge> visitedEdges)
         {
             QuadEdge curr = edge;
             int edgeCount = 0;

--- a/Sandcastle/NetTopologySuite.shfbproj
+++ b/Sandcastle/NetTopologySuite.shfbproj
@@ -24,7 +24,6 @@
       <DocumentationSource sourceFile="..\GeoAPI\GeoAPI\GeoAPI.csproj" configuration="Release" platform="AnyCPU" />
       <DocumentationSource sourceFile="..\NetTopologySuite\Geometries\Geometries.xml" />
       <DocumentationSource sourceFile="..\NetTopologySuite\NetTopologySuite.csproj" configuration="Release" platform="AnyCPU" />
-      <DocumentationSource sourceFile="..\PowerCollections\PowerCollections\PowerCollections.csproj" configuration="Release" platform="AnyCPU" />
       <DocumentationSource sourceFile="..\NetTopologySuite\Triangulate\QuadEdge\QuadEdgeSummary.xml" />
       <DocumentationSource sourceFile="..\NetTopologySuite\Triangulate\TriangulateSummary.xml" />
     </DocumentationSources>

--- a/TeamCity.targets
+++ b/TeamCity.targets
@@ -64,7 +64,7 @@
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v2.0" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
              Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v2.0;TargetFrameworkProfile=;DefineConstants=TRACE,NET20;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v2.0\;NeedsPowerCollections=True;" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v2.0;TargetFrameworkProfile=;DefineConstants=TRACE,NET20;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v2.0\;" 
              RunEachTargetSeparately="true" 
 			 ContinueOnError="true" 
              />		
@@ -76,7 +76,7 @@
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v3.5" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
              Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v3.5;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v3.5\;NeedsPowerCollections=False;" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v3.5;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v3.5\;" 
              RunEachTargetSeparately="true" 
              ContinueOnError="true" />
 	</Target>
@@ -87,7 +87,7 @@
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v4.0" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
              Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.0;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.0\;NeedsPowerCollections=False;" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.0;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.0\;" 
              RunEachTargetSeparately="true" 
              ContinueOnError="true" 
              />
@@ -99,7 +99,7 @@
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v4.0.3" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
              Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.0.3;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.0.3\;NeedsPowerCollections=False;" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.0.3;TargetFrameworkProfile=Client;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.0.3\;" 
              RunEachTargetSeparately="true" 
              ContinueOnError="true" 
              />		
@@ -111,7 +111,7 @@
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\v4.5" ContinueOnError="true"/>
 		<MSBuild Projects="$(SolutionFile)" 
              Targets="NetTopologySuite;NetTopologySuite_IO\NetTopologySuite_IO_GeoJSON;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile;NetTopologySuite_IO\NetTopologySuite_IO_ShapeFile_Extended;NetTopologySuite_IO\NetTopologySuite_IO_GDB;NetTopologySuite_IO\NetTopologySuite_IO_GeoTools;NetTopologySuite_IO\NetTopologySuite_IO_MsSqlSpatial;NetTopologySuite_IO\NetTopologySuite_IO_PostGis;NetTopologySuite_IO\NetTopologySuite_IO_SpatiaLite;NetTopologySuite_IO\NetTopologySuite_IO_SqlServer2008" 
-             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.5;TargetFrameworkProfile=;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.5\;NeedsPowerCollections=False;" 
+             Properties="fwVersion=$(fwVersion);Configuration=Release;TargetFrameworkVersion=v4.5;TargetFrameworkProfile=;DefineConstants=TRACE,NET20,NET35,NET40;BaseIntermediateOutputPath=$(MSBuildProjectDirectory)\obj\v4.5\;" 
              RunEachTargetSeparately="true" 
              ContinueOnError="true" 
              />


### PR DESCRIPTION
This refers to:

1. Everything that came up in a full search for "PowerCollections", **except** the license stuff.
2. A few `using` aliases for `HashSet<T>` that didn't need to exist anymore.