### PR TITLE
Fix #169

### DIFF
--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/NetTopologySuite.IO.GeoJSON.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/NetTopologySuite.IO.GeoJSON.csproj
@@ -53,8 +53,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\$(JSON)\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/NetTopologySuite.IO/NetTopologySuite.IO/IO/Streams/ByteStreamProvider.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO/IO/Streams/ByteStreamProvider.cs
@@ -91,7 +91,15 @@ namespace NetTopologySuite.IO.Streams
 
             using (var ms = new MemoryStream())
             {
-                input.CopyTo(ms);
+                // 81920: largest multiple of 4096 that doesn't go on the LOH.
+                // 4096 is a common internal buffer size.
+                byte[] array = new byte[81920];
+                int count;
+                while ((count = input.Read(array, 0, array.Length)) != 0)
+                {
+                    ms.Write(array, 0, count);
+                }
+
                 return ms.ToArray();
             }
         }

--- a/NetTopologySuite/NetTopologySuite.csproj
+++ b/NetTopologySuite/NetTopologySuite.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Utilities\FrameworkReplacements\Collections\Generic\SortedDictionary.cs" />
     <Compile Include="Utilities\FrameworkReplacements\Collections\Generic\SortedSet.cs" />
     <Compile Include="Utilities\FrameworkReplacements\Collections\HashHelpers.cs" />
+    <Compile Include="Utilities\FrameworkReplacements\Runtime\CompilerServices\ExtensionAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyVersion.cs">

--- a/NetTopologySuite/Utilities/FrameworkReplacements/Runtime/CompilerServices/ExtensionAttribute.cs
+++ b/NetTopologySuite/Utilities/FrameworkReplacements/Runtime/CompilerServices/ExtensionAttribute.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that a method is an extension method, or that a class or assembly contains extension methods.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+    public sealed class ExtensionAttribute : Attribute { }
+}


### PR DESCRIPTION
ExtensionAttribute: this wasn't added until .NET 3.5.
ByteStreamProvider: Stream.CopyTo wasn't added until .NET 4.0.
GeoJSON: reverting some changes from ee51f24, leaving only the version and HintPath updates.