### PR TITLE
Add initial support for GML3 to GMLWriter

### DIFF
--- a/NetTopologySuite/IO/GML2/GMLWriter.cs
+++ b/NetTopologySuite/IO/GML2/GMLWriter.cs
@@ -19,6 +19,15 @@ namespace NetTopologySuite.IO.GML2
     {
         private const int InitValue = 150;
         private const int CoordSize = 200;
+        private GmlVersion Version = GmlVersion.Two;
+
+        public GMLWriter()
+        {
+        }
+        public GMLWriter(GmlVersion version)
+        {
+            Version = version;
+        }
 
         /// <summary>
         /// Formatter for double values of coordinates
@@ -174,12 +183,12 @@ namespace NetTopologySuite.IO.GML2
         protected void Write(Polygon polygon, XmlWriter writer)
         {
             writer.WriteStartElement(GMLElements.gmlPrefix, "Polygon", GMLElements.gmlNS);
-            writer.WriteStartElement("outerBoundaryIs", GMLElements.gmlNS);
+            writer.WriteStartElement(Version == GmlVersion.Three ? "exterior" : "outerBoundaryIs", GMLElements.gmlNS);
             Write(polygon.ExteriorRing as LinearRing, writer);
             writer.WriteEndElement();
             for (int i = 0; i < polygon.NumInteriorRings; i++)
             {
-                writer.WriteStartElement("innerBoundaryIs", GMLElements.gmlNS);
+                writer.WriteStartElement(Version == GmlVersion.Three ? "exterior" : "innerBoundaryIs", GMLElements.gmlNS);
                 Write(polygon.InteriorRings[i] as LinearRing, writer);
                 writer.WriteEndElement();
             }

--- a/NetTopologySuite/IO/GML2/GmlVersion.cs
+++ b/NetTopologySuite/IO/GML2/GmlVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace NetTopologySuite.IO.GML2
+{
+    public enum GmlVersion
+    {
+        Two = 2,
+        Three = 3
+    }
+}


### PR DESCRIPTION
Give user the ability to declare which version of the GMLWriter they wish to use.  The default is V2 so not to break compatibility.

The writer checks which version is being used and changes the output accordingly.  outerBoundaryIs and innerBoundaryIs were both depricated with GML3.

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
This is only a small change really.

_Thanks for contributing to NetTopologySuite!_
