### PR TITLE
Bring ordinate indexes more in-line with JTS.

### DIFF
--- a/NetTopologySuite.Samples.Console/Geometries/extendedcoordinate.cs
+++ b/NetTopologySuite.Samples.Console/Geometries/extendedcoordinate.cs
@@ -56,19 +56,19 @@ namespace NetTopologySuite.Samples.Geometries
         }
 
         /// <inheritdoc />
-        public override double this[Ordinate ordinateIndex]
+        public override double this[int ordinateIndex]
         {
             get
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         return X;
-                    case Ordinate.Y:
+                    case 1:
                         return Y;
-                    case Ordinate.Z:
+                    case 2:
                         return Z;
-                    case Ordinate.M:
+                    case 3:
                         return M;
                 }
                 throw new ArgumentOutOfRangeException(nameof(ordinateIndex));
@@ -77,16 +77,16 @@ namespace NetTopologySuite.Samples.Geometries
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         X = value;
                         return;
-                    case Ordinate.Y:
+                    case 1:
                         Y = value;
                         return;
-                    case Ordinate.Z:
+                    case 2:
                         Z = value;
                         return;
-                    case Ordinate.M:
+                    case 3:
                         M = value;
                         return;
                 }

--- a/NetTopologySuite.Samples.Console/Geometries/extendedcoordinatesequence.cs
+++ b/NetTopologySuite.Samples.Console/Geometries/extendedcoordinatesequence.cs
@@ -192,20 +192,20 @@ namespace NetTopologySuite.Samples.Geometries
         /// (for instance, they may contain other dimensions or measure values).
         /// </summary>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
         /// <returns></returns>
-        public double GetOrdinate(int index, Ordinate ordinate)
+        public double GetOrdinate(int index, int ordinateIndex)
         {
             var exc = (ExtendedCoordinate) _coordinates[index];
-            switch (ordinate)
+            switch (ordinateIndex)
             {
-                case Ordinate.X:
+                case 0:
                     return exc.X;
-                case Ordinate.Y:
+                case 1:
                     return exc.Y;
-                case Ordinate.Z:
+                case 2:
                     return exc.Z;
-                case Ordinate.M:
+                case 3:
                     return exc.M;
                 default:
                     return double.NaN;
@@ -216,23 +216,23 @@ namespace NetTopologySuite.Samples.Geometries
         /// Sets the value for a given ordinate of a coordinate in this sequence.
         /// </summary>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
         /// <param name="value">The new ordinate value.</param>
-        public void SetOrdinate(int index, Ordinate ordinate, double value)
+        public void SetOrdinate(int index, int ordinateIndex, double value)
         {
             var exc = (ExtendedCoordinate)_coordinates[index];
-            switch (ordinate)
+            switch (ordinateIndex)
             {
-                case Ordinate.X:
+                case 0:
                     exc.X = value;
                     break;
-                case Ordinate.Y:
+                case 1:
                     exc.Y = value;
                     break;
-                case Ordinate.Z:
+                case 2:
                     exc.Z = value;
                     break;
-                case Ordinate.M:
+                case 3:
                     exc.M = value;
                     break;
             }

--- a/NetTopologySuite.Tests.NUnit/Geometries/AdditionalCoordinateTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Geometries/AdditionalCoordinateTest.cs
@@ -9,8 +9,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
     // of those same tests in a different way, as well as doing a special test for the indexer.
     public abstract class CoordinateBaseTest<T> where T : Coordinate
     {
-        protected Ordinate? ZIndex = null;
-        protected Ordinate? MIndex = null;
+        protected int? ZIndex = null;
+        protected int? MIndex = null;
 
         protected abstract T CreateCoordinate2D(double x, double y);
         protected abstract T CreateCoordinate2DM(double x, double y, double m = double.NaN);
@@ -20,7 +20,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
         protected abstract T CreateCoordinate();
 
-        protected void CheckIndexer(T coordinate, Ordinate index, double value)
+        protected void CheckIndexer(T coordinate, int index, double value)
         {
             double val = double.NaN;
             if (IsIndexValid(ref index))
@@ -29,41 +29,41 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
                 Assert.Throws<ArgumentOutOfRangeException>(() => val = coordinate[index]);
         }
 
-        protected void CheckGetter(Ordinate index, double expected, double actual)
+        protected void CheckGetter(int index, double expected, double actual)
         {
             expected = CorrectExpected(index, expected);
             Assert.AreEqual(expected, actual);
         }
 
-        private double CorrectExpected(Ordinate index, double expected)
+        private double CorrectExpected(int index, double expected)
         {
             if (!IsIndexValid(ref index))
                 return GetDefault(index);
             return expected;
         }
 
-        private double GetDefault(Ordinate index)
+        private double GetDefault(int index)
         {
             return double.NaN;
         }
 
-        protected bool IsIndexValid(ref Ordinate ordinate)
+        protected bool IsIndexValid(ref int ordinate)
         {
             switch (ordinate)
             {
-                case Ordinate.X:
-                case Ordinate.Y:
+                case 0:
+                case 1:
                     return true;
 
-                case Ordinate.Z when ZIndex.HasValue:
+                case 2 when ZIndex.HasValue:
                     ordinate = ZIndex.Value;
                     return true;
 
-                case Ordinate.Z when MIndex == Ordinate.Z:
-                    ordinate = Ordinate.Ordinate4; // just pick something way out there
+                case 2 when MIndex == 2:
+                    ordinate = 4; // just pick something way out there
                     return false;
 
-                case Ordinate.M when MIndex.HasValue:
+                case 3 when MIndex.HasValue:
                     ordinate = MIndex.Value;
                     return true;
 
@@ -78,8 +78,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             T c = CreateCoordinate3D(350.2, 4566.8, 5266.3);
             Assert.AreEqual(350.2, c.X);
             Assert.AreEqual(4566.8, c.Y);
-            CheckGetter(Ordinate.Z, 5266.3, c.Z);
-            CheckGetter(Ordinate.M, Coordinate.NullOrdinate, c.M);
+            CheckGetter(2, 5266.3, c.Z);
+            CheckGetter(3, Coordinate.NullOrdinate, c.M);
         }
 
         [Test]
@@ -88,8 +88,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             T c = CreateCoordinate2D(350.2, 4566.8);
             Assert.AreEqual(350.2, c.X);
             Assert.AreEqual(4566.8, c.Y);
-            CheckGetter(Ordinate.Z, Coordinate.NullOrdinate, c.Z);
-            CheckGetter(Ordinate.M, Coordinate.NullOrdinate, c.M);
+            CheckGetter(2, Coordinate.NullOrdinate, c.Z);
+            CheckGetter(3, Coordinate.NullOrdinate, c.M);
         }
 
         [Test]
@@ -98,8 +98,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             T c = CreateCoordinate();
             Assert.AreEqual(0d, c.X);
             Assert.AreEqual(0d, c.Y);
-            CheckGetter(Ordinate.Z, Coordinate.NullOrdinate, c.Z);
-            CheckGetter(Ordinate.M, Coordinate.NullOrdinate, c.M);
+            CheckGetter(2, Coordinate.NullOrdinate, c.Z);
+            CheckGetter(3, Coordinate.NullOrdinate, c.M);
         }
 
         [Test]
@@ -109,8 +109,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             T c = CreateCoordinate(orig);
             Assert.AreEqual(350.2, c.X);
             Assert.AreEqual(4566.8, c.Y);
-            CheckGetter(Ordinate.Z, 5266.3, c.Z);
-            CheckGetter(Ordinate.M, Coordinate.NullOrdinate, c.M);
+            CheckGetter(2, 5266.3, c.Z);
+            CheckGetter(3, Coordinate.NullOrdinate, c.M);
         }
 
         [Test]
@@ -122,8 +122,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
             Assert.AreEqual(350.2, c.X);
             Assert.AreEqual(4566.8, c.Y);
-            CheckGetter(Ordinate.Z, 5266.3, c.Z);
-            CheckGetter(Ordinate.M, Coordinate.NullOrdinate, c.M);
+            CheckGetter(2, 5266.3, c.Z);
+            CheckGetter(3, Coordinate.NullOrdinate, c.M);
 
             Assert.That(ReferenceEquals(orig, c), Is.False);
         }
@@ -139,66 +139,66 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
             Assert.AreEqual(c.X, 350.2);
             Assert.AreEqual(c.Y, 4566.8);
-            CheckGetter(Ordinate.Z, 5266.3, c.Z);
-            CheckGetter(Ordinate.M, Coordinate.NullOrdinate, c.M);
+            CheckGetter(2, 5266.3, c.Z);
+            CheckGetter(3, Coordinate.NullOrdinate, c.M);
         }
 
         [Test]
         public void TestGetOrdinate2D()
         {
             T c = CreateCoordinate2D(350.2, 4566.8);
-            Assert.AreEqual(c[Ordinate.X], 350.2);
-            Assert.AreEqual(c[Ordinate.Y], 4566.8);
-            CheckIndexer(c, Ordinate.Z, double.NaN);
-            CheckIndexer(c, Ordinate.M, double.NaN);
+            Assert.AreEqual(c[0], 350.2);
+            Assert.AreEqual(c[1], 4566.8);
+            CheckIndexer(c, 2, double.NaN);
+            CheckIndexer(c, 3, double.NaN);
         }
 
         [Test]
         public void TestGetOrdinate3D()
         {
             T c = CreateCoordinate3D(350.2, 4566.8, 5266.3);
-            Assert.AreEqual(c[Ordinate.X], 350.2);
-            Assert.AreEqual(c[Ordinate.Y], 4566.8);
-            CheckIndexer(c, Ordinate.Z, 5266.3);
-            CheckIndexer(c, Ordinate.M, double.NaN);
+            Assert.AreEqual(c[0], 350.2);
+            Assert.AreEqual(c[1], 4566.8);
+            CheckIndexer(c, 2, 5266.3);
+            CheckIndexer(c, 3, double.NaN);
         }
 
         [Test]
         public void TestGetOrdinate3DM()
         {
             T c = CreateCoordinate3DM(350.2, 4566.8, 5266.3, 6226.4);
-            Assert.AreEqual(c[Ordinate.X], 350.2);
-            Assert.AreEqual(c[Ordinate.Y], 4566.8);
-            CheckIndexer(c, Ordinate.Z, 5266.3);
-            CheckIndexer(c, Ordinate.M, 6226.4);
+            Assert.AreEqual(c[0], 350.2);
+            Assert.AreEqual(c[1], 4566.8);
+            CheckIndexer(c, 2, 5266.3);
+            CheckIndexer(c, 3, 6226.4);
         }
 
         [Test]
         public void TestGetOrdinate2DM()
         {
             T c = CreateCoordinate2DM(350.2, 4566.8, 6226.4);
-            Assert.AreEqual(c[Ordinate.X], 350.2);
-            Assert.AreEqual(c[Ordinate.Y], 4566.8);
-            CheckIndexer(c, Ordinate.Z, double.NaN);
-            CheckIndexer(c, Ordinate.M, 6226.4);
+            Assert.AreEqual(c[0], 350.2);
+            Assert.AreEqual(c[1], 4566.8);
+            CheckIndexer(c, 2, double.NaN);
+            CheckIndexer(c, 3, 6226.4);
         }
 
         [Test]
         public void TestSetOrdinate()
         {
             T c = CreateCoordinate();
-            c[Ordinate.X] = 111;
-            c[Ordinate.Y] = 222;
+            c[0] = 111;
+            c[1] = 222;
             if (ZIndex.HasValue)
                 c[ZIndex.Value] = 333;
 
             if (MIndex.HasValue)
                 c[MIndex.Value] = 444;
 
-            Assert.AreEqual(c[Ordinate.X], 111.0);
-            Assert.AreEqual(c[Ordinate.Y], 222.0);
-            CheckIndexer(c, Ordinate.Z, 333d);
-            CheckIndexer(c, Ordinate.M, 444d);
+            Assert.AreEqual(c[0], 111.0);
+            Assert.AreEqual(c[1], 222.0);
+            CheckIndexer(c, 2, 333d);
+            CheckIndexer(c, 3, 444d);
         }
 
         [Test]
@@ -296,26 +296,24 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
             if (ZIndex.HasValue)
             {
-                Assert.DoesNotThrow(() => c[ZIndex.Value] = 3);
+                Assert.DoesNotThrow(() => c[Ordinate.Z] = 3);
                 Assert.AreEqual(3d, c.Z);
                 Assert.AreEqual(c.Z, c[ZIndex.Value]);
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => c[Ordinate.Z] = 3);
             }
 
             if (MIndex.HasValue)
             {
-                Assert.DoesNotThrow(() => c[MIndex.Value] = 4);
+                Assert.DoesNotThrow(() => c[Ordinate.M] = 4);
                 Assert.AreEqual(4d, c.M);
                 Assert.AreEqual(4d, c[MIndex.Value]);
             }
-
-            if (ZIndex != Ordinate.Ordinate2 && MIndex != Ordinate.Ordinate2)
+            else
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => c[Ordinate.Ordinate2] = 3);
-            }
-
-            if (ZIndex != Ordinate.Ordinate3 && MIndex != Ordinate.Ordinate3)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => c[Ordinate.Ordinate3] = 4);
+                Assert.Throws<InvalidOperationException>(() => c[Ordinate.M] = 4);
             }
         }
     }
@@ -372,7 +370,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         public CoordinateMTest()
         {
             ZIndex = null;
-            MIndex = Ordinate.Ordinate2;
+            MIndex = 2;
         }
         protected override CoordinateM CreateCoordinate2D(double x, double y)
         {
@@ -415,7 +413,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
     {
         public CoordinateZTest()
         {
-            ZIndex = Ordinate.Ordinate2;
+            ZIndex = 2;
             MIndex = null;
         }
 
@@ -491,8 +489,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
     {
         public CoordinateZMTest()
         {
-            ZIndex = Ordinate.Ordinate2;
-            MIndex = Ordinate.Ordinate3;
+            ZIndex = 2;
+            MIndex = 3;
         }
 
         protected override CoordinateZM CreateCoordinate2D(double x, double y)

--- a/NetTopologySuite.Tests.NUnit/Geometries/CoordinateTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Geometries/CoordinateTest.cs
@@ -191,7 +191,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             Assert.AreEqual(3d, c.Z);
             Assert.AreEqual(c.Z, c[Ordinate.Z]);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => c[Ordinate.M] = 4);
+            Assert.Throws<InvalidOperationException>(() => c[Ordinate.M] = 4);
         }
 
         [Test]

--- a/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateArraySequenceTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateArraySequenceTest.cs
@@ -163,7 +163,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
             {
                 for (int ordinateIndex = 0; ordinateIndex < seq.Dimension; ordinateIndex++)
                 {
-                    seq.SetOrdinate(index, (Ordinate)ordinateIndex, index);
+                    seq.SetOrdinate(index, ordinateIndex, index);
                 }
             }
         }

--- a/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateSequenceTestBase.cs
+++ b/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateSequenceTestBase.cs
@@ -90,6 +90,51 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
             Assert.IsTrue(IsEqual(seq2, coords));
         }
 
+        [TestCase(2, 0)] // XY
+        [TestCase(3, 0)] // XYZ
+        [TestCase(3, 1)] // XYM
+        [TestCase(4, 1)] // XYZM
+        public void NamedAndOrdinateGettersShouldBeConsistent(int dimension, int measures)
+        {
+            var seq = CsFactory.Create(1, dimension, measures);
+            for (int dim = 0; dim < dimension; dim++)
+            {
+                seq.SetOrdinate(0, dim, 10 + dim);
+            }
+
+            // we just set all the ordinate values to 10 plus their index.
+            double expectedX = 10;
+            double expectedY = 11;
+            double expectedZ = seq.HasZ ? 12 : Coordinate.NullOrdinate;
+            double expectedM = seq.HasM ? seq.HasZ ? 13 : 12 : Coordinate.NullOrdinate;
+
+            var c = seq.GetCoordinate(0);
+
+            // X
+            Assert.That(seq.GetX(0), Is.EqualTo(expectedX));
+            Assert.That(seq.GetOrdinate(0, Ordinate.X), Is.EqualTo(expectedX));
+            Assert.That(c.X, Is.EqualTo(expectedX));
+            Assert.That(c[Ordinate.X], Is.EqualTo(expectedX));
+
+            // Y
+            Assert.That(seq.GetY(0), Is.EqualTo(expectedY));
+            Assert.That(seq.GetOrdinate(0, Ordinate.Y), Is.EqualTo(expectedY));
+            Assert.That(c.Y, Is.EqualTo(expectedY));
+            Assert.That(c[Ordinate.Y], Is.EqualTo(expectedY));
+
+            // Z
+            Assert.That(seq.GetZ(0), Is.EqualTo(expectedZ));
+            Assert.That(seq.GetOrdinate(0, Ordinate.Z), Is.EqualTo(expectedZ));
+            Assert.That(c.Z, Is.EqualTo(expectedZ));
+            Assert.That(c[Ordinate.Z], Is.EqualTo(expectedZ));
+
+            // M
+            Assert.That(seq.GetM(0), Is.EqualTo(expectedM));
+            Assert.That(seq.GetOrdinate(0, Ordinate.M), Is.EqualTo(expectedM));
+            Assert.That(c.M, Is.EqualTo(expectedM));
+            Assert.That(c[Ordinate.M], Is.EqualTo(expectedM));
+        }
+
         // TODO: This private method was marked as protected to allow PackedCoordinateSequenceTest to override Test2DZOrdinate
         // The method should not be marked as protected, and should be altered when the correct PackedCoordinateSequence.GetCoordinate result is migrated to NTS
         protected Coordinate[] CreateArray(int size)
@@ -110,9 +155,9 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
                 if (!coord.Equals(seq.GetCoordinate(i)))
                     return false;
 
-                if (coord.X != seq.GetOrdinate(i, Ordinate.X))
+                if (coord.X != seq.GetOrdinate(i, 0))
                     return false;
-                if (coord.Y != seq.GetOrdinate(i, Ordinate.Y))
+                if (coord.Y != seq.GetOrdinate(i, 1))
                     return false;
                 if (seq.HasZ)
                 {
@@ -126,12 +171,12 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
                 }
                 if (seq.Dimension > 2)
                 {
-                    if (coord[Ordinate.Ordinate2] != seq.GetOrdinate(i, Ordinate.Ordinate2))
+                    if (coord[2] != seq.GetOrdinate(i, 2))
                         return false;
                 }
                 if (seq.Dimension > 3)
                 {
-                    if (coord[Ordinate.Ordinate3] != seq.GetOrdinate(i, Ordinate.Ordinate3))
+                    if (coord[3] != seq.GetOrdinate(i, 3))
                         return false;
                 }
             }
@@ -175,18 +220,18 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
                 }
 
                 // Ordinate indexed getters
-                if (!coords[i].X.Equals(seq.GetOrdinate(i, Ordinate.X)))
+                if (!coords[i].X.Equals(seq.GetOrdinate(i, 0)))
                     return false;
-                if (!coords[i].Y.Equals(seq.GetOrdinate(i, Ordinate.Y)))
+                if (!coords[i].Y.Equals(seq.GetOrdinate(i, 1)))
                     return false;
                 if (seq.Dimension > 2)
                 {
-                    if (!coords[i][Ordinate.Ordinate2].Equals(seq.GetOrdinate(i, Ordinate.Ordinate2)))
+                    if (!coords[i][2].Equals(seq.GetOrdinate(i, 2)))
                         return false;
                 }
                 if (seq.Dimension > 3)
                 {
-                    if (!coords[i][Ordinate.Ordinate3].Equals(seq.GetOrdinate(i, Ordinate.Ordinate3)))
+                    if (!coords[i][3].Equals(seq.GetOrdinate(i, 3)))
                         return false;
                 }
 

--- a/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceTest.cs
+++ b/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceTest.cs
@@ -121,7 +121,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
             {
                 for (int ordinateIndex = 0; ordinateIndex < seq.Dimension; ordinateIndex++)
                 {
-                    seq.SetOrdinate(index, (Ordinate)ordinateIndex, index);
+                    seq.SetOrdinate(index, ordinateIndex, index);
                 }
             }
         }

--- a/NetTopologySuite.Tests.NUnit/GeometryTestCase.cs
+++ b/NetTopologySuite.Tests.NUnit/GeometryTestCase.cs
@@ -251,8 +251,8 @@ namespace NetTopologySuite.Tests.NUnit
             {
                 for (int j = 0; j < dimension; j++)
                 {
-                    double val1 = seq1.GetOrdinate(i, (Ordinate)j);
-                    double val2 = seq2.GetOrdinate(i, (Ordinate)j);
+                    double val1 = seq1.GetOrdinate(i, j);
+                    double val2 = seq2.GetOrdinate(i, j);
                     if (double.IsNaN(val1))
                     {
                         if (!double.IsNaN(val2))

--- a/NetTopologySuite.Tests.NUnit/IO/WKBTest.cs
+++ b/NetTopologySuite.Tests.NUnit/IO/WKBTest.cs
@@ -289,7 +289,7 @@ namespace NetTopologySuite.Tests.NUnit.IO
     {
         public void Filter(Coordinate coord)
         {
-            coord[Ordinate.Ordinate2] = (coord.X + coord.Y) / 2;
+            coord[2] = (coord.X + coord.Y) / 2;
         }
     }
 

--- a/NetTopologySuite.Tests.NUnit/IO/WKTReaderTest.cs
+++ b/NetTopologySuite.Tests.NUnit/IO/WKTReaderTest.cs
@@ -482,7 +482,7 @@ namespace NetTopologySuite.Tests.NUnit.IO
             {
                 for (int j = 0; j < dimension; j++)
                 {
-                    res.SetOrdinate(k, (Ordinate)j, ordinateValues[i + j]);
+                    res.SetOrdinate(k, j, ordinateValues[i + j]);
                 }
 
                 k++;

--- a/NetTopologySuite/Geometries/Coordinate.cs
+++ b/NetTopologySuite/Geometries/Coordinate.cs
@@ -19,7 +19,7 @@ namespace NetTopologySuite.Geometries
     /// <para/>
     /// Implementations may optionally support Z-ordinate and M-measure values
     /// as appropriate for a <see cref="ICoordinateSequence"/>. Use of <see cref="Z"/>
-    /// and <see cref="M"/> setters or <see cref="P:NetTopologySuite.Geometries.Coordinate.this[Ordinate]" /> indexer are recommended.
+    /// and <see cref="M"/> setters or <see cref="P:NetTopologySuite.Geometries.Coordinate.this[int]" /> indexer are recommended.
     /// </remarks>
     [Serializable]
 #pragma warning disable 612,618
@@ -94,23 +94,78 @@ namespace NetTopologySuite.Geometries
         public Coordinate(Coordinate c) : this(c.X, c.Y) { }
 
         /// <summary>
+        /// Gets or sets the value for the given ordinate.
+        /// </summary>
+        /// <param name="ordinate">The ordinate.</param>
+        /// <returns>The ordinate value</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="ordinate"/> is not one of <see cref="Ordinate.X"/>, <see cref="Ordinate.Y"/>, <see cref="Ordinate.Z"/>, or <see cref="Ordinate.M"/>.</exception>
+        public double this[Ordinate ordinate]
+        {
+            get
+            {
+                switch (ordinate)
+                {
+                    case Ordinate.X:
+                        return X;
+
+                    case Ordinate.Y:
+                        return Y;
+
+                    case Ordinate.Z:
+                        return Z;
+
+                    case Ordinate.M:
+                        return M;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(ordinate), ordinate, "Coordinate instances only recognize X, Y, Z, and M ordinates.");
+                }
+            }
+
+            set
+            {
+                switch (ordinate)
+                {
+                    case Ordinate.X:
+                        X = value;
+                        break;
+
+                    case Ordinate.Y:
+                        Y = value;
+                        break;
+
+                    case Ordinate.Z:
+                        Z = value;
+                        break;
+
+                    case Ordinate.M:
+                        M = value;
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(ordinate), ordinate, "Coordinate instances only recognize X, Y, Z, and M ordinates.");
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the ordinate value for the given index.
         /// </summary>
         /// <remarks>
-        /// The base implementation supports <see cref="Ordinate.X"/> and <see cref="Ordinate.Y"/> as values for the index.
+        /// The base implementation supports 0 (X) and 1 (Y) as values for the index.
         /// </remarks>
         /// <param name="ordinateIndex">The ordinate index</param>
         /// <returns>The ordinate value</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="ordinateIndex"/> is not in the valid range.</exception>
-        public virtual double this[Ordinate ordinateIndex]
+        public virtual double this[int ordinateIndex]
         {
             get
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         return X;
-                    case Ordinate.Y:
+                    case 1:
                         return Y;
                 }
                 throw new ArgumentOutOfRangeException(nameof(ordinateIndex));
@@ -119,10 +174,10 @@ namespace NetTopologySuite.Geometries
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         X = value;
                         return;
-                    case Ordinate.Y:
+                    case 1:
                         Y = value;
                         return;
                 }

--- a/NetTopologySuite/Geometries/CoordinateM.cs
+++ b/NetTopologySuite/Geometries/CoordinateM.cs
@@ -27,7 +27,7 @@ namespace NetTopologySuite.Geometries
     /// <para/>
     /// Implementations may optionally support Z-ordinate and M-measure values
     /// as appropriate for a <see cref="ICoordinateSequence"/>. Use of <see cref="CoordinateZ.Z"/>
-    /// and <see cref="M"/> setters or <see cref="P:NetTopologySuite.Geometries.CoordinateM.this[Ordinate]" /> indexer are recommended.
+    /// and <see cref="M"/> setters or <see cref="P:NetTopologySuite.Geometries.CoordinateM.this[int]" /> indexer are recommended.
     /// </remarks>
     [Serializable]
 #pragma warning disable 612,618
@@ -70,33 +70,24 @@ namespace NetTopologySuite.Geometries
 
         /// <summary>
         /// Gets or sets the ordinate value for the given index.
-        /// <para>
-        /// Do not use <see cref="Ordinate.M"/> to try to get or set the value of <see cref="M"/>.
-        /// Use <see cref="Ordinate.Ordinate2"/> instead.
-        /// </para>
-        /// <para>
-        /// <see cref="Ordinate.M"/> is the "standard" name of <see cref="Ordinate.Ordinate3"/> in
-        /// the XYZM space.  Since this does not have Z, the "standard" names of everything after it
-        /// (i.e., M) shift down by 1.
-        /// </para>
         /// </summary>
         /// <remarks>
-        /// The base implementation supports <see cref="Ordinate.X"/>, <see cref="Ordinate.Y"/> and <see cref="Ordinate.Ordinate2"/> as values for the index.
+        /// The base implementation supports 0 (X), 1 (Y) and 2 (M) as values for the index.
         /// </remarks>
         /// <param name="ordinateIndex">The ordinate index</param>
         /// <returns>The ordinate value</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="ordinateIndex"/> is not in the valid range.</exception>
-        public override double this[Ordinate ordinateIndex]
+        public override double this[int ordinateIndex]
         {
             get
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         return X;
-                    case Ordinate.Y:
+                    case 1:
                         return Y;
-                    case Ordinate.Ordinate2:
+                    case 2:
                         return M;
                 }
                 throw new ArgumentOutOfRangeException(nameof(ordinateIndex));
@@ -105,13 +96,13 @@ namespace NetTopologySuite.Geometries
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         X = value;
                         return;
-                    case Ordinate.Y:
+                    case 1:
                         Y = value;
                         return;
-                    case Ordinate.Ordinate2:
+                    case 2:
                         M = value;
                         return;
                 }

--- a/NetTopologySuite/Geometries/CoordinateSequenceComparator.cs
+++ b/NetTopologySuite/Geometries/CoordinateSequenceComparator.cs
@@ -85,8 +85,8 @@ namespace NetTopologySuite.Geometries
         {
             for (int d = 0; d < dimension; d++)
             {
-                double ord1 = s1.GetOrdinate(i, (Ordinate)d);
-                double ord2 = s2.GetOrdinate(i, (Ordinate)d);
+                double ord1 = s1.GetOrdinate(i, d);
+                double ord2 = s2.GetOrdinate(i, d);
                 int comp = Compare(ord1, ord2);
                 if (comp != 0) return comp;
             }

--- a/NetTopologySuite/Geometries/CoordinateSequences.cs
+++ b/NetTopologySuite/Geometries/CoordinateSequences.cs
@@ -33,9 +33,9 @@ namespace NetTopologySuite.Geometries
 
             for (int dim = 0; dim < seq.Dimension; dim++)
             {
-                double tmp = seq.GetOrdinate(i, (Ordinate)dim);
-                seq.SetOrdinate(i, (Ordinate)dim, seq.GetOrdinate(j, (Ordinate)dim));
-                seq.SetOrdinate(j, (Ordinate)dim, tmp);
+                double tmp = seq.GetOrdinate(i, dim);
+                seq.SetOrdinate(i, dim, seq.GetOrdinate(j, dim));
+                seq.SetOrdinate(j, dim, tmp);
             }
         }
 
@@ -69,9 +69,8 @@ namespace NetTopologySuite.Geometries
             int minDim = Math.Min(src.Dimension, dest.Dimension);
             for (int dim = 0; dim < minDim; dim++)
             {
-                var ordinate = (Ordinate)dim;
-                double value = src.GetOrdinate(srcPos, ordinate);
-                dest.SetOrdinate(destPos, ordinate, value);
+                double value = src.GetOrdinate(srcPos, dim);
+                dest.SetOrdinate(destPos, dim, value);
             }
         }
 
@@ -92,8 +91,8 @@ namespace NetTopologySuite.Geometries
             if (n <= 3)
                 return false;
             // test if closed
-            return seq.GetOrdinate(0, Ordinate.X) == seq.GetOrdinate(n - 1, Ordinate.X)
-                && seq.GetOrdinate(0, Ordinate.Y) == seq.GetOrdinate(n - 1, Ordinate.Y);
+            return seq.GetOrdinate(0, 0) == seq.GetOrdinate(n - 1, 0)
+                && seq.GetOrdinate(0, 1) == seq.GetOrdinate(n - 1, 1);
         }
 
         /// <summary>
@@ -116,8 +115,8 @@ namespace NetTopologySuite.Geometries
             if (n <= 3)
                 return CreateClosedRing(fact, seq, 4);
 
-            bool isClosed = seq.GetOrdinate(0, Ordinate.X) == seq.GetOrdinate(n - 1, Ordinate.X) &&
-                           seq.GetOrdinate(0, Ordinate.Y) == seq.GetOrdinate(n - 1, Ordinate.Y);
+            bool isClosed = seq.GetOrdinate(0, 0) == seq.GetOrdinate(n - 1, 0) &&
+                           seq.GetOrdinate(0, 1) == seq.GetOrdinate(n - 1, 1);
             if (isClosed) return seq;
             // make a new closed ring
             return CreateClosedRing(fact, seq, n + 1);
@@ -170,10 +169,9 @@ namespace NetTopologySuite.Geometries
             {
                 for (int d = 0; d < dim; d++)
                 {
-                    var ordinate = (Ordinate)d;
-                    double v1 = cs1.GetOrdinate(i, ordinate);
-                    double v2 = cs2.GetOrdinate(i, ordinate);
-                    if (cs1.GetOrdinate(i, ordinate) == cs2.GetOrdinate(i, ordinate))
+                    double v1 = cs1.GetOrdinate(i, d);
+                    double v2 = cs2.GetOrdinate(i, d);
+                    if (cs1.GetOrdinate(i, d) == cs2.GetOrdinate(i, d))
                         continue;
                     // special check for NaNs
                     if (double.IsNaN(v1) && double.IsNaN(v2))
@@ -207,7 +205,7 @@ namespace NetTopologySuite.Geometries
                 for (int d = 0; d < dim; d++)
                 {
                     if (d > 0) sb.Append(",");
-                    double ordinate = cs.GetOrdinate(i, (Ordinate)d);
+                    double ordinate = cs.GetOrdinate(i, d);
                     sb.Append(string.Format("{0:0.#}", ordinate));
                 }
             }
@@ -318,14 +316,14 @@ namespace NetTopologySuite.Geometries
             for (int j = 0; j < last; j++)
             {
                 for (int k = 0; k < seq.Dimension; k++)
-                    seq.SetOrdinate(j, (Ordinate)k, copy.GetOrdinate((indexOfFirstCoordinate + j) % last, (Ordinate)k));
+                    seq.SetOrdinate(j, k, copy.GetOrdinate((indexOfFirstCoordinate + j) % last, k));
             }
 
             // Fix the ring (first == last)
             if (ensureRing)
             {
                 for (int k = 0; k < seq.Dimension; k++)
-                    seq.SetOrdinate(last, (Ordinate)k, seq.GetOrdinate(0, (Ordinate)k));
+                    seq.SetOrdinate(last, k, seq.GetOrdinate(0, k));
             }
         }
 
@@ -342,8 +340,8 @@ namespace NetTopologySuite.Geometries
         {
             for (int i = 0; i < seq.Count; i++)
             {
-                if (coordinate.X == seq.GetOrdinate(i, Ordinate.X) &&
-                    coordinate.Y == seq.GetOrdinate(i, Ordinate.Y))
+                if (coordinate.X == seq.GetOrdinate(i, 0) &&
+                    coordinate.Y == seq.GetOrdinate(i, 1))
                 {
                     return i;
                 }

--- a/NetTopologySuite/Geometries/CoordinateZ.cs
+++ b/NetTopologySuite/Geometries/CoordinateZ.cs
@@ -27,7 +27,7 @@ namespace NetTopologySuite.Geometries
     /// <para/>
     /// Implementations may optionally support Z-ordinate and M-measure values
     /// as appropriate for a <see cref="ICoordinateSequence"/>. Use of <see cref="Z"/>
-    /// and <see cref="Coordinate.M"/> setters or <see cref="P:NetTopologySuite.Geometries.CoordinateZ.this[Ordinate]" /> indexer are recommended.
+    /// and <see cref="Coordinate.M"/> setters or <see cref="P:NetTopologySuite.Geometries.CoordinateZ.this[int]" /> indexer are recommended.
     /// </remarks>
     [Serializable]
 #pragma warning disable 612,618
@@ -72,22 +72,22 @@ namespace NetTopologySuite.Geometries
         /// Gets or sets the ordinate value for the given index.
         /// </summary>
         /// <remarks>
-        /// The base implementation supports  <see cref="Ordinate.X"/>, <see cref="Ordinate.Y"/> and <see cref="Ordinate.Z"/> as values for the index.
+        /// The base implementation supports 0 (X), 1 (Y) and 2 (Z) as values for the index.
         /// </remarks>
         /// <param name="ordinateIndex">The ordinate index</param>
         /// <returns>The ordinate value</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="ordinateIndex"/> is not in the valid range.</exception>
-        public override double this[Ordinate ordinateIndex]
+        public override double this[int ordinateIndex]
         {
             get
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         return X;
-                    case Ordinate.Y:
+                    case 1:
                         return Y;
-                    case Ordinate.Z:
+                    case 2:
                         return Z;
                 }
                 throw new ArgumentOutOfRangeException(nameof(ordinateIndex));
@@ -96,13 +96,13 @@ namespace NetTopologySuite.Geometries
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         X = value;
                         return;
-                    case Ordinate.Y:
+                    case 1:
                         Y = value;
                         return;
-                    case Ordinate.Z:
+                    case 2:
                         Z = value;
                         return;
                 }

--- a/NetTopologySuite/Geometries/CoordinateZM.cs
+++ b/NetTopologySuite/Geometries/CoordinateZM.cs
@@ -28,7 +28,7 @@ namespace NetTopologySuite.Geometries
     /// <para/>
     /// Implementations may optionally support Z-ordinate and M-measure values
     /// as appropriate for a <see cref="ICoordinateSequence"/>. Use of <see cref="CoordinateZ.Z"/>
-    /// and <see cref="M"/> setters or <see cref="P:NetTopologySuite.Geometries.CoordinateZM.this[Ordinate]" /> indexer are recommended.
+    /// and <see cref="M"/> setters or <see cref="P:NetTopologySuite.Geometries.CoordinateZM.this[int]" /> indexer are recommended.
     /// </remarks>
     [Serializable]
 #pragma warning disable 612,618
@@ -75,24 +75,24 @@ namespace NetTopologySuite.Geometries
         /// Gets or sets the ordinate value for the given index.
         /// </summary>
         /// <remarks>
-        /// The base implementation supports  <see cref="Ordinate.X"/>, <see cref="Ordinate.Y"/> and <see cref="Ordinate.Z"/> as values for the index.
+        /// The base implementation supports 0 (X), 1 (Y) and 2 (Z) as values for the index.
         /// </remarks>
         /// <param name="ordinateIndex">The ordinate index</param>
         /// <returns>The ordinate value</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="ordinateIndex"/> is not in the valid range.</exception>
-        public override double this[Ordinate ordinateIndex]
+        public override double this[int ordinateIndex]
         {
             get
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         return X;
-                    case Ordinate.Y:
+                    case 1:
                         return Y;
-                    case Ordinate.Z:
+                    case 2:
                         return Z;
-                    case Ordinate.M:
+                    case 3:
                         return M;
                 }
                 throw new ArgumentOutOfRangeException(nameof(ordinateIndex));
@@ -101,16 +101,16 @@ namespace NetTopologySuite.Geometries
             {
                 switch (ordinateIndex)
                 {
-                    case Ordinate.X:
+                    case 0:
                         X = value;
                         return;
-                    case Ordinate.Y:
+                    case 1:
                         Y = value;
                         return;
-                    case Ordinate.Z:
+                    case 2:
                         Z = value;
                         return;
-                    case Ordinate.M:
+                    case 3:
                         M = value;
                         return;
                 }

--- a/NetTopologySuite/Geometries/Geometry.cs
+++ b/NetTopologySuite/Geometries/Geometry.cs
@@ -2087,8 +2087,17 @@ namespace NetTopologySuite.Geometries
         protected static double[] CreateArray(ICoordinateSequence sequence, Ordinate ordinate)
         {
             double[] result = new double[sequence.Count];
-            for (int i = 0; i < result.Length; i++)
-                result[i] = sequence.GetOrdinate(i, ordinate);
+            if (OrdinatesUtility.IndexOfOrdinateInSequence(ordinate, sequence) is int ordinateIndex)
+            {
+                for (int i = 0; i < result.Length; i++)
+                    result[i] = sequence.GetOrdinate(i, ordinateIndex);
+            }
+            else
+            {
+                for (int i = 0; i < result.Length; i++)
+                    result[i] = Coordinate.NullOrdinate;
+            }
+
             return result;
         }
 

--- a/NetTopologySuite/Geometries/ICoordinateSequence.cs
+++ b/NetTopologySuite/Geometries/ICoordinateSequence.cs
@@ -199,9 +199,9 @@ namespace NetTopologySuite.Geometries
         /// If the sequence does not provide value for the required ordinate, the implementation <b>must not</b> throw an exception, it should return <see cref="Coordinate.NullOrdinate"/>.
         /// </remarks>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
-        /// <returns>The ordinate value, or <see cref="Coordinate.NullOrdinate"/> if the sequence does not provide values for <paramref name="ordinate"/>"/></returns>       
-        double GetOrdinate(int index, Ordinate ordinate);
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <returns>The ordinate value, or <see cref="Coordinate.NullOrdinate"/> if the sequence does not provide values for <paramref name="ordinateIndex"/>"/></returns>       
+        double GetOrdinate(int index, int ordinateIndex);
 
         /// <summary>
         /// Gets a value indicating the number of coordinates in this sequence.
@@ -215,9 +215,9 @@ namespace NetTopologySuite.Geometries
         /// If the sequence can't store the ordinate value, the implementation <b>must not</b> throw an exception, it should simply ignore the call.
         /// </remarks>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
         /// <param name="value">The new ordinate value.</param>       
-        void SetOrdinate(int index, Ordinate ordinate, double value);
+        void SetOrdinate(int index, int ordinateIndex, double value);
 
         /// <summary>
         /// Returns (possibly copies of) the Coordinates in this collection.

--- a/NetTopologySuite/Geometries/Implementation/CoordinateArraySequence.cs
+++ b/NetTopologySuite/Geometries/Implementation/CoordinateArraySequence.cs
@@ -300,18 +300,18 @@ namespace NetTopologySuite.Geometries.Implementation
         /// (for instance, they may contain other dimensions or measure values).
         /// </summary>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
         /// <returns></returns>
-        public double GetOrdinate(int index, Ordinate ordinate)
+        public double GetOrdinate(int index, int ordinateIndex)
         {
-            switch (ordinate)
+            switch (ordinateIndex)
             {
-                case Ordinate.X:
+                case 0:
                     return Coordinates[index].X;
-                case Ordinate.Y:
+                case 1:
                     return Coordinates[index].Y;
                 default:
-                    return Coordinates[index][ordinate];
+                    return Coordinates[index][ordinateIndex];
             }
         }
 
@@ -350,20 +350,20 @@ namespace NetTopologySuite.Geometries.Implementation
         /// Sets the value for a given ordinate of a coordinate in this sequence.
         /// </summary>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
         /// <param name="value">The new ordinate value.</param>
-        public void SetOrdinate(int index, Ordinate ordinate, double value)
+        public void SetOrdinate(int index, int ordinateIndex, double value)
         {
-            switch (ordinate)
+            switch (ordinateIndex)
             {
-                case Ordinate.X:
+                case 0:
                     Coordinates[index].X = value;
                     break;
-                case Ordinate.Y:
+                case 1:
                     Coordinates[index].Y = value;
                     break;
                 default:
-                    Coordinates[index][ordinate] = value;
+                    Coordinates[index][ordinateIndex] = value;
                     break;
             }
         }

--- a/NetTopologySuite/Geometries/Implementation/DotSpatialAffineCoordinateSequence.cs
+++ b/NetTopologySuite/Geometries/Implementation/DotSpatialAffineCoordinateSequence.cs
@@ -149,8 +149,8 @@ namespace NetTopologySuite.Geometries.Implementation
             {
                 _xy[j++] = coordSeq.GetX(i);
                 _xy[j++] = coordSeq.GetY(i);
-                if (_z != null) _z[i] = coordSeq.GetOrdinate(i, Ordinate.Z);
-                if (_m != null) _m[i] = coordSeq.GetOrdinate(i, Ordinate.M);
+                if (_z != null) _z[i] = coordSeq.GetZ(i);
+                if (_m != null) _m[i] = coordSeq.GetM(i);
             }
         }
 
@@ -251,39 +251,39 @@ namespace NetTopologySuite.Geometries.Implementation
             return _m?[index] ?? Coordinate.NullOrdinate;
         }
 
-        public double GetOrdinate(int index, Ordinate ordinate)
+        public double GetOrdinate(int index, int ordinateIndex)
         {
-            switch (ordinate)
+            switch (ordinateIndex)
             {
-                case Ordinate.X:
+                case 0:
                     return _xy[index * 2];
-                case Ordinate.Y:
+                case 1:
                     return _xy[index * 2 + 1];
-                case Ordinate.Ordinate2 when HasZ:
+                case 2 when HasZ:
                     return _z[index];
-                case Ordinate.Ordinate2:
-                case Ordinate.M:
+                case 2:
+                case 3:
                     return _m?[index] ?? Coordinate.NullOrdinate;
                 default:
                     throw new NotSupportedException();
             }
         }
 
-        public void SetOrdinate(int index, Ordinate ordinate, double value)
+        public void SetOrdinate(int index, int ordinateIndex, double value)
         {
-            switch (ordinate)
+            switch (ordinateIndex)
             {
-                case Ordinate.X:
+                case 0:
                     _xy[index * 2] = value;
                     break;
-                case Ordinate.Y:
+                case 1:
                     _xy[index * 2 + 1] = value;
                     break;
-                case Ordinate.Ordinate2 when HasZ:
+                case 2 when HasZ:
                     if (_z != null) _z[index] = value;
                     break;
-                case Ordinate.Ordinate2:
-                case Ordinate.M:
+                case 2:
+                case 3:
                     if (_m != null) _m[index] = value;
                     break;
                 default:

--- a/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
+++ b/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
@@ -155,8 +155,8 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <param name="c">A Coordinate to receive the value.</param>
         public void GetCoordinate(int i, Coordinate c)
         {
-            c.X = GetOrdinate(i, Ordinate.X);
-            c.Y = GetOrdinate(i, Ordinate.Y);
+            c.X = GetOrdinate(i, 0);
+            c.Y = GetOrdinate(i, 1);
             if (HasZ)
             {
                 c.Z = GetZ(i);
@@ -220,7 +220,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </returns>
         public double GetX(int index)
         {
-            return GetOrdinate(index, Ordinate.X);
+            return GetOrdinate(index, 0);
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </returns>
         public double GetY(int index)
         {
-            return GetOrdinate(index, Ordinate.Y);
+            return GetOrdinate(index, 1);
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace NetTopologySuite.Geometries.Implementation
         {
             if (HasZ)
             {
-                return GetOrdinate(index, Ordinate.Z);
+                return GetOrdinate(index, 2);
             }
             else
             {
@@ -266,7 +266,7 @@ namespace NetTopologySuite.Geometries.Implementation
             if (HasM)
             {
                 int mIndex = Dimension - Measures;
-                return GetOrdinate(index, (Ordinate)mIndex);
+                return GetOrdinate(index, mIndex);
             }
             else
             {
@@ -282,9 +282,9 @@ namespace NetTopologySuite.Geometries.Implementation
         /// values as described by <see cref="Dimension"/> and <see cref="Measures"/>).
         /// </summary>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
         /// <returns></returns>
-        public abstract double GetOrdinate(int index, Ordinate ordinate);
+        public abstract double GetOrdinate(int index, int ordinateIndex);
 
         /// <summary>
         /// Sets the first ordinate of a coordinate in this sequence.
@@ -294,7 +294,7 @@ namespace NetTopologySuite.Geometries.Implementation
         public void SetX(int index, double value)
         {
             CoordRef = null;
-            SetOrdinate(index, Ordinate.X, value);
+            SetOrdinate(index, 0, value);
         }
 
         /// <summary>
@@ -305,21 +305,21 @@ namespace NetTopologySuite.Geometries.Implementation
         public void SetY(int index, double value)
         {
             CoordRef = null;
-            SetOrdinate(index, Ordinate.Y, value);
+            SetOrdinate(index, 1, value);
         }
 
         /// <summary>
         /// Sets the ordinate of a coordinate in this sequence.
         /// </summary>
         /// <param name="index">The coordinate index.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate, 0 based,
+        /// <param name="ordinateIndex">The ordinate index in the coordinate, 0 based,
         /// smaller than the number of dimensions.</param>
         /// <param name="value">The new ordinate value.</param>
         /// <remarks>
         /// Warning: for performance reasons the ordinate index is not checked.
         /// If it is larger than the dimension a meaningless value may be returned.
         /// </remarks>
-        public abstract void SetOrdinate(int index, Ordinate ordinate, double value);
+        public abstract void SetOrdinate(int index, int ordinateIndex, double value);
 
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString()
@@ -424,9 +424,9 @@ namespace NetTopologySuite.Geometries.Implementation
                 if (Dimension >= 2)
                     _coords[i * Dimension + 1] = coordinates[i].Y;
                 if (Dimension >= 3)
-                    _coords[i * Dimension + 2] = coordinates[i][Ordinate.Ordinate2]; // Z or M
+                    _coords[i * Dimension + 2] = coordinates[i][2]; // Z or M
                 if (Dimension >= 4)
-                    _coords[i * Dimension + 3] = coordinates[i][Ordinate.M]; // M
+                    _coords[i * Dimension + 3] = coordinates[i][3]; // M
             }
         }
 
@@ -518,28 +518,28 @@ namespace NetTopologySuite.Geometries.Implementation
         /// value.
         /// </remarks>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
         /// <returns></returns>
-        public override double GetOrdinate(int index, Ordinate ordinate)
+        public override double GetOrdinate(int index, int ordinateIndex)
         {
-            return _coords[index * Dimension + (int) ordinate];
+            return _coords[index * Dimension + ordinateIndex];
         }
 
         /// <summary>
         /// Sets the ordinate of a coordinate in this sequence.
         /// </summary>
         /// <param name="index">The coordinate index.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate, 0 based,
+        /// <param name="ordinateIndex">The ordinate index in the coordinate, 0 based,
         /// smaller than the number of dimensions.</param>
         /// <param name="value">The new ordinate value.</param>
         /// <remarks>
         /// Warning: for performance reasons the ordinate index is not checked.
         /// If it is larger than the dimension a meaningless value may be returned.
         /// </remarks>
-        public override void SetOrdinate(int index, Ordinate ordinate, double value)
+        public override void SetOrdinate(int index, int ordinateIndex, double value)
         {
             CoordRef = null;
-            _coords[index * Dimension + (int) ordinate] = value;
+            _coords[index * Dimension + ordinateIndex] = value;
         }
 
         /// <summary>
@@ -725,28 +725,28 @@ namespace NetTopologySuite.Geometries.Implementation
         /// value.
         /// </remarks>
         /// <param name="index">The coordinate index in the sequence.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
+        /// <param name="ordinateIndex">The ordinate index in the coordinate (in range [0, dimension-1]).</param>
         /// <returns></returns>
-        public override double GetOrdinate(int index, Ordinate ordinate)
+        public override double GetOrdinate(int index, int ordinateIndex)
         {
-            return _coords[index * Dimension + (int) ordinate];
+            return _coords[index * Dimension + ordinateIndex];
         }
 
         /// <summary>
         /// Sets the ordinate of a coordinate in this sequence.
         /// </summary>
         /// <param name="index">The coordinate index.</param>
-        /// <param name="ordinate">The ordinate index in the coordinate, 0 based,
+        /// <param name="ordinateIndex">The ordinate index in the coordinate, 0 based,
         /// smaller than the number of dimensions.</param>
         /// <param name="value">The new ordinate value.</param>
         /// <remarks>
         /// Warning: for performance reasons the ordinate index is not checked:
         /// if it is over dimensions you may not get an exception but a meaningless value.
         /// </remarks>
-        public override void SetOrdinate(int index, Ordinate ordinate, double value)
+        public override void SetOrdinate(int index, int ordinateIndex, double value)
         {
             CoordRef = null;
-            _coords[index * Dimension + (int) ordinate] = (float) value;
+            _coords[index * Dimension + ordinateIndex] = (float) value;
         }
 
         /// <summary>

--- a/NetTopologySuite/Geometries/LineString.cs
+++ b/NetTopologySuite/Geometries/LineString.cs
@@ -426,9 +426,9 @@ namespace NetTopologySuite.Geometries
             get => _points.GetCoordinate(n);
             set
             {
-                _points.SetOrdinate(n, Ordinate.X, value.X);
-                _points.SetOrdinate(n, Ordinate.Y, value.Y);
-                _points.SetOrdinate(n, Ordinate.Z, value.Z);
+                _points.SetOrdinate(n, 0, value.X);
+                _points.SetOrdinate(n, 1, value.Y);
+                _points.SetOrdinate(n, 2, value.Z);
             }
         }
 

--- a/NetTopologySuite/Geometries/Ordinate.cs
+++ b/NetTopologySuite/Geometries/Ordinate.cs
@@ -36,16 +36,6 @@
         M = 3,
 
         /// <summary>
-        /// Ordinate at index 2
-        /// </summary>
-        Ordinate2 = 2,
-
-        /// <summary>
-        /// Ordinate at index 3
-        /// </summary>
-        Ordinate3 = 3,
-
-        /// <summary>
         /// Ordinate at index 4
         /// </summary>
         Ordinate4 = 4,

--- a/NetTopologySuite/Geometries/Ordinates.cs
+++ b/NetTopologySuite/Geometries/Ordinates.cs
@@ -56,14 +56,6 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Flag for ordinate at index 2
         /// </summary>
-        Ordinate2 = 1 << Ordinate.Ordinate2,
-        /// <summary>
-        /// Flag for ordinate at index 2
-        /// </summary>
-        Ordinate3 = 1 << Ordinate.Ordinate3,
-        /// <summary>
-        /// Flag for ordinate at index 2
-        /// </summary>
         Ordinate4 = 1 << Ordinate.Ordinate4,
         /// <summary>
         /// Flag for ordinate at index 2

--- a/NetTopologySuite/Geometries/OridinatesUtility.cs
+++ b/NetTopologySuite/Geometries/OridinatesUtility.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace NetTopologySuite.Geometries
@@ -67,6 +68,92 @@ namespace NetTopologySuite.Geometries
                 result |= (Ordinates) (1 << ((int) ordinate));
             }
             return result;
+        }
+
+        /// <summary>
+        /// Converts an <see cref="Ordinate"/> value to the index of that ordinate within a
+        /// particular <see cref="ICoordinateSequence"/>, or <see langword="null"/> if the sequence
+        /// does not contain values for that ordinate.
+        /// <para>
+        /// Ordinate values greater than <see cref="Ordinate.M"/> are considered ambiguous and will
+        /// always map to <see langword="null"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="ordinate">The <see cref="Ordinate"/> value to convert.</param>
+        /// <param name="seq">The <see cref="ICoordinateSequence"/> to look for.</param>
+        /// <returns>
+        /// The ordinate index to use to store / fetch the values of <paramref name="ordinate"/> in
+        /// <paramref name="seq"/>, or <see langword="null"/> if the ordinate is not present.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="seq"/> is <see langword="null"/>.
+        /// </exception>
+        public static int? IndexOfOrdinateInSequence(Ordinate ordinate, ICoordinateSequence seq)
+        {
+            if (seq is null)
+            {
+                throw new ArgumentNullException(nameof(seq));
+            }
+
+            switch (ordinate)
+            {
+                case Ordinate.X:
+                    return 0;
+
+                case Ordinate.Y:
+                    return 1;
+
+                case Ordinate.Z when seq.HasZ:
+                    return 2;
+
+                case Ordinate.M when seq.HasM:
+                    return seq.HasZ ? 3 : 2;
+
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns the ordinate of a coordinate in this sequence.
+        /// </summary>
+        /// <param name="seq">The <see cref="ICoordinateSequence"/> whose ordinate value to get.</param>
+        /// <param name="index">The coordinate index in the sequence.</param>
+        /// <param name="ordinate">The ordinate value to get.</param>
+        /// <returns>The ordinate value, or <see cref="Coordinate.NullOrdinate"/> if the sequence does not provide values for <paramref name="ordinate"/>"/></returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="seq"/> is <see langword="null"/>.
+        /// </exception>
+        public static double GetOrdinate(this ICoordinateSequence seq, int index, Ordinate ordinate)
+        {
+            if (seq is null)
+            {
+                throw new ArgumentNullException(nameof(seq));
+            }
+
+            return IndexOfOrdinateInSequence(ordinate, seq) is int ordinateIndex
+                ? seq.GetOrdinate(index, ordinateIndex)
+                : Coordinate.NullOrdinate;
+        }
+
+        /// <summary>
+        /// Sets the value for a given ordinate of a coordinate in this sequence.
+        /// </summary>
+        /// <param name="seq">The <see cref="ICoordinateSequence"/> whose ordinate value to set.</param>
+        /// <param name="index">The coordinate index in the sequence.</param>
+        /// <param name="ordinate">The ordinate value to set.</param>
+        /// <param name="value">The new ordinate value.</param>
+        public static void SetOrdinate(this ICoordinateSequence seq, int index, Ordinate ordinate, double value)
+        {
+            if (seq is null)
+            {
+                throw new ArgumentNullException(nameof(seq));
+            }
+
+            if (IndexOfOrdinateInSequence(ordinate, seq) is int ordinateIndex)
+            {
+                seq.SetOrdinate(index, ordinateIndex, value);
+            }
         }
     }
 }

--- a/NetTopologySuite/Geometries/Point.cs
+++ b/NetTopologySuite/Geometries/Point.cs
@@ -81,7 +81,10 @@ namespace NetTopologySuite.Geometries
             if ((_coordinates.Ordinates & ordinateFlag) != ordinateFlag)
                 return new[] {Coordinate.NullOrdinate};
 
-            return new [] { _coordinates.GetOrdinate(0, ordinate)};
+            double val = OrdinatesUtility.IndexOfOrdinateInSequence(ordinate, _coordinates) is int ordinateIndex
+                ? _coordinates.GetOrdinate(0, ordinateIndex)
+                : Coordinate.NullOrdinate;
+            return new [] { val };
         }
 
         /// <summary>
@@ -302,11 +305,17 @@ namespace NetTopologySuite.Geometries
         {
             get
             {
-                if (Coordinate == null)
+                if (CoordinateSequence == null)
                     throw new ArgumentOutOfRangeException("Z called on empty Point");
-                return Coordinate.Z;
+                return CoordinateSequence.GetZ(0);
             }
-            set => Coordinate.Z = value;
+            set
+            {
+                if (OrdinatesUtility.IndexOfOrdinateInSequence(Ordinate.Z, CoordinateSequence) is int ordinateIndex)
+                {
+                    CoordinateSequence.SetOrdinate(0, ordinateIndex, value);
+                }
+            }
         }
 
         /* END ADDED BY MPAUL42: monoGIS team */
@@ -317,9 +326,15 @@ namespace NetTopologySuite.Geometries
             {
                 if (CoordinateSequence == null)
                     throw new ArgumentOutOfRangeException("M called on empty Point");
-                return CoordinateSequence.GetOrdinate(0, Ordinate.M);
+                return CoordinateSequence.GetM(0);
             }
-            set => CoordinateSequence.SetOrdinate(0, Ordinate.M, value);
+            set
+            {
+                if (OrdinatesUtility.IndexOfOrdinateInSequence(Ordinate.M, CoordinateSequence) is int ordinateIndex)
+                {
+                    CoordinateSequence.SetOrdinate(0, ordinateIndex, value);
+                }
+            }
         }
     }
 }

--- a/NetTopologySuite/Geometries/Utilities/AffineTransformation.cs
+++ b/NetTopologySuite/Geometries/Utilities/AffineTransformation.cs
@@ -990,10 +990,10 @@ namespace NetTopologySuite.Geometries.Utilities
         /// <param name="i"> the index of the coordinate to transform</param>
         public void Transform(ICoordinateSequence seq, int i)
         {
-            double xp = _m00 * seq.GetOrdinate(i, Ordinate.X) + _m01 * seq.GetOrdinate(i, Ordinate.Y) + _m02;
-            double yp = _m10 * seq.GetOrdinate(i, Ordinate.X) + _m11 * seq.GetOrdinate(i, Ordinate.Y) + _m12;
-            seq.SetOrdinate(i, Ordinate.X, xp);
-            seq.SetOrdinate(i, Ordinate.Y, yp);
+            double xp = _m00 * seq.GetOrdinate(i, 0) + _m01 * seq.GetOrdinate(i, 1) + _m02;
+            double yp = _m10 * seq.GetOrdinate(i, 0) + _m11 * seq.GetOrdinate(i, 1) + _m12;
+            seq.SetOrdinate(i, 0, xp);
+            seq.SetOrdinate(i, 1, yp);
         }
 
         /// <summary>

--- a/NetTopologySuite/IO/WKBReader.cs
+++ b/NetTopologySuite/IO/WKBReader.cs
@@ -252,8 +252,8 @@ namespace NetTopologySuite.IO
                 if (_precisionModel != null) x = _precisionModel.MakePrecise(x);
                 if (_precisionModel != null) y = _precisionModel.MakePrecise(y);
 
-                sequence.SetOrdinate(i, Ordinate.X, x);
-                sequence.SetOrdinate(i, Ordinate.Y, y);
+                sequence.SetOrdinate(i, 0, x);
+                sequence.SetOrdinate(i, 1, y);
 
                 switch (cs)
                 {
@@ -262,20 +262,20 @@ namespace NetTopologySuite.IO
                     case CoordinateSystem.XYZ:
                         double z = reader.ReadDouble();
                         if (HandleOrdinate(Ordinate.Z))
-                            sequence.SetOrdinate(i, Ordinate.Z, z);
+                            sequence.SetOrdinate(i, 2, z);
                         break;
                     case CoordinateSystem.XYM:
                         double m = reader.ReadDouble();
                         if (HandleOrdinate(Ordinate.M))
-                            sequence.SetOrdinate(i, Ordinate.Ordinate2, m);
+                            sequence.SetOrdinate(i, 2, m);
                         break;
                     case CoordinateSystem.XYZM:
                         z = reader.ReadDouble();
                         if (HandleOrdinate(Ordinate.Z))
-                            sequence.SetOrdinate(i, Ordinate.Z, z);
+                            sequence.SetOrdinate(i, 2, z);
                         m = reader.ReadDouble();
                         if (HandleOrdinate(Ordinate.M))
-                            sequence.SetOrdinate(i, Ordinate.M, m);
+                            sequence.SetOrdinate(i, 3, m);
                         break;
                     default:
                         throw new ArgumentException(string.Format("Coordinate system not supported: {0}", cs));

--- a/NetTopologySuite/IO/WKBWriter.cs
+++ b/NetTopologySuite/IO/WKBWriter.cs
@@ -273,8 +273,8 @@ namespace NetTopologySuite.IO
             double ordinateM = Coordinate.NullOrdinate;
 
             // test if zm-values are provided by sequence
-            bool getZ = (sequence.Ordinates & Ordinates.Z) == Ordinates.Z;
-            bool getM = (sequence.Ordinates & Ordinates.M) == Ordinates.M;
+            bool getZ = sequence.HasZ;
+            bool getM = sequence.HasM;
 
             // test if zm-values should be emitted
             bool writeZ = (HandleOrdinates & Ordinates.Z) == Ordinates.Z;
@@ -282,16 +282,16 @@ namespace NetTopologySuite.IO
 
             for (int index = 0; index < sequence.Count; index++)
             {
-                writer.Write(sequence.GetOrdinate(index, Ordinate.X));
-                writer.Write(sequence.GetOrdinate(index, Ordinate.Y));
+                writer.Write(sequence.GetOrdinate(index, 0));
+                writer.Write(sequence.GetOrdinate(index, 1));
                 if (writeZ)
                 {
-                    if (getZ) ordinateZ = sequence.GetOrdinate(index, Ordinate.Z);
+                    if (getZ) ordinateZ = sequence.GetZ(index);
                     writer.Write(ordinateZ);
                 }
                 if (writeM)
                 {
-                    if (getM) ordinateM = sequence.GetOrdinate(index, Ordinate.M);
+                    if (getM) ordinateM = sequence.GetM(index);
                     writer.Write(ordinateM);
                 }
             }

--- a/NetTopologySuite/IO/WKTReader.cs
+++ b/NetTopologySuite/IO/WKTReader.cs
@@ -228,23 +228,23 @@ namespace NetTopologySuite.IO
             // create a sequence for one coordinate
             int offsetM = ordinateFlags.HasFlag(Ordinates.Z) ? 1 : 0;
             var sequence = _coordinateSequencefactory.Create(1, this.ToDimension(ordinateFlags), ordinateFlags.HasFlag(Ordinates.M) ? 1 : 0);
-            sequence.SetOrdinate(0, Ordinate.X, _precisionModel.MakePrecise(GetNextNumber(tokens)));
-            sequence.SetOrdinate(0, Ordinate.Y, _precisionModel.MakePrecise(GetNextNumber(tokens)));
+            sequence.SetOrdinate(0, 0, _precisionModel.MakePrecise(GetNextNumber(tokens)));
+            sequence.SetOrdinate(0, 1, _precisionModel.MakePrecise(GetNextNumber(tokens)));
 
             // additionally read other vertices
             if (ordinateFlags.HasFlag(Ordinates.Z))
             {
-                sequence.SetOrdinate(0, Ordinate.Z, GetNextNumber(tokens));
+                sequence.SetOrdinate(0, 2, GetNextNumber(tokens));
             }
 
             if (ordinateFlags.HasFlag(Ordinates.M))
             {
-                sequence.SetOrdinate(0, Ordinate.Z + offsetM, GetNextNumber(tokens));
+                sequence.SetOrdinate(0, 2 + offsetM, GetNextNumber(tokens));
             }
 
             if (ordinateFlags == Ordinates.XY && _isAllowOldNtsCoordinateSyntax && IsNumberNext(tokens))
             {
-                sequence.SetOrdinate(0, Ordinate.Z, GetNextNumber(tokens));
+                sequence.SetOrdinate(0, 2, GetNextNumber(tokens));
             }
 
             // read close token if it was opened here
@@ -373,15 +373,15 @@ namespace NetTopologySuite.IO
             // create and fill the result sequence
             var sequence = _coordinateSequencefactory.Create(sequences.Count, this.ToDimension(mergeOrdinates), mergeOrdinates.HasFlag(Ordinates.M) ? 1 : 0);
 
-            var offsetM = Ordinate.Z + (mergeOrdinates.HasFlag(Ordinates.Z) ? 1 : 0);
+            int offsetM = 2 + (mergeOrdinates.HasFlag(Ordinates.Z) ? 1 : 0);
             for (int i = 0; i < sequences.Count; i++)
             {
                 var item = sequences[i];
-                sequence.SetOrdinate(i, Ordinate.X, item.GetOrdinate(0, Ordinate.X));
-                sequence.SetOrdinate(i, Ordinate.Y, item.GetOrdinate(0, Ordinate.Y));
+                sequence.SetOrdinate(i, 0, item.GetOrdinate(0, 0));
+                sequence.SetOrdinate(i, 1, item.GetOrdinate(0, 1));
                 if (mergeOrdinates.HasFlag(Ordinates.Z))
                 {
-                    sequence.SetOrdinate(i, Ordinate.Z, item.GetOrdinate(0, Ordinate.Z));
+                    sequence.SetOrdinate(i, 2, item.GetOrdinate(0, 2));
                 }
 
                 if (mergeOrdinates.HasFlag(Ordinates.M))

--- a/NetTopologySuite/IO/WKTWriter.cs
+++ b/NetTopologySuite/IO/WKTWriter.cs
@@ -226,7 +226,7 @@ namespace NetTopologySuite.IO
                     break;
 
                 case 3:
-                    _outputOrdinates = Ordinates.XY | Ordinates.Ordinate2;
+                    _outputOrdinates = Ordinates.XYZ;
                     break;
 
                 case 4:

--- a/NetTopologySuite/Operation/Distance3D/AxisPlaneCoordinateSequence.cs
+++ b/NetTopologySuite/Operation/Distance3D/AxisPlaneCoordinateSequence.cs
@@ -50,15 +50,15 @@ namespace NetTopologySuite.Operation.Distance3D
             return new AxisPlaneCoordinateSequence(seq, YZIndex);
         }
 
-        private static readonly Ordinate[] XYIndex = new[] {Ordinate.X, Ordinate.Y};
-        private static readonly Ordinate[] XZIndex = new[] {Ordinate.X, Ordinate.Z};
-        private static readonly Ordinate[] YZIndex = new[] {Ordinate.Y, Ordinate.Z};
+        private static readonly int[] XYIndex = new[] {0, 1};
+        private static readonly int[] XZIndex = new[] {0, 2};
+        private static readonly int[] YZIndex = new[] {1, 2};
         // ReSharper restore InconsistentNaming
 
         private readonly ICoordinateSequence _seq;
-        private readonly Ordinate[] _indexMap;
+        private readonly int[] _indexMap;
 
-        private AxisPlaneCoordinateSequence(ICoordinateSequence seq, Ordinate[] indexMap)
+        private AxisPlaneCoordinateSequence(ICoordinateSequence seq, int[] indexMap)
         {
             _seq = seq;
             _indexMap = indexMap;
@@ -90,24 +90,24 @@ namespace NetTopologySuite.Operation.Distance3D
 
         public void GetCoordinate(int index, Coordinate coord)
         {
-            coord.X = GetOrdinate(index, Ordinate.X);
-            coord.Y = GetOrdinate(index, Ordinate.Y);
-            coord.Z = GetOrdinate(index, Ordinate.Z);
+            coord.X = GetOrdinate(index, 0);
+            coord.Y = GetOrdinate(index, 1);
+            coord.Z = GetOrdinate(index, 2);
         }
 
         public double GetX(int index)
         {
-            return GetOrdinate(index, Ordinate.X);
+            return GetOrdinate(index, 0);
         }
 
         public double GetY(int index)
         {
-            return GetOrdinate(index, Ordinate.Y);
+            return GetOrdinate(index, 1);
         }
 
         public double GetZ(int index)
         {
-            return GetOrdinate(index, Ordinate.Z);
+            return GetOrdinate(index, 2);
         }
 
         public double GetM(int index)
@@ -115,16 +115,16 @@ namespace NetTopologySuite.Operation.Distance3D
             return double.NaN;
         }
 
-        public double GetOrdinate(int index, Ordinate ordinateIndex)
+        public double GetOrdinate(int index, int ordinateIndex)
         {
             // Z ord is always 0
-            if (ordinateIndex > Ordinate.Y) return 0;
-            return _seq.GetOrdinate(index, _indexMap[(int) ordinateIndex]);
+            if (ordinateIndex > 1) return 0;
+            return _seq.GetOrdinate(index, _indexMap[ordinateIndex]);
         }
 
         public int Count => _seq.Count;
 
-        public void SetOrdinate(int index, Ordinate ordinateIndex, double value)
+        public void SetOrdinate(int index, int ordinateIndex, double value)
         {
             throw new NotSupportedException();
         }

--- a/NetTopologySuite/Operation/Distance3D/PlanarPolygon3D.cs
+++ b/NetTopologySuite/Operation/Distance3D/PlanarPolygon3D.cs
@@ -94,9 +94,9 @@ namespace NetTopologySuite.Operation.Distance3D
             int n = seq.Count;
             for (int i = 0; i < n; i++)
             {
-                a.X += seq.GetOrdinate(i, Ordinate.X);
-                a.Y += seq.GetOrdinate(i, Ordinate.Y);
-                a.Z += seq.GetOrdinate(i, Ordinate.Z);
+                a.X += seq.GetOrdinate(i, 0);
+                a.Y += seq.GetOrdinate(i, 1);
+                a.Z += seq.GetOrdinate(i, 2);
             }
             a.X /= n;
             a.Y /= n;

--- a/NetTopologySuite/Precision/CommonBitsRemover.cs
+++ b/NetTopologySuite/Precision/CommonBitsRemover.cs
@@ -136,10 +136,10 @@ namespace NetTopologySuite.Precision
             /// <param name="seq">The coordinate sequence</param>
             public void Filter(ICoordinateSequence seq, int i)
             {
-                double xp = seq.GetOrdinate(i, Ordinate.X) + _trans.X;
-                double yp = seq.GetOrdinate(i, Ordinate.Y) + _trans.Y;
-                seq.SetOrdinate(i, Ordinate.X, xp);
-                seq.SetOrdinate(i, Ordinate.Y, yp);
+                double xp = seq.GetOrdinate(i, 0) + _trans.X;
+                double yp = seq.GetOrdinate(i, 1) + _trans.Y;
+                seq.SetOrdinate(i, 0, xp);
+                seq.SetOrdinate(i, 1, yp);
             }
 
             public bool Done => false;

--- a/NetTopologySuite/Precision/CoordinatePrecisionReducerFilter.cs
+++ b/NetTopologySuite/Precision/CoordinatePrecisionReducerFilter.cs
@@ -31,8 +31,8 @@ namespace NetTopologySuite.Precision
         /// </summary>
         public void Filter(ICoordinateSequence seq, int i)
         {
-            seq.SetOrdinate(i, Ordinate.X, _precModel.MakePrecise(seq.GetOrdinate(i, Ordinate.X)));
-            seq.SetOrdinate(i, Ordinate.Y, _precModel.MakePrecise(seq.GetOrdinate(i, Ordinate.Y)));
+            seq.SetOrdinate(i, 0, _precModel.MakePrecise(seq.GetOrdinate(i, 0)));
+            seq.SetOrdinate(i, 1, _precModel.MakePrecise(seq.GetOrdinate(i, 1)));
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #311

Doing NetTopologySuite/GeoAPI#68 for coordinate sequences will probably see the new `OrdinatesUtility` extension methods for `ICoordinateSequence` moved to instance methods on the base class.