### PR TITLE
ConformingDelaunayTriangulationBuilder.CreateVertices should use the indexer, not Add

### DIFF
--- a/NetTopologySuite.Tests.NUnit/Triangulate/ConformingDelaunayTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Triangulate/ConformingDelaunayTest.cs
@@ -25,6 +25,19 @@ namespace NetTopologySuite.Tests.NUnit.Triangulate
             RunDelaunay(wkt, lineWKT, true, expectedTri);
         }
 
+        [Test, Category("Issue234")]
+        public void TestPolygonWithHole()
+        {
+            const string SitesWKT = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (4 4, 6 4, 6 6, 4 6, 4 4))";
+            const string ConstraintsWKT = "LINESTRING (4 4, 6 4, 6 6, 4 6, 4 4)";
+
+            const string ExpectedEdgesWKT = "MULTILINESTRING ((0 10, 10 10), (0 0, 0 10), (0 0, 10 0), (10 0, 10 10), (6 4, 10 0), (6 4, 10 10), (6 4, 6 6), (6 6, 10 10), (4 6, 6 6), (4 6, 10 10), (0 10, 4 6), (4 4, 4 6), (0 10, 4 4), (0 0, 4 4), (4 4, 10 0), (4 4, 6 4), (4 6, 6 4))";
+            RunDelaunay(SitesWKT, ConstraintsWKT, false, ExpectedEdgesWKT);
+
+            const string ExpectedTriWKT = "GEOMETRYCOLLECTION (POLYGON ((0 10, 0 0, 4 4, 0 10)), POLYGON ((0 10, 4 4, 4 6, 0 10)), POLYGON ((0 10, 4 6, 10 10, 0 10)), POLYGON ((10 10, 4 6, 6 6, 10 10)), POLYGON ((10 10, 6 6, 6 4, 10 10)), POLYGON ((10 10, 6 4, 10 0, 10 10)), POLYGON ((0 0, 10 0, 4 4, 0 0)), POLYGON ((4 4, 10 0, 6 4, 4 4)), POLYGON ((4 4, 6 4, 4 6, 4 4)), POLYGON ((4 6, 6 4, 6 6, 4 6)))";
+            RunDelaunay(SitesWKT, ConstraintsWKT, true, ExpectedTriWKT);
+        }
+
         private const double ComparisonTolerance = 1.0e-7;
 
         private static void RunDelaunay(string sitesWKT, string constraintsWKT, bool computeTriangles, string expectedWKT)

--- a/NetTopologySuite/Triangulate/ConformingDelaunayTriangulationBuilder.cs
+++ b/NetTopologySuite/Triangulate/ConformingDelaunayTriangulationBuilder.cs
@@ -99,7 +99,7 @@ namespace NetTopologySuite.Triangulate
             for (int i = 0; i < coords.Length; i++)
             {
                 Vertex v = new ConstraintVertex(coords[i]);
-                _constraintVertexMap.Add(coords[i], v);
+                _constraintVertexMap[coords[i]] = v;
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. 
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #234 by using the indexer instead of `Add`, to move this closer to what JTS's version of the operation does.

I did **not** check for any other places where we make this mistake (i.e., Java would have used `Map.put()`, but we use `IDictionary<TKey, TValue>.Add`).