### PR TITLE
Ensure the SHP header is written at the beginning of the file

### DIFF
--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/ShapefileWriter.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/ShapefileWriter.cs
@@ -85,9 +85,11 @@ namespace NetTopologySuite.IO
                 /*Update header to reflect the data written*/
                 _shpStream.Seek(0, SeekOrigin.Begin);
                 var shpLenWords = (int) _shpBinaryWriter.BaseStream.Length/2;
+                
+                // Write the SHP header at the beginning of the file to update the dummy/stale header
+                WriteShpHeader(_shpBinaryWriter, shpLenWords, _totalEnvelope);
                 _shpStream.Seek(0, SeekOrigin.End);
 
-                WriteShpHeader(_shpBinaryWriter, shpLenWords, _totalEnvelope);
                 if (_shxStream != null)
                 {
                     _shxStream.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
This resolves issue [#157](https://github.com/NetTopologySuite/NetTopologySuite/issues/157) by moving the seek to the end of the file after writing the header, instead of before it.