### PR TITLE
Allow STRtree<T>.Remove to work with value types

### DIFF
--- a/src/NetTopologySuite/Index/Strtree/AbstractSTRtree.cs
+++ b/src/NetTopologySuite/Index/Strtree/AbstractSTRtree.cs
@@ -371,15 +371,9 @@ namespace NetTopologySuite.Index.Strtree
             for (var i = node.ChildBoundables.GetEnumerator(); i.MoveNext(); )
             {
                 var childBoundable = i.Current as ItemBoundable<T, TItem>;
-                if (childBoundable != null)
+                if (childBoundable != null && EqualityComparerForRemoveItem.Equals(childBoundable.Item, item))
                 {
-                    // EqualityComparerForRemoveItem might be null, to signal that we should use the
-                    // default equality comparer for the type.
-                    if (EqualityComparerForRemoveItem?.Equals(childBoundable.Item, item) ??
-                        EqualityComparer<TItem>.Default.Equals(childBoundable.Item, item))
-                    {
-                        childToRemove = childBoundable;
-                    }
+                    childToRemove = childBoundable;
                 }
             }
             if (childToRemove != null)
@@ -451,10 +445,7 @@ namespace NetTopologySuite.Index.Strtree
         {
             if (typeof(TItem).IsValueType)
             {
-                // the JIT in .NET Core can devirtualize .Equals if it has local knowledge that the
-                // equality comparer is EqualityComparer<TItem>.Default.  so return null to signal
-                // to RemoveItem that it should fetch the default in-place.
-                return null;
+                return EqualityComparer<TItem>.Default;
             }
 
             // for compatibility (and a little touch of speed in expected common cases), don't use

--- a/test/NetTopologySuite.Tests.NUnit/Index/Strtree/STRtreeTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Index/Strtree/STRtreeTest.cs
@@ -162,6 +162,8 @@ namespace NetTopologySuite.Tests.NUnit.Index.Strtree
         }
 
         [Test]
+        [Category("GitHub Issue")]
+        [Category("Issue366")]
         public void TestRemoveValueType()
         {
             var tree = new STRtree<int>();

--- a/test/NetTopologySuite.Tests.NUnit/Index/Strtree/STRtreeTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Index/Strtree/STRtreeTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Index;
 using NetTopologySuite.Index.Strtree;
@@ -158,6 +159,18 @@ namespace NetTopologySuite.Tests.NUnit.Index.Strtree
             tree.Insert(new Envelope(15, 25, 15, 25), "4");
             tree.Remove(new Envelope(10, 20, 10, 20), "4");
             Assert.AreEqual(3, tree.Count);
+        }
+
+        [Test]
+        public void TestRemoveValueType()
+        {
+            var tree = new STRtree<int>();
+            tree.Insert(new Envelope(0, 10, 0, 10), 1);
+            tree.Insert(new Envelope(5, 15, 5, 15), 2);
+            tree.Insert(new Envelope(10, 20, 10, 20), 3);
+            tree.Insert(new Envelope(15, 25, 15, 25), 4);
+            tree.Remove(new Envelope(10, 20, 10, 20), 4);
+            Assert.That(tree.ItemsTree().OfType<int>(), Is.EquivalentTo(new[] { 1, 2, 3 }));
         }
 
         [Test]


### PR DESCRIPTION
Workaround for #366

I think the **ideal** would be to allow the caller to inject the `IEqualityComparer<TItem>` (or something equivalent), or else to **always** use the default `IEqualityComparer<TItem>` for the type.

This approach, however, ensures that the only observable changes will be in cases that would have **never** worked before (or at least, they would **only** have worked on runtimes that do the same kind of box reuse that the JVM exhibits in the repro I made for locationtech/jts#497, which technically violates ECMA-355 §III.4.1 even though nobody in their right mind ought to care about that particular violation).

This approach also gives us the most flexibility to port whatever locationtech/jts#497 turns into down the road: there's no API change, and the only observable behavior change should be a subset of the changes that would come from any realistic fix for that issue.