### PR TITLE
Enforce polygon ring orientation with GeometryFactory (#360)

### DIFF
--- a/src/NetTopologySuite/Geometries/GeometryFactory.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactory.cs
@@ -504,7 +504,7 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         /// <param name="polygons">Polygons, each of which may be empty but not null.</param>
         /// <returns>A <see cref="MultiPolygon"/> object</returns>
-        public MultiPolygon CreateMultiPolygon(Polygon[] polygons)
+        public virtual MultiPolygon CreateMultiPolygon(Polygon[] polygons)
         {
             return new MultiPolygon(polygons, this);
         }

--- a/src/NetTopologySuite/Geometries/GeometryFactoryEx.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactoryEx.cs
@@ -1,0 +1,144 @@
+﻿using System;
+
+namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// An extended <see cref="GeometryFactory"/> that is capable of enforcing a ring orientation for polygons.
+    /// </summary>
+    public class GeometryFactoryEx : GeometryFactory
+    {
+        /// <summary>
+        /// Gets the default polygon shell ring orientation that is used when nothing else has been set.
+        /// </summary>
+        private const LinearRingOrientation DefaultRingOrientation = LinearRingOrientation.Default;
+
+        /// <summary>
+        /// The polygon shell ring orientation enforced by this factory
+        /// </summary>
+        private LinearRingOrientation? _polygonShellRingOrientation;
+
+        /// <summary>
+        /// Gets or sets a value indicating the ring orientation of the
+        /// <c>Polygon</c>'s exterior rings.<para>
+        /// If its value is <see cref="LinearRingOrientation.DontCare"/>, this
+        /// factory behaves just like the base <see cref="GeometryFactory"/>.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// The setter of this property has to be used prior to any call
+        /// to <c>CreatePolygon</c> or <c>"CreateMultiPolygon</c></remarks>
+        /// <seealso cref="GeometryFactory.CreatePolygon(Coordinate[])"/>
+        /// <seealso cref="GeometryFactory.CreatePolygon(CoordinateSequence)"/>
+        /// <seealso cref="GeometryFactory.CreatePolygon(LinearRing)"/>
+        /// <seealso cref="GeometryFactory.CreatePolygon(LinearRing, LinearRing[])"/>
+        /// <seealso cref="GeometryFactory.CreateMultiPolygon(Polygon[])"/>
+        public LinearRingOrientation OrientationOfExteriorRing
+        {
+            get => _polygonShellRingOrientation ?? (_polygonShellRingOrientation = DefaultRingOrientation).Value;
+            set
+            {
+                if (_polygonShellRingOrientation.HasValue && _polygonShellRingOrientation.Value != value)
+                    throw new InvalidOperationException();
+                if ((int)value < -1 || (int)value > 1)
+                    throw new ArgumentOutOfRangeException();
+
+                _polygonShellRingOrientation = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating the ring orientation for the interior rings
+        /// </summary>
+        /// <remarks>
+        /// This value is always opposite of <see cref="OrientationOfExteriorRing"/>,
+        /// except when its value is <see cref="LinearRingOrientation.DontCare"/>.
+        /// </remarks>
+        private LinearRingOrientation OrientationOfInteriorRings
+        {
+            get
+            {
+                switch (OrientationOfExteriorRing)
+                {
+                    case LinearRingOrientation.CCW:
+                        return LinearRingOrientation.CW;
+                    case LinearRingOrientation.CW:
+                        return LinearRingOrientation.CCW;
+                    default:
+                        return LinearRingOrientation.DontCare;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Constructs a <c>Polygon</c> with the given exterior boundary and
+        /// interior boundaries.
+        /// <para/>
+        /// The <see cref="OrientationOfExteriorRing"/> is enforced on the constructed polygon.
+        /// </summary>
+        /// <param name="shell">
+        /// The outer boundary of the new <c>Polygon</c>, or
+        /// <c>null</c> or an empty <c>LinearRing</c> if
+        /// the empty point is to be created.
+        /// </param>
+        /// <param name="holes">
+        /// The inner boundaries of the new <c>Polygon</c>, or
+        /// <c>null</c> or empty <c>LinearRing</c> s if
+        /// the empty point is to be created.
+        /// </param>
+        /// <returns>A <see cref="Polygon"/> object</returns>
+        public override Polygon CreatePolygon(LinearRing shell, LinearRing[] holes)
+        {
+            shell = EnsureOrientation(shell, OrientationOfExteriorRing);
+            if (holes != null && holes.Length > 0)
+            {
+                var ringOrientation = OrientationOfInteriorRings;
+                for (int i = 0; i < holes.Length; i++)
+                    holes[i] = EnsureOrientation(holes[i], ringOrientation);
+            }
+            return new Polygon(shell, holes, this);
+        }
+
+        /// <summary>
+        /// Creates a <c>MultiPolygon</c> using the given <c>Polygons</c>; a null or empty array
+        /// will create an empty Polygon. The polygons must conform to the
+        /// assertions specified in the <see href="http://www.opengis.org/techno/specs.htm"/> OpenGIS Simple Features
+        /// Specification for SQL.<para/>
+        /// The <see cref="OrientationOfExteriorRing"/> is enforced on each polygon.
+        /// </summary>
+        /// <param name="polygons">Polygons, each of which may be empty but not null.</param>
+        /// <returns>A <see cref="MultiPolygon"/> object</returns>
+        public override MultiPolygon CreateMultiPolygon(Polygon[] polygons)
+        {
+            if (polygons == null || polygons.Length == 0)
+                return CreateMultiPolygon();
+
+            // Check if polygons were created with a ring orientation enforcing factory and that the ring
+            // orientation matches that of this one.
+            if (polygons[0]?.Factory is GeometryFactoryEx gfe && gfe.OrientationOfExteriorRing == OrientationOfExteriorRing)
+                return new MultiPolygon(polygons, this);
+
+            for (int i = 0; i < polygons.Length; i++)
+                polygons[i] = CreatePolygon(polygons[i].Shell, polygons[i].Holes);
+
+            return new MultiPolygon(polygons, this);
+        }
+
+        /// <summary>
+        /// Utility function to enforce a specific ring orientation on a linear ring
+        /// </summary>
+        /// <param name="ring">The ring</param>
+        /// <param name="ringOrientation">The required orientation</param>
+        /// <returns>A ring</returns>
+        private static LinearRing EnsureOrientation(LinearRing ring, LinearRingOrientation ringOrientation)
+        {
+            if (ringOrientation == LinearRingOrientation.DontCare)
+                return ring;
+
+            if (ringOrientation == LinearRingOrientation.CCW && !ring.IsCCW ||
+                ringOrientation == LinearRingOrientation.CW && ring.IsCCW)
+                ring = (LinearRing)ring.Reverse();
+
+            return ring;
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/GeometryFactoryEx.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactoryEx.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NetTopologySuite.Geometries.Implementation;
 
 namespace NetTopologySuite.Geometries
 {
@@ -11,6 +12,79 @@ namespace NetTopologySuite.Geometries
         /// Gets the default polygon shell ring orientation that is used when nothing else has been set.
         /// </summary>
         private const LinearRingOrientation DefaultRingOrientation = LinearRingOrientation.Default;
+
+        private static readonly PrecisionModel FloatingPrecisionModel = new PrecisionModel();
+
+        private static CoordinateSequenceFactory _defaultCoordinateSequenceFactory;
+        private static PrecisionModel _defaultPrecisionModel;
+
+        /// <summary>
+        /// Gets or sets the default precision model to use with these geometry factories
+        /// </summary>
+        public static PrecisionModel DefaultPrecisionModel
+        {
+            get => _defaultPrecisionModel ?? FloatingPrecisionModel;
+            set => _defaultPrecisionModel = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the default coordinate sequence factory to use with these geometry factories
+        /// </summary>
+        public static CoordinateSequenceFactory DefaultCoordinateSequenceFactory
+        {
+            get => _defaultCoordinateSequenceFactory ?? CoordinateArraySequenceFactory.Instance;
+            set => _defaultCoordinateSequenceFactory = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the default spatial reference id.
+        /// </summary>
+        public static int DefaultSRID { get; set; } = 0;
+
+        /// <summary>
+        /// Constructs a GeometryFactory that generates Geometries having the given
+        /// PrecisionModel, spatial-reference ID, and CoordinateSequence implementation.
+        /// </summary>
+        public GeometryFactoryEx(PrecisionModel precisionModel, int srid, CoordinateSequenceFactory coordinateSequenceFactory)
+            : base(precisionModel, srid, coordinateSequenceFactory)
+        { }
+
+        /// <summary>
+        /// Constructs a GeometryFactory that generates Geometries having the given
+        /// CoordinateSequence implementation, a double-precision floating PrecisionModel and a
+        /// spatial-reference ID of 0.
+        /// </summary>
+        public GeometryFactoryEx(CoordinateSequenceFactory coordinateSequenceFactory) :
+            this(DefaultPrecisionModel, DefaultSRID, coordinateSequenceFactory)
+        { }
+
+        /// <summary>
+        /// Constructs a GeometryFactory that generates Geometries having the given
+        /// {PrecisionModel} and the default CoordinateSequence
+        /// implementation.
+        /// </summary>
+        /// <param name="precisionModel">The PrecisionModel to use.</param>
+        public GeometryFactoryEx(PrecisionModel precisionModel) :
+            this(precisionModel, DefaultSRID, DefaultCoordinateSequenceFactory)
+        { }
+
+        /// <summary>
+        /// Constructs a GeometryFactory that generates Geometries having the given
+        /// <c>PrecisionModel</c> and spatial-reference ID, and the default CoordinateSequence
+        /// implementation.
+        /// </summary>
+        /// <param name="precisionModel">The PrecisionModel to use.</param>
+        /// <param name="srid">The SRID to use.</param>
+        public GeometryFactoryEx(PrecisionModel precisionModel, int srid) :
+            this(precisionModel, srid, DefaultCoordinateSequenceFactory)
+        { }
+
+        /// <summary>
+        /// Constructs a GeometryFactory that generates Geometries having a floating
+        /// PrecisionModel and a spatial-reference ID of 0.
+        /// </summary>
+        public GeometryFactoryEx() : this(DefaultPrecisionModel, DefaultSRID) { }
+
 
         /// <summary>
         /// The polygon shell ring orientation enforced by this factory

--- a/src/NetTopologySuite/Geometries/LinearRingOrientation.cs
+++ b/src/NetTopologySuite/Geometries/LinearRingOrientation.cs
@@ -1,0 +1,56 @@
+﻿namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// An enumeration of ring orientation values
+    /// </summary>
+    public enum LinearRingOrientation
+    {
+
+        /// <summary>
+        /// The orientation of the ring's coordinates is counter-clockwise.
+        /// </summary>
+        CounterClockwise = -1,
+
+        /// <summary>
+        /// The orientation of the ring's coordinates follows the left-hand-rule,
+        /// saying that if you follow the ring in the direction of its coordinates
+        /// your left hand will be inside the ring.
+        /// </summary>
+        /// <seealso cref="CounterClockwise"/>
+        LeftHandRule = CounterClockwise,
+
+        /// <summary>
+        /// The orientation of the ring's coordinates is counter-clockwise.
+        /// </summary>
+        CCW = CounterClockwise,
+
+        /// <summary>
+        /// The orientation of the rings coordinates does not matter.
+        /// </summary>
+        DontCare = 0,
+
+        /// <summary>
+        /// The default orientation of the rings coordinates.
+        /// Set to <see cref="CounterClockwise"/>
+        /// </summary>
+        Default = CCW,
+
+        /// <summary>
+        /// The orientation of the ring's coordinates is clockwise.
+        /// </summary>
+        Clockwise = 1,
+
+        /// <summary>
+        /// The orientation of the ring's coordinates follows the right-hand-rule,
+        /// saying that if you follow the ring in the direction of its coordinates
+        /// your right hand will be inside the ring.
+        /// </summary>
+        /// <seealso cref="Clockwise"/>
+        RightHandRule = Clockwise,
+
+        /// <summary>
+        /// The orientation of the ring's coordinates is clockwise.
+        /// </summary>
+        CW = Clockwise
+    }
+}

--- a/src/NetTopologySuite/Geometries/OgcCompliantGeometryFactory.cs
+++ b/src/NetTopologySuite/Geometries/OgcCompliantGeometryFactory.cs
@@ -6,6 +6,7 @@ namespace NetTopologySuite.Geometries
     /// <summary>
     /// OGC compliant geometry factory
     /// </summary>
+    [Obsolete("Use GeometryFactoryEx with OrientationOfExteriorRing = CCW")]
     public class OgcCompliantGeometryFactory : GeometryFactory
     {
         /// <summary>

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -48,6 +48,24 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             Assert.IsTrue(TestShellRingOrientationEnforcement(LinearRingOrientation.Clockwise));
         }
 
+        [Test]
+        public void TestEnvelopeToGeometry()
+        {
+            var env = new Envelope(-10, 10, -8, 8);
+
+            var gf = new GeometryFactoryEx();
+            Assert.IsTrue(((Polygon)gf.ToGeometry(env)).Shell.IsCCW );
+
+            gf = new GeometryFactoryEx {OrientationOfExteriorRing = LinearRingOrientation.DontCare };
+            Assert.IsFalse(((Polygon)gf.ToGeometry(env)).Shell.IsCCW);
+
+            gf = new GeometryFactoryEx { OrientationOfExteriorRing = LinearRingOrientation.Clockwise };
+            Assert.IsFalse(((Polygon)gf.ToGeometry(env)).Shell.IsCCW);
+
+            gf = new GeometryFactoryEx { OrientationOfExteriorRing = LinearRingOrientation.CounterClockwise };
+            Assert.IsTrue(((Polygon)gf.ToGeometry(env)).Shell.IsCCW);
+        }
+
         private static bool TestShellRingOrientationEnforcement(LinearRingOrientation ringOrientation)
         {
             var gf = new GeometryFactoryEx();

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -95,7 +95,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
                     if (!polygon.Holes[0].IsCCW)
                         Assert.Fail($"Hole[0] ring orientation requested {LinearRingOrientation.CCW}, was CW"); ;
                     if (!polygon.Holes[1].IsCCW)
-                        Assert.Fail($"Hole[0] ring orientation requested {LinearRingOrientation.CCW}, was CW"); ;
+                        Assert.Fail($"Hole[1] ring orientation requested {LinearRingOrientation.CCW}, was CW"); ;
                     break;
                 case LinearRingOrientation.CCW:
                     if (!polygon.Shell.IsCCW)
@@ -103,7 +103,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
                     if (polygon.Holes[0].IsCCW)
                         Assert.Fail($"Hole[0] ring orientation requested {LinearRingOrientation.CW}, was CCW"); ;
                     if (polygon.Holes[1].IsCCW)
-                        Assert.Fail($"Hole[0] ring orientation requested {LinearRingOrientation.CW}, was CCW"); ;
+                        Assert.Fail($"Hole[1] ring orientation requested {LinearRingOrientation.CW}, was CCW"); ;
                     break;
                 case LinearRingOrientation.DontCare:
                     if (polygon.Shell.IsCCW != Orientation.IsCCW(origShellSequence))

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -32,7 +32,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             TestShellRingOrientationSetter(gf, (LinearRingOrientation)(-2), 1);
             TestShellRingOrientationSetter(gf, (LinearRingOrientation)2, 1);
 
-            // check preventation of setting after first usage
+            // check prevention of setting after first usage
             var ro = gf.OrientationOfExteriorRing;
             // don't fail if value does not change
             TestShellRingOrientationSetter(gf, ro, 0);
@@ -43,9 +43,9 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         [Test]
         public void TestShellRingOrientationEnforcement()
         {
-            Assert.IsTrue(TestShellRingOrientationEnforcement(LinearRingOrientation.DontCare));
-            Assert.IsTrue(TestShellRingOrientationEnforcement(LinearRingOrientation.CounterClockwise));
-            Assert.IsTrue(TestShellRingOrientationEnforcement(LinearRingOrientation.Clockwise));
+            TestShellRingOrientationEnforcement(LinearRingOrientation.DontCare);
+            TestShellRingOrientationEnforcement(LinearRingOrientation.CounterClockwise);
+            TestShellRingOrientationEnforcement(LinearRingOrientation.Clockwise);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             Assert.IsTrue(((Polygon)gf.ToGeometry(env)).Shell.IsCCW);
         }
 
-        private static bool TestShellRingOrientationEnforcement(LinearRingOrientation ringOrientation)
+        private static void TestShellRingOrientationEnforcement(LinearRingOrientation ringOrientation)
         {
             var gf = new GeometryFactoryEx();
             gf.OrientationOfExteriorRing = ringOrientation;
@@ -91,27 +91,27 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             {
                 case LinearRingOrientation.CW:
                     if (polygon.Shell.IsCCW)
-                        return false;
+                        Assert.Fail($"Shell ring orientation requested {LinearRingOrientation.CW}, was CCW");
                     if (!polygon.Holes[0].IsCCW)
-                        return false;
+                        Assert.Fail($"Hole[0] ring orientation requested {LinearRingOrientation.CCW}, was CW"); ;
                     if (!polygon.Holes[1].IsCCW)
-                        return false;
+                        Assert.Fail($"Hole[0] ring orientation requested {LinearRingOrientation.CCW}, was CW"); ;
                     break;
                 case LinearRingOrientation.CCW:
                     if (!polygon.Shell.IsCCW)
-                        return false;
+                        Assert.Fail($"Shell ring orientation requested {LinearRingOrientation.CCW}, was CW");
                     if (polygon.Holes[0].IsCCW)
-                        return false;
+                        Assert.Fail($"Hole[0] ring orientation requested {LinearRingOrientation.CW}, was CCW"); ;
                     if (polygon.Holes[1].IsCCW)
-                        return false;
+                        Assert.Fail($"Hole[0] ring orientation requested {LinearRingOrientation.CW}, was CCW"); ;
                     break;
                 case LinearRingOrientation.DontCare:
                     if (polygon.Shell.IsCCW != Orientation.IsCCW(origShellSequence))
-                        return false;
+                        Assert.Fail($"Shell ring orientation flipped");
                     if (polygon.Holes[0].IsCCW != Orientation.IsCCW(origHolesSequences[0]))
-                        return false;
+                        Assert.Fail($"Hole[0] ring orientation flipped");
                     if (polygon.Holes[1].IsCCW != Orientation.IsCCW(origHolesSequences[1]))
-                        return false;
+                        Assert.Fail($"Hole[1] ring orientation flipped");
                     break;
             }
 
@@ -125,18 +125,17 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             if (ringOrientation == LinearRingOrientation.CW)
             {
                 if (test.Shell.IsCCW)
-                    return false;
+                    Assert.Fail($"Buffer should return shell ring with CW orientation");
                 if (!test.Holes[0].IsCCW)
-                    return false;
+                    Assert.Fail($"Buffer should return hole ring with CCW orientation");
             }
             else if (ringOrientation == LinearRingOrientation.CCW)
             {
                 if (!test.Shell.IsCCW)
-                    return false;
+                    Assert.Fail($"Buffer should return shell ring with CCW orientation");
                 if (test.Holes[0].IsCCW)
-                    return false;
+                    Assert.Fail($"Buffer should return hole ring with CW orientation");
             }
-            return true;
         }
 
         private static Coordinate[] CreateCcwRing(int number)

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using NetTopologySuite.Algorithm;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries
+{
+    public class GeometryFactoryExTest : GeometryFactoryTest
+    {
+        [Test]
+        public void TestShellRingOrientationSetting()
+        {
+
+            // check default
+            var gf = new GeometryFactoryEx();
+            Assert.AreEqual(LinearRingOrientation.CounterClockwise, gf.OrientationOfExteriorRing);
+
+            // Check for valid ring orientation values
+            gf = new GeometryFactoryEx();
+            TestShellRingOrientationSetter(gf, LinearRingOrientation.DontCare, 0);
+            gf = new GeometryFactoryEx();
+            TestShellRingOrientationSetter(gf, LinearRingOrientation.Clockwise, 0);
+            gf = new GeometryFactoryEx();
+            TestShellRingOrientationSetter(gf, LinearRingOrientation.RightHandRule, 0);
+            gf = new GeometryFactoryEx();
+            TestShellRingOrientationSetter(gf, LinearRingOrientation.CounterClockwise, 0);
+            gf = new GeometryFactoryEx();
+            TestShellRingOrientationSetter(gf, LinearRingOrientation.LeftHandRule, 0);
+
+            // check for invalid arguments
+            gf = new GeometryFactoryEx();
+            TestShellRingOrientationSetter(gf, (LinearRingOrientation)(-2), 1);
+            TestShellRingOrientationSetter(gf, (LinearRingOrientation)2, 1);
+
+            // check preventation of setting after first usage
+            var ro = gf.OrientationOfExteriorRing;
+            // don't fail if value does not change
+            TestShellRingOrientationSetter(gf, ro, 0);
+            TestShellRingOrientationSetter(gf, LinearRingOrientation.RightHandRule, 2);
+            TestShellRingOrientationSetter(gf, LinearRingOrientation.DontCare, 2);
+        }
+
+        [Test]
+        public void TestShellRingOrientationEnforcement()
+        {
+            Assert.IsTrue(TestShellRingOrientationEnforcement(LinearRingOrientation.DontCare));
+            Assert.IsTrue(TestShellRingOrientationEnforcement(LinearRingOrientation.CounterClockwise));
+            Assert.IsTrue(TestShellRingOrientationEnforcement(LinearRingOrientation.Clockwise));
+        }
+
+        private static bool TestShellRingOrientationEnforcement(LinearRingOrientation ringOrientation)
+        {
+            var gf = new GeometryFactoryEx();
+            gf.OrientationOfExteriorRing = ringOrientation;
+            var cf = gf.CoordinateSequenceFactory;
+
+            var origShellSequence = CreateRing(cf, 0, ringOrientation);
+            var origHolesSequences = new[]
+            {
+                CreateRing(cf, 1, ringOrientation),
+                CreateRing(cf, 2, ringOrientation)
+            };
+
+            var shell = gf.CreateLinearRing(origShellSequence.Copy());
+            var holes = new LinearRing[]
+            {
+                gf.CreateLinearRing(origHolesSequences[0].Copy()),
+                gf.CreateLinearRing(origHolesSequences[1].Copy())
+            };
+
+            var polygon = gf.CreatePolygon(shell, holes);
+            switch (ringOrientation)
+            {
+                case LinearRingOrientation.CW:
+                    if (polygon.Shell.IsCCW)
+                        return false;
+                    if (!polygon.Holes[0].IsCCW)
+                        return false;
+                    if (!polygon.Holes[1].IsCCW)
+                        return false;
+                    break;
+                case LinearRingOrientation.CCW:
+                    if (!polygon.Shell.IsCCW)
+                        return false;
+                    if (polygon.Holes[0].IsCCW)
+                        return false;
+                    if (polygon.Holes[1].IsCCW)
+                        return false;
+                    break;
+                case LinearRingOrientation.DontCare:
+                    if (polygon.Shell.IsCCW != Orientation.IsCCW(origShellSequence))
+                        return false;
+                    if (polygon.Holes[0].IsCCW != Orientation.IsCCW(origHolesSequences[0]))
+                        return false;
+                    if (polygon.Holes[1].IsCCW != Orientation.IsCCW(origHolesSequences[1]))
+                        return false;
+                    break;
+            }
+
+            // Set up a polygon with hole using buffer
+            var pt = new Coordinate(0, 0);
+            var c = gf.CreatePoint(pt);
+            var b = c.Buffer(10d);
+            var s = c.Buffer(6d);
+            var test = (Polygon)b.Difference(s);
+
+            if (ringOrientation == LinearRingOrientation.CW)
+            {
+                if (test.Shell.IsCCW)
+                    return false;
+                if (!test.Holes[0].IsCCW)
+                    return false;
+            }
+            else if (ringOrientation == LinearRingOrientation.CCW)
+            {
+                if (!test.Shell.IsCCW)
+                    return false;
+                if (test.Holes[0].IsCCW)
+                    return false;
+            }
+            return true;
+        }
+
+        private static Coordinate[] CreateCcwRing(int number)
+        {
+            if (number == 0)
+                return new Coordinate[]{
+                    new Coordinate(0, 0), new Coordinate(10, 0),
+                    new Coordinate(10, 10), new Coordinate(0, 10),
+                    new Coordinate(0, 0)};
+            if (number == 1)
+                return new Coordinate[]{
+                    new Coordinate(2, 1), new Coordinate(9, 1),
+                    new Coordinate(9, 8), new Coordinate(2, 1)
+                };
+
+            return new Coordinate[]{
+                new Coordinate(1, 2), new Coordinate(8, 9),
+                new Coordinate(1, 9), new Coordinate(1, 2)
+            };
+        }
+
+        private static bool reverseSequence = false;
+
+        private static CoordinateSequence CreateRing(CoordinateSequenceFactory factory, int ring, LinearRingOrientation orientation)
+        {
+            var coordinates = CreateCcwRing(ring);
+            if (orientation == LinearRingOrientation.Clockwise)
+                CoordinateArrays.Reverse(coordinates);
+            if (orientation == LinearRingOrientation.DontCare)
+            {
+                if (reverseSequence) CoordinateArrays.Reverse(coordinates);
+                reverseSequence = !reverseSequence;
+            }
+
+            return factory.Create(coordinates);
+        }
+
+        private static void TestShellRingOrientationSetter(GeometryFactoryEx gf, LinearRingOrientation ringOrientation, int failKind)
+        {
+            try
+            {
+                gf.OrientationOfExteriorRing = ringOrientation;
+                if (failKind != 0)
+                    Assert.Fail("Setting exterior ring orientation should have failed!");
+                Assert.AreEqual(ringOrientation, gf.OrientationOfExteriorRing);
+            }
+            catch (ArgumentOutOfRangeException iae)
+            {
+                if (failKind != 1)
+                    Assert.Fail("Wrong argument");
+            }
+            catch (InvalidOperationException isa)
+            {
+                if (failKind != 2)
+                    Assert.Fail("Setting exterior ring orientation twice!");
+            }
+            catch (Exception e)
+            {
+                Assert.Fail(e.Message);
+            }
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
@@ -8,8 +8,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
     [TestFixture]
     public class GeometryFactoryTest
     {
-        private readonly static PrecisionModel PrecModel = new PrecisionModel();
-        private readonly static GeometryFactory Factory = new GeometryFactory(PrecModel, 0);
+        private static readonly PrecisionModel PrecModel = new PrecisionModel();
+        private static readonly GeometryFactory Factory = new GeometryFactory(PrecModel, 0);
         private readonly WKTReader _reader = new WKTReader(Factory);
 
         [Test]


### PR DESCRIPTION
Default `NetTopologySuite.Geometries.GeometryFactory` does not enforce a specific orientation of polygon exterior or interior rings. For reasons described in #360, there might be a need for a specfic orientation of polygon rings.

This PR includes
* New `LinearRingOrientation` enum, defining `Clockwise`, `CounterClockwise`, `DontCare` and some substitues
* New `GeometryFactoryEx` class that can enforce clockwise or counterclockwise ring orientation on a polygons exterior ring. If not configured to `DontCare`, the interior rings are oriented the other way around.
* Unit test to validate behavior.