### PR TITLE
Initial support for GML3 within the GMLWriter

### DIFF
--- a/src/NetTopologySuite/IO/GML2/GMLVersion.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace NetTopologySuite.IO.GML2
+{
+    public enum GMLVersion
+    {
+        Two = 2,
+        Three = 3
+    }
+}

--- a/src/NetTopologySuite/IO/GML2/GMLVersion.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLVersion.cs
@@ -1,8 +1,18 @@
 ﻿namespace NetTopologySuite.IO.GML2
 {
+    /// <summary>
+    /// Identifies a version of the GML specification.
+    /// </summary>
     public enum GMLVersion
     {
+        /// <summary>
+        /// Version 2.1.1 (OGC 02-009).
+        /// </summary>
         Two = 2,
+
+        /// <summary>
+        /// Version 3.2.2 (OGC 07-036r1 / ISO 19136:2007).
+        /// </summary>
         Three = 3
     }
 }

--- a/src/NetTopologySuite/IO/GML2/GMLWriter.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLWriter.cs
@@ -19,11 +19,21 @@ namespace NetTopologySuite.IO.GML2
     {
         private const int InitValue = 150;
         private const int CoordSize = 200;
+        private readonly GMLVersion Version = GMLVersion.Two;
 
         /// <summary>
         /// Formatter for double values of coordinates
         /// </summary>
         protected static NumberFormatInfo NumberFormatter => Global.GetNfi();
+
+        public GMLWriter()
+        {
+        }
+
+        public GMLWriter(GMLVersion version)
+        {
+            Version = version;
+        }
 
         /// <summary>
         /// Returns an <c>XmlReader</c> with feature informations.
@@ -174,12 +184,12 @@ namespace NetTopologySuite.IO.GML2
         protected void Write(Polygon polygon, XmlWriter writer)
         {
             writer.WriteStartElement(GMLElements.gmlPrefix, "Polygon", GMLElements.gmlNS);
-            writer.WriteStartElement("outerBoundaryIs", GMLElements.gmlNS);
+            writer.WriteStartElement(Version == GMLVersion.Three ? "exterior" : "outerBoundaryIs", GMLElements.gmlNS);
             Write(polygon.ExteriorRing as LinearRing, writer);
             writer.WriteEndElement();
             for (int i = 0; i < polygon.NumInteriorRings; i++)
             {
-                writer.WriteStartElement("innerBoundaryIs", GMLElements.gmlNS);
+                writer.WriteStartElement(Version == GMLVersion.Three ? "exterior" : "innerBoundaryIs", GMLElements.gmlNS);
                 Write(polygon.InteriorRings[i] as LinearRing, writer);
                 writer.WriteEndElement();
             }

--- a/src/NetTopologySuite/IO/GML2/GMLWriter.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLWriter.cs
@@ -184,12 +184,12 @@ namespace NetTopologySuite.IO.GML2
         protected void Write(Polygon polygon, XmlWriter writer)
         {
             writer.WriteStartElement(GMLElements.gmlPrefix, "Polygon", GMLElements.gmlNS);
-            writer.WriteStartElement(Version == GMLVersion.Three ? "exterior" : "outerBoundaryIs", GMLElements.gmlNS);
+            writer.WriteStartElement(Version == GMLVersion.Two ? "outerBoundaryIs" : "exterior", GMLElements.gmlNS);
             Write(polygon.ExteriorRing as LinearRing, writer);
             writer.WriteEndElement();
             for (int i = 0; i < polygon.NumInteriorRings; i++)
             {
-                writer.WriteStartElement(Version == GMLVersion.Three ? "exterior" : "innerBoundaryIs", GMLElements.gmlNS);
+                writer.WriteStartElement(Version == GMLVersion.Two ? "innerBoundaryIs" : "exterior", GMLElements.gmlNS);
                 Write(polygon.InteriorRings[i] as LinearRing, writer);
                 writer.WriteEndElement();
             }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
The GMLWriter doesn't support GML3.  I have added initial support for GML3 to resolve the fact that outerBoundaryIs and innerBoundaryIs was depricated with GML3.

I have added a version which can be supplied (or not) but the default version is left at GML2 so things don't break.

Just a simple change.