### PR TITLE
Add public setter to LastUpdateDate property for DbaseFileHeader

### DIFF
--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/Dbase/DbaseFileHeader.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/Dbase/DbaseFileHeader.cs
@@ -59,12 +59,13 @@ namespace NetTopologySuite.IO
         }
 
         /// <summary>
-        /// Return the date this file was last updated.
+        /// Sets or returns the date this file was last updated.
         /// </summary>
         /// <returns></returns>
         public DateTime LastUpdateDate
         {
             get { return _updateDate; }
+            set { _updateDate = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
Newly-generated Shapefile headers have an incorrect last modified date since it always uses the default DateTime (1/1/0001) without a way to change it.  This addresses Issue [#159](https://github.com/NetTopologySuite/NetTopologySuite/issues/159).