### PR TITLE
fix for nearest neighbor search for kd tree

### DIFF
--- a/NetTopologySuite.Tests.NUnit/Index/KdTree/KdTreeTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Index/KdTree/KdTreeTest.cs
@@ -53,6 +53,28 @@ namespace NetTopologySuite.Tests.NUnit.Index.KdTree
         }
 
         [Test]
+        public void TestNearestNeighbor()
+        {
+            var kd = new KdTree<string>();
+            kd.Insert(new Coordinate(12, 16), "A");
+            kd.Insert(new Coordinate(15, 8), "B");
+            kd.Insert(new Coordinate(5, 18), "C");
+            kd.Insert(new Coordinate(18, 5), "D");
+            kd.Insert(new Coordinate(16, 15), "E");
+            kd.Insert(new Coordinate(2, 5), "F");
+            kd.Insert(new Coordinate(7, 10), "G");
+            kd.Insert(new Coordinate(8, 7), "H");
+            kd.Insert(new Coordinate(5, 5), "I");
+            kd.Insert(new Coordinate(19, 12), "J");
+            kd.Insert(new Coordinate(10, 2), "K");
+
+
+            var res = kd.NearestNeighbor(new Coordinate(13, 2));
+
+            Assert.AreEqual("K", res.Data);
+        }
+
+        [Test]
         public void TestMultiplePoint()
         {
             TestQuery("MULTIPOINT ( (1 1), (2 2) )", 0,

--- a/NetTopologySuite.Tests.NUnit/Index/KdTree/KdTreeTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Index/KdTree/KdTreeTest.cs
@@ -68,7 +68,6 @@ namespace NetTopologySuite.Tests.NUnit.Index.KdTree
             kd.Insert(new Coordinate(19, 12), "J");
             kd.Insert(new Coordinate(10, 2), "K");
 
-
             var res = kd.NearestNeighbor(new Coordinate(13, 2));
 
             Assert.AreEqual("K", res.Data);

--- a/NetTopologySuite/Index/KdTree/KdTree.cs
+++ b/NetTopologySuite/Index/KdTree/KdTree.cs
@@ -337,12 +337,10 @@ namespace NetTopologySuite.Index.KdTree
                 var searchLeft = false;
                 var searchRight = false;
                 if (currentNode.Left != null)
-                    searchLeft = (Math.Pow(currentNode.Left.X - queryCoordinate.X, 2) +
-                                  Math.Pow(currentNode.Left.Y - queryCoordinate.Y, 2)) < closestDistanceSq;
+                    searchLeft = NeedsToBeSearched(queryCoordinate, currentNode.Left, closestDistanceSq);
 
                 if (currentNode.Right != null)
-                    searchRight = (Math.Pow(currentNode.Right.X - queryCoordinate.X, 2) +
-                                   Math.Pow(currentNode.Right.Y - queryCoordinate.Y, 2)) < closestDistanceSq;
+                    searchRight = NeedsToBeSearched(queryCoordinate, currentNode.Right, closestDistanceSq);
 
                 if (searchLeft)
                 {
@@ -357,6 +355,12 @@ namespace NetTopologySuite.Index.KdTree
                 }
                 break;
             }
+        }
+
+        private static bool NeedsToBeSearched(Coordinate target, KdNode<T> node, double closestDistSq)
+        {
+            return node.X >= target.X - closestDistSq && node.X <= target.X + closestDistSq
+                || node.Y >= target.Y - closestDistSq && node.Y <= target.Y + closestDistSq;
         }
 
         /// <summary>


### PR DESCRIPTION
from last commit "It was just checking to see if the left or right tree had a better score than current but the algorithm should check to see if the planes cross our best score for the coordinate we are looking for, not if the nodes score is better or not."

test added is from http://christopherstoll.org/assets/blogger/kD-tree_02.gif
