### PR TITLE
Add License.md file to repository root

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,0 +1,72 @@
+# NTS - .NET Topology Suite Licensing
+May 1st, 2018
+
+## Preamble
+NTS is derivative work of __[JTS Topology Suite](https://github.com/locationtech/jts)__. You can read about the licensing for this project [below][JTS Topology Suite licensing].
+
+
+## Project License
+>Copyright (C) 2005-2018 NetTopologySuite team
+>
+>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+>
+>1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+>
+>2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+>
+>3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+>
+>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For more information please visit: https://github.com/NetTopologySuite/NetTopologySuite
+
+
+## JTS Topology Suite licensing
+As of version 1.15 __JTS Topology Suite__ is released using the following licenses:
+
+>The Eclipse Foundation makes available all content in this project ("Content"). Unless otherwise indicated below, the Content is provided to you under the terms and conditions of either the [Eclipse Public License 1.0](https://www.eclipse.org/legal/epl-v10.html) ("EPL") or the [Eclipse Distribution License 1.0](http://www.eclipse.org/org/documents/edl-v10.php) (a BSD Style License).  For purposes of the EPL, "Program" will mean the Content.
+>
+>If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by another party ("Redistributor") and different terms and conditions may apply to your use of any object code in the Content. Check the Redistributor's license that was provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise indicated below, the terms and conditions of the EPL still apply to any source code in the Content and such source code may be obtained at http://www.eclipse.org.
+
+For more detailed information please visit https://github.com/locationtech/jts/LICENSES.md.
+
+## Third party content
+
+### RTools.Util
+`StreamTokenizer` and related classes are taken from __[RTools.Util - C# Library](https://www.codeproject.com/Articles/3143/RTools-Util-C-Library)__. The code was released to the public domain.
+
+>Copyright (C) 2003 Ryan Seghers
+This software is provided AS IS. No warranty is granted, 
+neither expressed nor implied. USE THIS SOFTWARE AT YOUR OWN RISK.
+NO REPRESENTATION OF MERCHANTABILITY or FITNESS FOR ANY 
+PURPOSE is given.
+License to use this software is limited by the following terms:
+>1) This code may be used in any program, including programs developed
+   for commercial purposes, provided that this notice is included verbatim.
+Also, in return for using this code, please attempt to make your fixes and
+updates available in some way, such as by sending your updates to the
+author.
+
+### High Speed Priority Queue for C#
+`PriorityQueueNode` and `AlternativePriorityQueue` are derived from 
+BlueRaja's __[High Speed Priority Queue for C#](https://github.com/BlueRaja/High-Speed-Priority-Queue-for-C-Sharp)__, released under MIT License (MIT)
+
+>Copyright (c) 2013 Daniel "BlueRaja" Pflughoeft
+>
+>Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+>
+>The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+>
+>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. 
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
The root folder of this repository does not contain a license file (#207).
__JTS__ switched to a more liberal license. This is the goal for NTS as well.

Closes #196
Closes #207