### PR TITLE
Fix JTS Topology Suite license link in License.md

### DIFF
--- a/License.md
+++ b/License.md
@@ -2,7 +2,7 @@
 May 1st, 2018
 
 ## Preamble
-NTS is derivative work of __[JTS Topology Suite](https://github.com/locationtech/jts)__. You can read about the licensing for this project [below][JTS Topology Suite licensing].
+NTS is derivative work of __[JTS Topology Suite](https://github.com/locationtech/jts)__. You can read about the licensing for this project [below](#jts-topology-suite-licensing).
 
 
 ## Project License


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
Fixes the link to the JTS Topology licensing section in License.md
