### PR TITLE
Add .NET Standard 2.0 Target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: latest
-solution: NetTopologySuite.sln
+dotnet: 2.0.0
 dist: trusty
 install:
 - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner

--- a/NTS.nuspec
+++ b/NTS.nuspec
@@ -28,24 +28,24 @@
 		<dependencies>
 			<!-- traditional .NET framework targets -->
 			<group targetFramework=".NETFramework3.5-Client">
-				<dependency id="GeoAPI" version="[1.7.5-pre006, )" />
+				<dependency id="GeoAPI" version="[1.7.5-pre009, )" />
 			</group>
 
 			<group targetFramework=".NETFramework4.0-Client">
-				<dependency id="GeoAPI" version="[1.7.5-pre006, )" />
+				<dependency id="GeoAPI" version="[1.7.5-pre009, )" />
 			</group>
 
 			<group targetFramework=".NETFramework4.0.3-Client">
-				<dependency id="GeoAPI" version="[1.7.5-pre006, )" />
+				<dependency id="GeoAPI" version="[1.7.5-pre009, )" />
 			</group>
 
 			<group targetFramework=".NETFramework4.5">
-				<dependency id="GeoAPI" version="[1.7.5-pre006, )" />
+				<dependency id="GeoAPI" version="[1.7.5-pre009, )" />
 			</group>
 
 			<!-- .NET Standard targets -->
 			<group targetFramework=".NETStandard1.0">
-				<dependency id="GeoAPI" version="[1.7.5-pre006, )" />
+				<dependency id="GeoAPI" version="[1.7.5-pre009, )" />
 				<dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
 				<dependency id="System.Linq" version="[4.3.0, )" />
 				<dependency id="System.Text.RegularExpressions" version="[4.3.0, )" />
@@ -54,13 +54,17 @@
 			</group>
 
 			<group targetFramework=".NETStandard1.3">
-				<dependency id="GeoAPI" version="[1.7.5-pre006, )" />
+				<dependency id="GeoAPI" version="[1.7.5-pre009, )" />
 				<dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
 				<dependency id="System.IO.FileSystem" version="[4.3.0, )" />
 				<dependency id="System.Linq" version="[4.3.0, )" />
 				<dependency id="System.Text.RegularExpressions" version="[4.3.0, )" />
 				<dependency id="System.Xml.ReaderWriter" version="[4.3.0, )" />
 				<dependency id="System.Xml.XDocument" version="[4.3.0, )" />
+			</group>
+
+			<group targetFramework=".NETStandard2.0">
+				<dependency id="GeoAPI" version="[1.7.5-pre009, )" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/NetTopologySuite.Common.props
+++ b/NetTopologySuite.Common.props
@@ -4,7 +4,7 @@
     <OutputPath>$(SolutionDir)$(Configuration)\$(Platform)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GeoAPIPackageReferenceVersion>1.7.5-pre006</GeoAPIPackageReferenceVersion>
+    <GeoAPIPackageReferenceVersion>1.7.5-pre009</GeoAPIPackageReferenceVersion>
   </PropertyGroup>
 
   <!-- Client Profile frameworks don't have built-in shortcuts, so we need to specify these. -->
@@ -32,6 +32,9 @@
     <!-- The NUnit 2 test adapter doesn't support portable PDBs. -->
     <DebugType>full</DebugType>
 
+    <!-- There was no compelling reason for this to be here. -->
+    <DefineConstants>$(DefineConstants);COMPAT_SHAPEFILE_IMPORT_TO_SQL_SERVER</DefineConstants>
+
     <DefineConstants>$(DefineConstants);FEATURE_FILE_IO</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_APPLICATIONEXCEPTION</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_ICLONEABLE</DefineConstants>
@@ -57,16 +60,27 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' Or '$(TargetFramework)' == 'netstandard1.3' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' Or '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_XML_NAMESPACEHANDLING</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_REFLECTION_TYPEINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_STRING_ISNULLORWHITESPACE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);FEATURE_FILE_IO</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_IO_MEMORYSTREAM_CTOR_PUBLICLYVISIBLE</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_TEXT_ENCODING_ASCII</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_SYSTEM_XML_XMLDOCUMENT</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);HAS_SYSTEM_APPLICATIONEXCEPTION</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_SYSTEM_ICLONEABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_SYSTEM_SERIALIZABLEATTRIBUTE</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_SYSTEM_TEXT_ENCODING_DEFAULT</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_SYSTEM_TYPE_ISASSIGNABLEFROM</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_XML_XMLDOCUMENT</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/NetTopologySuite.Common.props
+++ b/NetTopologySuite.Common.props
@@ -81,6 +81,5 @@
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_SERIALIZABLEATTRIBUTE</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_TEXT_ENCODING_DEFAULT</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_TYPE_ISASSIGNABLEFROM</DefineConstants>
-    <DefineConstants>$(DefineConstants);HAS_SYSTEM_XML_XMLDOCUMENT</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.GDB/NetTopologySuite.IO.GDB.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GDB/NetTopologySuite.IO.GDB.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/NetTopologySuite.IO.GeoJSON.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/NetTopologySuite.IO.GeoJSON.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/NetTopologySuite.IO.GeoTools.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/NetTopologySuite.IO.GeoTools.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/Shapefile.FullFat.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoTools/Shapefile.FullFat.cs
@@ -4,7 +4,9 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using System.Data;
+#if COMPAT_SHAPEFILE_IMPORT_TO_SQL_SERVER
 using System.Data.SqlClient;
+#endif
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 
@@ -68,6 +70,7 @@ namespace NetTopologySuite.IO
             return table;
         }
 
+#if COMPAT_SHAPEFILE_IMPORT_TO_SQL_SERVER
         /// <summary>
         /// Imports a shapefile into a database table.
         /// </summary>
@@ -191,5 +194,6 @@ namespace NetTopologySuite.IO
                 return String.Format("nvarchar({0}) ", length);
             throw new NotSupportedException("Need to add the SQL type for " + type.Name);
         }
+#endif
     }
 }

--- a/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/NetTopologySuite.IO.MsSqlSpatial.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/NetTopologySuite.IO.MsSqlSpatial.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/NetTopologySuite.IO.PostGis.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/NetTopologySuite.IO.PostGis.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.ShapeFile.Extended/NetTopologySuite.IO.ShapeFile.Extended.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.ShapeFile.Extended/NetTopologySuite.IO.ShapeFile.Extended.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net40-client;net403-client;net45</TargetFrameworks>
+    <TargetFrameworks>net40-client;net403-client;net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)NetTopologySuite.Common.props" />

--- a/NetTopologySuite.IO/NetTopologySuite.IO.ShapeFile/NetTopologySuite.IO.ShapeFile.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.ShapeFile/NetTopologySuite.IO.ShapeFile.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.SpatiaLite/NetTopologySuite.IO.SpatiaLite.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.SpatiaLite/NetTopologySuite.IO.SpatiaLite.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>

--- a/NetTopologySuite.IO/NetTopologySuite.IO.TopoJSON/NetTopologySuite.IO.TopoJSON.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.TopoJSON/NetTopologySuite.IO.TopoJSON.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
   </PropertyGroup>
 

--- a/NetTopologySuite.IO/NetTopologySuite.IO/NetTopologySuite.IO.csproj
+++ b/NetTopologySuite.IO/NetTopologySuite.IO/NetTopologySuite.IO.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite</RootNamespace>
     <DefineConstants>$(DefineConstants);UseCoordinateBufferPublicly</DefineConstants>
     <SignAssembly>true</SignAssembly>

--- a/NetTopologySuite.Lab/NetTopologySuite.Lab.csproj
+++ b/NetTopologySuite.Lab/NetTopologySuite.Lab.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>NetTopologySuite</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>

--- a/NetTopologySuite/NetTopologySuite.csproj
+++ b/NetTopologySuite/NetTopologySuite.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\</SolutionDir>
-    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35-client;net40-client;net403-client;net45;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>
     <NoWarn>659,168</NoWarn>


### PR DESCRIPTION
In summary, this PR adds the .NET Standard 2.0 target framework to all projects that already target .NET Standard 1.x, and also to `NetTopologySuite.IO.GeoTools` and `NetTopologySuite.IO.ShapeFile.Extended`, which exposes the "familiar" shapefile reading / writing functionality of NetTopologySuite to all platforms that implement .NET Standard 2.0 (see [this matrix](https://github.com/dotnet/standard/blob/master/docs/versions.md) for which platforms those are).

It does so without (knowingly) introducing any breaking API changes that would be visible to downstream consumers on the full .NET Framework, and with only one (known) relevant public API difference between the .NET Standard 2.0 and "fat" .NET Framework targets (namely, the change in the single modified C# source code file).

This intersects a lot with #184, as @xivk has an alternative suggestion for how to bring shapefile reading / writing to other target frameworks (most interestingly, .NET Standard 1.3).  I've shared some opinions in the comments of that issue about that idea.

Because of the intersection with #184, I'm going to hold off a bit on merging this until others have an opportunity to share their opinions on this.
1. If this goes out there "soon", and then we bring in the breaking API changes proposed in the most recent concrete solution proposed in #184, then those breaking changes can affect any downstream consumers who would have begun to use the new things added here, which I think just looks bad.
2. If, on the other hand, those breaking changes are added before we do something like this PR, then downstream consumers on frameworks other than "fat" .NET Framework would not be impacted by any of those breaking changes because they would only develop against the aftermath.
3. Finally, if we reject those breaking changes for now, then this would be "perfectly fine" as-is, apart from the fact that I still really hate the "design" of the shapefile reading / writing API.