### PR TITLE
Added non-seekable stream support

### DIFF
--- a/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/MsSqlSpatialReader.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/MsSqlSpatialReader.cs
@@ -8,7 +8,7 @@ namespace NetTopologySuite.IO
     {
         public override IGeometry Read(Stream stream)
         {
-            using (var reader = new BiEndianBinaryReader(stream, byteOrder))
+            using (var reader = new BiEndianBinaryReader(stream))
             {
                 IGeometry geometry = Read(reader);
                 int srid = -1;

--- a/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/MsSqlSpatialReader.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/MsSqlSpatialReader.cs
@@ -8,7 +8,6 @@ namespace NetTopologySuite.IO
     {
         public override IGeometry Read(Stream stream)
         {
-            var byteOrder = (ByteOrder)stream.ReadByte();
             using (var reader = new BiEndianBinaryReader(stream, byteOrder))
             {
                 IGeometry geometry = Read(reader);

--- a/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/MsSqlSpatialReader.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/MsSqlSpatialReader.cs
@@ -9,7 +9,7 @@ namespace NetTopologySuite.IO
         public override IGeometry Read(Stream stream)
         {
             var byteOrder = (ByteOrder)stream.ReadByte();
-            using (var reader = new ConfigurableBinaryReader(stream, byteOrder))
+            using (var reader = new BiEndianBinaryReader(stream, byteOrder))
             {
                 IGeometry geometry = Read(reader);
                 int srid = -1;

--- a/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/MsSqlSpatialReader.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.MsSqlSpatial/MsSqlSpatialReader.cs
@@ -9,7 +9,7 @@ namespace NetTopologySuite.IO
         public override IGeometry Read(Stream stream)
         {
             var byteOrder = (ByteOrder)stream.ReadByte();
-            using (BinaryReader reader = byteOrder == ByteOrder.BigEndian ? new BEBinaryReader(stream) : new BinaryReader(stream))
+            using (var reader = new ConfigurableBinaryReader(stream, byteOrder))
             {
                 IGeometry geometry = Read(reader);
                 int srid = -1;

--- a/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/PostGisReader.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/PostGisReader.cs
@@ -94,7 +94,7 @@ namespace NetTopologySuite.IO
         /// <returns></returns>
         public IGeometry Read(Stream stream)
         {
-            using (var reader = new ConfigurableBinaryReader(stream))
+            using (var reader = new BinaryReader(stream))
                 return Read(reader);
         }
 
@@ -108,9 +108,9 @@ namespace NetTopologySuite.IO
         /// </summary>
         /// <param name="reader"></param>
         /// <returns></returns>
-        protected IGeometry Read(ConfigurableBinaryReader reader)
+        protected IGeometry Read(BinaryReader reader)
         {
-            reader.EncodingType = (ByteOrder)reader.ReadByte();
+            ((BiEndianBinaryReader)reader).Endianess = (ByteOrder)reader.ReadByte();
 
             var typeword = reader.ReadInt32();
 
@@ -293,7 +293,7 @@ namespace NetTopologySuite.IO
         /// </summary>
         /// <param name="reader">The binary reader.</param>
         /// <param name="container">The container for the geometries</param>
-        protected void ReadGeometryArray<TGeometry>(ConfigurableBinaryReader reader, TGeometry[] container)
+        protected void ReadGeometryArray<TGeometry>(BinaryReader reader, TGeometry[] container)
             where TGeometry : IGeometry
         {
             for (var i = 0; i < container.Length; i++)
@@ -306,7 +306,7 @@ namespace NetTopologySuite.IO
         /// <param name="reader">The binary reader.</param>
         /// <param name="factory">The geometry factory to use for geometry creation.</param>
         /// <returns>The MultiPoint</returns>
-        protected IMultiPoint ReadMultiPoint(ConfigurableBinaryReader reader, IGeometryFactory factory)
+        protected IMultiPoint ReadMultiPoint(BinaryReader reader, IGeometryFactory factory)
         {
             int numGeometries = reader.ReadInt32();
             var points = new IPoint[numGeometries];
@@ -320,7 +320,7 @@ namespace NetTopologySuite.IO
         /// <param name="reader">The binary reader.</param>
         /// <param name="factory">The geometry factory to use for geometry creation.</param>
         /// <returns>The MultiLineString</returns>
-        protected IMultiLineString ReadMultiLineString(ConfigurableBinaryReader reader, IGeometryFactory factory)
+        protected IMultiLineString ReadMultiLineString(BinaryReader reader, IGeometryFactory factory)
         {
             int numGeometries = reader.ReadInt32();
             var strings = new ILineString[numGeometries];
@@ -334,7 +334,7 @@ namespace NetTopologySuite.IO
         /// <param name="reader">The binary reader.</param>
         /// <param name="factory">The geometry factory to use for geometry creation.</param>
         /// <returns>The MultiPolygon</returns>
-        protected IMultiPolygon ReadMultiPolygon(ConfigurableBinaryReader reader, IGeometryFactory factory)
+        protected IMultiPolygon ReadMultiPolygon(BinaryReader reader, IGeometryFactory factory)
         {
             int numGeometries = reader.ReadInt32();
             var polygons = new IPolygon[numGeometries];
@@ -348,7 +348,7 @@ namespace NetTopologySuite.IO
         /// <param name="reader">The binary reader.</param>
         /// <param name="factory">The geometry factory to use for geometry creation.</param>
         /// <returns>The GeometryCollection</returns>
-        protected IGeometryCollection ReadGeometryCollection(ConfigurableBinaryReader reader, IGeometryFactory factory)
+        protected IGeometryCollection ReadGeometryCollection(BinaryReader reader, IGeometryFactory factory)
         {
             int numGeometries = reader.ReadInt32();
             var geometries = new IGeometry[numGeometries];

--- a/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/PostGisReader.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/PostGisReader.cs
@@ -94,7 +94,7 @@ namespace NetTopologySuite.IO
         /// <returns></returns>
         public IGeometry Read(Stream stream)
         {
-            using (var reader = new BinaryReader(stream))
+            using (var reader = new BiEndianBinaryReader(stream))
                 return Read(reader);
         }
 

--- a/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/PostGisReader.cs
+++ b/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/PostGisReader.cs
@@ -94,14 +94,8 @@ namespace NetTopologySuite.IO
         /// <returns></returns>
         public IGeometry Read(Stream stream)
         {
-            var byteOrder = (ByteOrder)stream.ReadByte();
-            // "Rewind" to let Read(BinaryReader) skip this byte
-            // in collection and non-collection geometries.
-            stream.Position = 0;
-            using (BinaryReader reader = byteOrder == ByteOrder.BigEndian ? new BEBinaryReader(stream) : new BinaryReader(stream))
-            {
+            using (var reader = new ConfigurableBinaryReader(stream))
                 return Read(reader);
-            }
         }
 
         /// <summary>
@@ -114,11 +108,9 @@ namespace NetTopologySuite.IO
         /// </summary>
         /// <param name="reader"></param>
         /// <returns></returns>
-        protected IGeometry Read(BinaryReader reader)
+        protected IGeometry Read(ConfigurableBinaryReader reader)
         {
-            // Dummy read, just for bytes compatibility.
-            // The byte order is determined only once.
-            reader.ReadByte();
+            reader.EncodingType = (ByteOrder)reader.ReadByte();
 
             var typeword = reader.ReadInt32();
 
@@ -301,7 +293,7 @@ namespace NetTopologySuite.IO
         /// </summary>
         /// <param name="reader">The binary reader.</param>
         /// <param name="container">The container for the geometries</param>
-        protected void ReadGeometryArray<TGeometry>(BinaryReader reader, TGeometry[] container)
+        protected void ReadGeometryArray<TGeometry>(ConfigurableBinaryReader reader, TGeometry[] container)
             where TGeometry : IGeometry
         {
             for (var i = 0; i < container.Length; i++)
@@ -314,7 +306,7 @@ namespace NetTopologySuite.IO
         /// <param name="reader">The binary reader.</param>
         /// <param name="factory">The geometry factory to use for geometry creation.</param>
         /// <returns>The MultiPoint</returns>
-        protected IMultiPoint ReadMultiPoint(BinaryReader reader, IGeometryFactory factory)
+        protected IMultiPoint ReadMultiPoint(ConfigurableBinaryReader reader, IGeometryFactory factory)
         {
             int numGeometries = reader.ReadInt32();
             var points = new IPoint[numGeometries];
@@ -328,7 +320,7 @@ namespace NetTopologySuite.IO
         /// <param name="reader">The binary reader.</param>
         /// <param name="factory">The geometry factory to use for geometry creation.</param>
         /// <returns>The MultiLineString</returns>
-        protected IMultiLineString ReadMultiLineString(BinaryReader reader, IGeometryFactory factory)
+        protected IMultiLineString ReadMultiLineString(ConfigurableBinaryReader reader, IGeometryFactory factory)
         {
             int numGeometries = reader.ReadInt32();
             var strings = new ILineString[numGeometries];
@@ -342,7 +334,7 @@ namespace NetTopologySuite.IO
         /// <param name="reader">The binary reader.</param>
         /// <param name="factory">The geometry factory to use for geometry creation.</param>
         /// <returns>The MultiPolygon</returns>
-        protected IMultiPolygon ReadMultiPolygon(BinaryReader reader, IGeometryFactory factory)
+        protected IMultiPolygon ReadMultiPolygon(ConfigurableBinaryReader reader, IGeometryFactory factory)
         {
             int numGeometries = reader.ReadInt32();
             var polygons = new IPolygon[numGeometries];
@@ -356,7 +348,7 @@ namespace NetTopologySuite.IO
         /// <param name="reader">The binary reader.</param>
         /// <param name="factory">The geometry factory to use for geometry creation.</param>
         /// <returns>The GeometryCollection</returns>
-        protected IGeometryCollection ReadGeometryCollection(BinaryReader reader, IGeometryFactory factory)
+        protected IGeometryCollection ReadGeometryCollection(ConfigurableBinaryReader reader, IGeometryFactory factory)
         {
             int numGeometries = reader.ReadInt32();
             var geometries = new IGeometry[numGeometries];

--- a/NetTopologySuite/IO/BEBinaryReader.cs
+++ b/NetTopologySuite/IO/BEBinaryReader.cs
@@ -17,6 +17,7 @@ namespace NetTopologySuite.IO
     /// and <see cref="BinaryReader.ReadDouble" /> and more, 
     /// for reading <see cref="ByteOrder.BigEndian" /> values in the BigEndian format.
     /// </remarks>
+    [Obsolete("Use " + nameof(ConfigurableBinaryReader))]
     public class BEBinaryReader : BinaryReader
     {
         /// <summary>

--- a/NetTopologySuite/IO/BEBinaryReader.cs
+++ b/NetTopologySuite/IO/BEBinaryReader.cs
@@ -17,7 +17,7 @@ namespace NetTopologySuite.IO
     /// and <see cref="BinaryReader.ReadDouble" /> and more, 
     /// for reading <see cref="ByteOrder.BigEndian" /> values in the BigEndian format.
     /// </remarks>
-    [Obsolete("Use " + nameof(ConfigurableBinaryReader))]
+    [Obsolete("Use " + nameof(BiEndianBinaryReader))]
     public class BEBinaryReader : BinaryReader
     {
         /// <summary>

--- a/NetTopologySuite/IO/BiEndianBinaryReader.cs
+++ b/NetTopologySuite/IO/BiEndianBinaryReader.cs
@@ -9,34 +9,34 @@ namespace NetTopologySuite.IO
     /// Extends the <see cref="BinaryReader" /> class to allow reading values in the specified format.    
     /// </summary>
     /// <remarks>
-    /// While <see cref="ConfigurableBinaryReader" /> extends <see cref="BinaryReader" /> 
-    /// adding methods for reading integer values (<see cref="ConfigurableBinaryReader.ReadInt32" />)
-    /// and double values (<see cref="ConfigurableBinaryReader.ReadDouble" />) in the specified format, 
+    /// While <see cref="BiEndianBinaryReader" /> extends <see cref="BinaryReader" /> 
+    /// adding methods for reading integer values (<see cref="BiEndianBinaryReader.ReadInt32" />)
+    /// and double values (<see cref="BiEndianBinaryReader.ReadDouble" />) in the specified format, 
     /// this implementation overrides methods, such <see cref="BinaryReader.ReadInt32" /> 
     /// and <see cref="BinaryReader.ReadDouble" /> and more, 
-    /// for reading values in the specified by <see cref="ConfigurableBinaryReader.EncodingType"/> format.
+    /// for reading values in the specified by <see cref="BiEndianBinaryReader.Endianess"/> format.
     /// </remarks>
-    public class ConfigurableBinaryReader : BinaryReader
+    public class BiEndianBinaryReader : BinaryReader
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigurableBinaryReader"/> class.
+        /// Initializes a new instance of the <see cref="BiEndianBinaryReader"/> class.
         /// </summary>
         /// <param name="stream">The stream.</param>
-        public ConfigurableBinaryReader(Stream stream) : base(stream) { }
+        public BiEndianBinaryReader(Stream stream) : base(stream) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigurableBinaryReader"/> class.
+        /// Initializes a new instance of the <see cref="BiEndianBinaryReader"/> class.
         /// </summary>
         /// <param name="input">The supplied stream.</param>
-        /// <param name="encodingType">The byte order.</param>
+        /// <param name="endianess">The byte order.</param>
         /// <exception cref="T:System.ArgumentException">The stream does not support reading, the stream is null, or the stream is already closed. </exception>
-        public ConfigurableBinaryReader(Stream input, ByteOrder encodingType) : base(input)
-            => EncodingType = encodingType;
+        public BiEndianBinaryReader(Stream input, ByteOrder endianess) : base(input)
+            => Endianess = endianess;
 
         /// <summary>
         /// Encoding type
         /// </summary>
-        public ByteOrder EncodingType { get; set; }
+        public ByteOrder Endianess { get; set; }
 
         /// <summary>
         /// Reads a 2-byte signed integer from the current stream using the specified encoding
@@ -51,7 +51,7 @@ namespace NetTopologySuite.IO
         public override short ReadInt16()
         {
             var result = base.ReadInt16();
-            return (EncodingType == ByteOrder.BigEndian)
+            return (Endianess == ByteOrder.BigEndian)
                 ? BitTweaks.ReverseByteOrder(result)
                 : result;
         }
@@ -70,7 +70,7 @@ namespace NetTopologySuite.IO
         public override ushort ReadUInt16()
         {
             var result = base.ReadUInt16();
-            return (EncodingType == ByteOrder.BigEndian)
+            return (Endianess == ByteOrder.BigEndian)
                 ? BitTweaks.ReverseByteOrder(result)
                 : result;
         }
@@ -88,7 +88,7 @@ namespace NetTopologySuite.IO
         public override int ReadInt32()
         {
             var result = base.ReadInt32();
-            return (EncodingType == ByteOrder.BigEndian)
+            return (Endianess == ByteOrder.BigEndian)
                 ? BitTweaks.ReverseByteOrder(result)
                 : result;
         }
@@ -107,7 +107,7 @@ namespace NetTopologySuite.IO
         public override uint ReadUInt32()
         {
             var result = base.ReadUInt32();
-            return (EncodingType == ByteOrder.BigEndian)
+            return (Endianess == ByteOrder.BigEndian)
                 ? BitTweaks.ReverseByteOrder(result)
                 : result;
         }
@@ -125,7 +125,7 @@ namespace NetTopologySuite.IO
         public override long ReadInt64()
         {
             var result = base.ReadInt64();
-            return (EncodingType == ByteOrder.BigEndian)
+            return (Endianess == ByteOrder.BigEndian)
                 ? BitTweaks.ReverseByteOrder(result)
                 : result;
         }
@@ -145,7 +145,7 @@ namespace NetTopologySuite.IO
         public override ulong ReadUInt64()
         {
             var result = base.ReadUInt64();
-            return (EncodingType == ByteOrder.BigEndian)
+            return (Endianess == ByteOrder.BigEndian)
                 ? BitTweaks.ReverseByteOrder(result)
                 : result;
         }
@@ -163,7 +163,7 @@ namespace NetTopologySuite.IO
         public override float ReadSingle()
         {
             var result = base.ReadSingle();
-            return (EncodingType == ByteOrder.BigEndian)
+            return (Endianess == ByteOrder.BigEndian)
                 ? BitTweaks.ReverseByteOrder(result)
                 : result;
         }
@@ -181,7 +181,7 @@ namespace NetTopologySuite.IO
         public override double ReadDouble()
         {
             var result = base.ReadDouble();
-            return (EncodingType == ByteOrder.BigEndian)
+            return (Endianess == ByteOrder.BigEndian)
                 ? BitTweaks.ReverseByteOrder(result)
                 : result;
         }
@@ -194,10 +194,11 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
-        [Obsolete("Not implemented", true)]
         public override string ReadString()
         {
-            throw new NotImplementedException();
+            if (Endianess == ByteOrder.BigEndian)
+                throw new NotSupportedException();
+            return base.ReadString();
         }
 
         /// <summary>
@@ -210,10 +211,11 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
-        [Obsolete("Not implemented", true)]
         public override decimal ReadDecimal()
         {
-            throw new NotImplementedException();
+            if (Endianess == ByteOrder.BigEndian)
+                throw new NotSupportedException();
+            return base.ReadDecimal();
         }
     }
 }

--- a/NetTopologySuite/IO/ConfigurableBinaryReader.cs
+++ b/NetTopologySuite/IO/ConfigurableBinaryReader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Text;
 using GeoAPI.IO;
 using NetTopologySuite.Utilities;
 
@@ -15,7 +14,7 @@ namespace NetTopologySuite.IO
     /// and double values (<see cref="ConfigurableBinaryReader.ReadDouble" />) in the specified format, 
     /// this implementation overrides methods, such <see cref="BinaryReader.ReadInt32" /> 
     /// and <see cref="BinaryReader.ReadDouble" /> and more, 
-    /// for reading values in the specified format.
+    /// for reading values in the specified by <see cref="ConfigurableBinaryReader.EncodingType"/> format.
     /// </remarks>
     public class ConfigurableBinaryReader : BinaryReader
     {
@@ -29,10 +28,10 @@ namespace NetTopologySuite.IO
         /// Initializes a new instance of the <see cref="ConfigurableBinaryReader"/> class.
         /// </summary>
         /// <param name="input">The supplied stream.</param>
-        /// <param name="encoding">The character encoding.</param>
-        /// <exception cref="T:System.ArgumentNullException">encoding is null. </exception>
+        /// <param name="encodingType">The byte order.</param>
         /// <exception cref="T:System.ArgumentException">The stream does not support reading, the stream is null, or the stream is already closed. </exception>
-        public ConfigurableBinaryReader(Stream input, Encoding encoding) : base(input, encoding) { }
+        public ConfigurableBinaryReader(Stream input, ByteOrder encodingType) : base(input)
+            => EncodingType = encodingType;
 
         /// <summary>
         /// Encoding type
@@ -195,7 +194,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
-        [Obsolete("Not implemented")]
+        [Obsolete("Not implemented", true)]
         public override string ReadString()
         {
             throw new NotImplementedException();
@@ -211,7 +210,7 @@ namespace NetTopologySuite.IO
         /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
-        [Obsolete("Not implemented")]
+        [Obsolete("Not implemented", true)]
         public override decimal ReadDecimal()
         {
             throw new NotImplementedException();

--- a/NetTopologySuite/IO/ConfigurableBinaryReader.cs
+++ b/NetTopologySuite/IO/ConfigurableBinaryReader.cs
@@ -15,7 +15,7 @@ namespace NetTopologySuite.IO
     /// and double values (<see cref="ConfigurableBinaryReader.ReadDouble" />) in the specified format, 
     /// this implementation overrides methods, such <see cref="BinaryReader.ReadInt32" /> 
     /// and <see cref="BinaryReader.ReadDouble" /> and more, 
-    /// for reading <see cref="ByteOrder.BigEndian" /> values in the specified format.
+    /// for reading values in the specified format.
     /// </remarks>
     public class ConfigurableBinaryReader : BinaryReader
     {

--- a/NetTopologySuite/IO/ConfigurableBinaryReader.cs
+++ b/NetTopologySuite/IO/ConfigurableBinaryReader.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using GeoAPI.IO;
+using NetTopologySuite.Utilities;
+
+namespace NetTopologySuite.IO
+{
+    /// <summary>
+    /// Extends the <see cref="BinaryReader" /> class to allow reading values in the specified format.    
+    /// </summary>
+    /// <remarks>
+    /// While <see cref="ConfigurableBinaryReader" /> extends <see cref="BinaryReader" /> 
+    /// adding methods for reading integer values (<see cref="ConfigurableBinaryReader.ReadInt32" />)
+    /// and double values (<see cref="ConfigurableBinaryReader.ReadDouble" />) in the specified format, 
+    /// this implementation overrides methods, such <see cref="BinaryReader.ReadInt32" /> 
+    /// and <see cref="BinaryReader.ReadDouble" /> and more, 
+    /// for reading <see cref="ByteOrder.BigEndian" /> values in the specified format.
+    /// </remarks>
+    public class ConfigurableBinaryReader : BinaryReader
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurableBinaryReader"/> class.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        public ConfigurableBinaryReader(Stream stream) : base(stream) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurableBinaryReader"/> class.
+        /// </summary>
+        /// <param name="input">The supplied stream.</param>
+        /// <param name="encoding">The character encoding.</param>
+        /// <exception cref="T:System.ArgumentNullException">encoding is null. </exception>
+        /// <exception cref="T:System.ArgumentException">The stream does not support reading, the stream is null, or the stream is already closed. </exception>
+        public ConfigurableBinaryReader(Stream input, Encoding encoding) : base(input, encoding) { }
+
+        /// <summary>
+        /// Encoding type
+        /// </summary>
+        public ByteOrder EncodingType { get; set; }
+
+        /// <summary>
+        /// Reads a 2-byte signed integer from the current stream using the specified encoding
+        /// and advances the current position of the stream by two bytes.
+        /// </summary>
+        /// <returns>
+        /// A 2-byte signed integer read from the current stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        public override short ReadInt16()
+        {
+            var result = base.ReadInt16();
+            return (EncodingType == ByteOrder.BigEndian)
+                ? BitTweaks.ReverseByteOrder(result)
+                : result;
+        }
+
+        /// <summary>
+        /// Reads a 2-byte unsigned integer from the current stream using the specified encoding 
+        /// and advances the position of the stream by two bytes.
+        /// </summary>
+        /// <returns>
+        /// A 2-byte unsigned integer read from this stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        [CLSCompliant(false)]
+        public override ushort ReadUInt16()
+        {
+            var result = base.ReadUInt16();
+            return (EncodingType == ByteOrder.BigEndian)
+                ? BitTweaks.ReverseByteOrder(result)
+                : result;
+        }
+
+        /// <summary>
+        /// Reads a 4-byte signed integer from the current stream using the specified encoding
+        /// and advances the current position of the stream by four bytes.
+        /// </summary>
+        /// <returns>
+        /// A 4-byte signed integer read from the current stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        public override int ReadInt32()
+        {
+            var result = base.ReadInt32();
+            return (EncodingType == ByteOrder.BigEndian)
+                ? BitTweaks.ReverseByteOrder(result)
+                : result;
+        }
+
+        /// <summary>
+        /// Reads a 4-byte unsigned integer from the current stream using the specified encoding
+        /// and advances the position of the stream by four bytes.
+        /// </summary>
+        /// <returns>
+        /// A 4-byte unsigned integer read from this stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        [CLSCompliant(false)]
+        public override uint ReadUInt32()
+        {
+            var result = base.ReadUInt32();
+            return (EncodingType == ByteOrder.BigEndian)
+                ? BitTweaks.ReverseByteOrder(result)
+                : result;
+        }
+
+        /// <summary>
+        /// Reads an 8-byte signed integer from the current stream using the specified encoding
+        /// and advances the current position of the stream by eight bytes.
+        /// </summary>
+        /// <returns>
+        /// An 8-byte signed integer read from the current stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        public override long ReadInt64()
+        {
+            var result = base.ReadInt64();
+            return (EncodingType == ByteOrder.BigEndian)
+                ? BitTweaks.ReverseByteOrder(result)
+                : result;
+        }
+
+
+        /// <summary>
+        /// Reads an 8-byte unsigned integer from the current stream using the specified encoding 
+        /// and advances the position of the stream by eight bytes.
+        /// </summary>
+        /// <returns>
+        /// An 8-byte unsigned integer read from this stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        [CLSCompliant(false)]
+        public override ulong ReadUInt64()
+        {
+            var result = base.ReadUInt64();
+            return (EncodingType == ByteOrder.BigEndian)
+                ? BitTweaks.ReverseByteOrder(result)
+                : result;
+        }
+
+        /// <summary>
+        /// Reads a 4-byte floating point value from the current stream using the specified encoding
+        /// and advances the current position of the stream by four bytes.
+        /// </summary>
+        /// <returns>
+        /// A 4-byte floating point value read from the current stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        public override float ReadSingle()
+        {
+            var result = base.ReadSingle();
+            return (EncodingType == ByteOrder.BigEndian)
+                ? BitTweaks.ReverseByteOrder(result)
+                : result;
+        }
+
+        /// <summary>
+        /// Reads an 8-byte floating point value from the current stream using the specified encoding
+        /// and advances the current position of the stream by eight bytes.
+        /// </summary>
+        /// <returns>
+        /// An 8-byte floating point value read from the current stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        public override double ReadDouble()
+        {
+            var result = base.ReadDouble();
+            return (EncodingType == ByteOrder.BigEndian)
+                ? BitTweaks.ReverseByteOrder(result)
+                : result;
+        }
+
+        /// <summary>
+        /// Reads a string from the current stream. 
+        /// The string is prefixed with the length, encoded as an integer seven bits at a time.
+        /// </summary>
+        /// <returns>The string being read.</returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        [Obsolete("Not implemented")]
+        public override string ReadString()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Reads a decimal value from the current stream 
+        /// and advances the current position of the stream by sixteen bytes.
+        /// </summary>
+        /// <returns>
+        /// A decimal value read from the current stream.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The stream is closed. </exception>
+        /// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        /// <exception cref="T:System.IO.EndOfStreamException">The end of the stream is reached. </exception>
+        [Obsolete("Not implemented")]
+        public override decimal ReadDecimal()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
We've faced an issue with reading data from a non-seekable stream using `PostGisReader` because of these lines:

https://github.com/NetTopologySuite/NetTopologySuite/blob/543b56b20c8c83df9d7ae12cf2ac3a15590c349f/NetTopologySuite.IO/NetTopologySuite.IO.PostGis/PostGisReader.cs#L97-L104

The solution is to have a `BinaryWriter` which allows to change byte order on the fly. The `PostGisReader` reads the actual byte order in the `Read` method and sets it to `ConfigurableBinaryReader.EncodingType`.