### PR TITLE
Add upper-bounds for GeoAPI references in the nuspec files

### DIFF
--- a/NTS.CoordinateSystems.nuspec
+++ b/NTS.CoordinateSystems.nuspec
@@ -28,24 +28,24 @@
     <dependencies>
       <!-- traditional .NET framework targets -->
       <group targetFramework=".NETFramework3.5-Client">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
       </group>
 
       <group targetFramework=".NETFramework4.0-Client">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
       </group>
 
       <group targetFramework=".NETFramework4.0.3-Client">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
       </group>
 
       <group targetFramework=".NETFramework4.5">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
       </group>
 
       <!-- .NET Standard targets -->
       <group targetFramework=".NETStandard1.0">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
         <dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
         <dependency id="System.Linq" version="[4.3.0, )" />
         <dependency id="System.Text.RegularExpressions" version="[4.3.0, )" />
@@ -54,7 +54,7 @@
       </group>
 
       <group targetFramework=".NETStandard1.3">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
         <dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
         <dependency id="System.IO.FileSystem" version="[4.3.0, )" />
         <dependency id="System.Linq" version="[4.3.0, )" />
@@ -64,7 +64,7 @@
       </group>
 
       <group targetFramework=".NETStandard2.0">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/NTS.CoordinateSystems.nuspec
+++ b/NTS.CoordinateSystems.nuspec
@@ -28,24 +28,24 @@
     <dependencies>
       <!-- traditional .NET framework targets -->
       <group targetFramework=".NETFramework3.5-Client">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
 
       <group targetFramework=".NETFramework4.0-Client">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
 
       <group targetFramework=".NETFramework4.0.3-Client">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
 
       <group targetFramework=".NETFramework4.5">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
 
       <!-- .NET Standard targets -->
       <group targetFramework=".NETStandard1.0">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0.0-0)" />
         <dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
         <dependency id="System.Linq" version="[4.3.0, )" />
         <dependency id="System.Text.RegularExpressions" version="[4.3.0, )" />
@@ -54,7 +54,7 @@
       </group>
 
       <group targetFramework=".NETStandard1.3">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0.0-0)" />
         <dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
         <dependency id="System.IO.FileSystem" version="[4.3.0, )" />
         <dependency id="System.Linq" version="[4.3.0, )" />
@@ -64,7 +64,7 @@
       </group>
 
       <group targetFramework=".NETStandard2.0">
-        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.CoordinateSystems" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
     </dependencies>
   </metadata>

--- a/NTS.Core.nuspec
+++ b/NTS.Core.nuspec
@@ -28,24 +28,24 @@
     <dependencies>
       <!-- traditional .NET framework targets -->
       <group targetFramework=".NETFramework3.5-Client">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
       </group>
 
       <group targetFramework=".NETFramework4.0-Client">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
       </group>
 
       <group targetFramework=".NETFramework4.0.3-Client">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
       </group>
 
       <group targetFramework=".NETFramework4.5">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
       </group>
 
       <!-- .NET Standard targets -->
       <group targetFramework=".NETStandard1.0">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
         <dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
         <dependency id="System.Linq" version="[4.3.0, )" />
         <dependency id="System.Text.RegularExpressions" version="[4.3.0, )" />
@@ -54,7 +54,7 @@
       </group>
 
       <group targetFramework=".NETStandard1.3">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
         <dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
         <dependency id="System.IO.FileSystem" version="[4.3.0, )" />
         <dependency id="System.Linq" version="[4.3.0, )" />
@@ -64,7 +64,7 @@
       </group>
 
       <group targetFramework=".NETStandard2.0">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, )" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/NTS.Core.nuspec
+++ b/NTS.Core.nuspec
@@ -28,24 +28,24 @@
     <dependencies>
       <!-- traditional .NET framework targets -->
       <group targetFramework=".NETFramework3.5-Client">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
 
       <group targetFramework=".NETFramework4.0-Client">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
 
       <group targetFramework=".NETFramework4.0.3-Client">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
 
       <group targetFramework=".NETFramework4.5">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
 
       <!-- .NET Standard targets -->
       <group targetFramework=".NETStandard1.0">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0.0-0)" />
         <dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
         <dependency id="System.Linq" version="[4.3.0, )" />
         <dependency id="System.Text.RegularExpressions" version="[4.3.0, )" />
@@ -54,7 +54,7 @@
       </group>
 
       <group targetFramework=".NETStandard1.3">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0.0-0)" />
         <dependency id="System.Diagnostics.Debug" version="[4.3.0, )" />
         <dependency id="System.IO.FileSystem" version="[4.3.0, )" />
         <dependency id="System.Linq" version="[4.3.0, )" />
@@ -64,7 +64,7 @@
       </group>
 
       <group targetFramework=".NETStandard2.0">
-        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0)" />
+        <dependency id="GeoAPI.Core" version="[$geoapiversion$, 2.0.0-0)" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This won't make NTS 1.x *completely* fail to work with GeoAPI 2.x, but it will ensure that someone doesn't *accidentally* restore GeoAPI 2.x, and it lets the system raise `NU1608` if they manually update anyway.
Fixes #283
Working around NuGet/Home#6434 by putting "2.0.0-0" instead of just a bare "2" or something.