### PR TITLE
Fix #192

### DIFF
--- a/NetTopologySuite/Geometries/Implementation/DotSpatialAffineCoordinateSequence.cs
+++ b/NetTopologySuite/Geometries/Implementation/DotSpatialAffineCoordinateSequence.cs
@@ -274,9 +274,10 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <returns></returns>
         private Coordinate[] GetCachedCoords()
         {
-            if (_coordinateArrayRef != null && _coordinateArrayRef.IsAlive)
+            var localCoordinateArrayRef = _coordinateArrayRef;
+            if (localCoordinateArrayRef != null && localCoordinateArrayRef.IsAlive)
             {
-                var arr = (Coordinate[])_coordinateArrayRef.Target;
+                var arr = (Coordinate[])localCoordinateArrayRef.Target;
                 if (arr != null)
                     return arr;
 

--- a/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
+++ b/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
@@ -144,11 +144,16 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <returns></returns>
         private Coordinate[] GetCachedCoords()
         {
-            var arr = (Coordinate[]) CoordRef?.Target;
-            if (arr != null) 
-                return arr;
+            var localCoordRef = CoordRef;
+            if (localCoordRef != null)
+            {
+                var arr = (Coordinate[]) localCoordRef.Target;
+                if (arr != null)
+                    return arr;
 
-            CoordRef = null;
+                CoordRef = null;
+                return null;
+            }
             return null;
         }
 

--- a/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
+++ b/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
@@ -144,15 +144,11 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <returns></returns>
         private Coordinate[] GetCachedCoords()
         {
-            if (CoordRef != null) 
-            {
-                var arr = (Coordinate[]) CoordRef.Target;
-                if (arr != null) 
-                    return arr;
-                
-                CoordRef = null;
-                return null;
-            }
+            var arr = (Coordinate[]) CoordRef?.Target;
+            if (arr != null) 
+                return arr;
+
+            CoordRef = null;
             return null;
         }
 


### PR DESCRIPTION
@dr-jts I think this applies equally well to JTS, around [these lines](https://github.com/locationtech/jts/blob/e570b7621cb629639d53a47822a67120e9fa7a90/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java#L104-L116).

The problem is an apparent race condition: `CoordRef` (`coordRef` in JTS) can be modified between the null-check and when we actually fetch the reference target.  It seemed to happen not-unreliably when I was doing stuff at work today, though I didn't get the opportunity to confirm that this exact change fixed it in the app (though, what else in this method could possibly throw `NullReferenceException`?).

This could happen even if nobody's actually mutating the geometry: threads A and B could both just be calling `GetCachedCoords` (`getCachedCoords` in JTS), they could both run just past the initial null check, then Thread A could go all the rest of the way through the method and null out the field, then when it's Thread B's turn, it re-fetches the field (which is now null) and then tries to dereference.

If not for the fact that JTS seems to have the same problem, I'd just merge it in myself, but as-is, I'd like to get some feedback from others because of how touchy we are about deviating from JTS...