### PR TITLE
Always keep track of GeoJSON feature ID when parsing

### DIFF
--- a/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/Converters/FeatureConverter.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.GeoJSON/Converters/FeatureConverter.cs
@@ -148,12 +148,17 @@ namespace NetTopologySuite.IO.Converters
 
             //read = reader.Read(); // move next
 
-            IAttributesTable attributes = feature.Attributes;
-            if (attributes != null)
+            if (featureId != null)
             {
-                if (featureId != null && !attributes.Exists("id"))
+                IAttributesTable attributes = feature.Attributes;
+
+                if (attributes == null)
+                    attributes = feature.Attributes = new AttributesTable();
+
+                if (!attributes.Exists("id"))
                     attributes.AddAttribute("id", featureId);
             }
+
             return feature;
         }
 


### PR DESCRIPTION
Fixes the issue described in #216.
If this change is deemed acceptable, I shall add a unit test.