### PR TITLE
Control Geometry overlay algorithm via factory setting

### DIFF
--- a/src/NetTopologySuite/Geometries/Geometry.cs
+++ b/src/NetTopologySuite/Geometries/Geometry.cs
@@ -2,18 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Xml;
 using NetTopologySuite.Algorithm;
-using NetTopologySuite.Geometries.Utilities;
 using NetTopologySuite.IO;
 using NetTopologySuite.IO.GML2;
 using NetTopologySuite.Operation;
 using NetTopologySuite.Operation.Buffer;
 using NetTopologySuite.Operation.Distance;
 using NetTopologySuite.Operation.Linemerge;
-using NetTopologySuite.Operation.Overlay;
-using NetTopologySuite.Operation.Overlay.Snap;
 using NetTopologySuite.Operation.Predicate;
 using NetTopologySuite.Operation.Relate;
-using NetTopologySuite.Operation.Union;
 using NetTopologySuite.Operation.Valid;
 
 namespace NetTopologySuite.Geometries
@@ -1515,8 +1511,11 @@ namespace NetTopologySuite.Geometries
         /// <returns>A geometry representing the point-set common to the two <c>Geometry</c>s.</returns>
         /// <exception cref="TopologyException">if a robustness error occurs.</exception>
         /// <exception cref="ArgumentException">if the argument is a non-empty heterogeneous <c>GeometryCollection</c></exception>
+        /// <exception cref="ArgumentException">if the argument has a factory with a different <c>GeometryOverlay</c> object assigned</exception>
         public Geometry Intersection(Geometry other)
         {
+            if (!Equals(other.Factory.GeometryOverlay, Factory.GeometryOverlay))
+                throw new ArgumentException("Geometry has factory with different GeometryOverlay operation assigned", nameof(other));
             return Factory.GeometryOverlay.Intersection(this, other);
         }
 
@@ -1552,9 +1551,12 @@ namespace NetTopologySuite.Geometries
         /// points of <c>other</c></returns>
         /// <exception cref="TopologyException">Thrown if a robustness error occurs</exception>
         /// <exception cref="ArgumentException">Thrown if either input is a non-empty GeometryCollection</exception>
+        /// <exception cref="ArgumentException">if the argument has a factory with a different <c>GeometryOverlay</c> object assigned</exception>
         /// <seealso cref="LineMerger"/>
         public Geometry Union(Geometry other)
         {
+            if (!Equals(other.Factory.GeometryOverlay, Factory.GeometryOverlay))
+                throw new ArgumentException("Geometry has factory with different GeometryOverlay operation assigned", nameof(other));
             return Factory.GeometryOverlay.Union(this, other);
         }
 
@@ -1570,8 +1572,11 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         /// <param name="other">The <c>Geometry</c> with which to compute the difference.</param>
         /// <returns>A Geometry representing the point-set difference of this <c>Geometry</c> with <c>other</c>.</returns>
+        /// <exception cref="ArgumentException">if the argument has a factory with a different <c>GeometryOverlay</c> object assigned</exception>
         public Geometry Difference(Geometry other)
         {
+            if (!Equals(other.Factory.GeometryOverlay, Factory.GeometryOverlay))
+                throw new ArgumentException("Geometry has factory with different GeometryOverlay operation assigned", nameof(other));
             return Factory.GeometryOverlay.Difference(this, other);
         }
 
@@ -1588,8 +1593,11 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         /// <param name="other">The <c>Geometry</c> with which to compute the symmetric difference.</param>
         /// <returns>a Geometry representing the point-set symmetric difference of this <c>Geometry</c> with <c>other</c>.</returns>
+        /// <exception cref="ArgumentException">if the argument has a factory with a different <c>GeometryOverlay</c> object assigned</exception>
         public Geometry SymmetricDifference(Geometry other)
         {
+            if (!Equals(other.Factory.GeometryOverlay, Factory.GeometryOverlay))
+                throw new ArgumentException("Geometry has factory with different GeometryOverlay operation assigned", nameof(other));
             return Factory.GeometryOverlay.SymmetricDifference(this, other);
         }
 

--- a/src/NetTopologySuite/Geometries/GeometryFactory.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactory.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NetTopologySuite.Geometries.Implementation;
 using NetTopologySuite.Geometries.Utilities;
 using NetTopologySuite.Utilities;
 
@@ -73,19 +72,10 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Gets a value indicating the geometry overlay function set to use
         /// </summary>
+        /// <returns>A geometry overlay function set.</returns>
         internal GeometryOverlay GeometryOverlay
         {
-            get { return _geometryOverlay ?? (_geometryOverlay = NtsGeometryServices.Instance.GeometryOverlay); }
-            set
-            {
-                if (_geometryOverlay != null)
-                    throw new InvalidOperationException("GeometryOverlay already set.");
-
-                if (value == null)
-                    value = NtsGeometryServices.Instance.GeometryOverlay;
-
-                _geometryOverlay = value;
-            }
+            get { return _geometryOverlay; }
         }
 
         /// <summary>
@@ -101,14 +91,30 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
-        /// Constructs a GeometryFactory that generates Geometries having the given
-        /// PrecisionModel, spatial-reference ID, and CoordinateSequence implementation.
+        /// Constructs a <c>GeometryFactory</c> that generates Geometries having the given
+        /// <paramref name="precisionModel">precision model</paramref>, <paramref name="srid">spatial-reference ID</paramref>, 
+        /// <paramref name="coordinateSequenceFactory">CoordinateSequence</paramref> and
+        /// <paramref name="geometryOverlay">Geometry overlay </paramref>.
         /// </summary>
-        public GeometryFactory(PrecisionModel precisionModel, int srid, CoordinateSequenceFactory coordinateSequenceFactory)
+        /// <param name="precisionModel">A precision model</param>
+        /// <param name="srid">A spatial reference id</param>
+        /// <param name="coordinateSequenceFactory">A coordinate sequence factory</param>
+        /// <param name="geometryOverlay">A geometry overlay function set</param>
+        public GeometryFactory(PrecisionModel precisionModel, int srid, CoordinateSequenceFactory coordinateSequenceFactory, GeometryOverlay geometryOverlay)
         {
             _precisionModel = precisionModel;
             _coordinateSequenceFactory = coordinateSequenceFactory;
             _srid = srid;
+            _geometryOverlay = geometryOverlay;
+        }
+
+        /// <summary>
+        /// Constructs a GeometryFactory that generates Geometries having the given
+        /// PrecisionModel, spatial-reference ID, and CoordinateSequence implementation.
+        /// </summary>
+        public GeometryFactory(PrecisionModel precisionModel, int srid, CoordinateSequenceFactory coordinateSequenceFactory)
+            : this(precisionModel, srid, coordinateSequenceFactory, NtsGeometryServices.Instance.GeometryOverlay)
+        {
         }
 
         /// <summary>
@@ -126,7 +132,7 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         /// <param name="precisionModel">The PrecisionModel to use.</param>
         public GeometryFactory(PrecisionModel precisionModel) :
-            this(precisionModel, 0, GetDefaultCoordinateSequenceFactory()) { }
+            this(precisionModel, 0, NtsGeometryServices.Instance.DefaultCoordinateSequenceFactory) { }
 
         /// <summary>
         /// Constructs a GeometryFactory that generates Geometries having the given
@@ -136,7 +142,7 @@ namespace NetTopologySuite.Geometries
         /// <param name="precisionModel">The PrecisionModel to use.</param>
         /// <param name="srid">The SRID to use.</param>
         public GeometryFactory(PrecisionModel precisionModel, int srid) :
-            this(precisionModel, srid, GetDefaultCoordinateSequenceFactory()) { }
+            this(precisionModel, srid, NtsGeometryServices.Instance.DefaultCoordinateSequenceFactory) { }
 
         /// <summary>
         /// Constructs a GeometryFactory that generates Geometries having a floating
@@ -677,9 +683,10 @@ namespace NetTopologySuite.Geometries
             return editor.Edit(g, operation);
         }
 
-        private static CoordinateSequenceFactory GetDefaultCoordinateSequenceFactory()
+        /// <inheritdoc cref="object.ToString()"/>
+        public override string ToString()
         {
-            return CoordinateArraySequenceFactory.Instance;
+            return $"{GetType().Name}[PM={PrecisionModel}, SRID={SRID}, CSFactory={CoordinateSequenceFactory.GetType().Name}, GeometryOverlay:{GeometryOverlay}]";
         }
     }
 }

--- a/src/NetTopologySuite/Geometries/GeometryFactory.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactory.cs
@@ -68,6 +68,26 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         public int SRID => _srid;
 
+        private GeometryOverlay _geometryOverlay;
+
+        /// <summary>
+        /// Gets a value indicating the geometry overlay function set to use
+        /// </summary>
+        public GeometryOverlay GeometryOverlay
+        {
+            get { return _geometryOverlay ?? (_geometryOverlay = GeometryOverlay.Default); }
+            set
+            {
+                if (_geometryOverlay != null)
+                    throw new InvalidOperationException("GeometryOverlay already set.");
+
+                if (value == null)
+                    value = GeometryOverlay.Default;
+
+                _geometryOverlay = value;
+            }
+        }
+
         /// <summary>
         ///
         /// </summary>

--- a/src/NetTopologySuite/Geometries/GeometryFactory.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactory.cs
@@ -73,16 +73,16 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Gets a value indicating the geometry overlay function set to use
         /// </summary>
-        public GeometryOverlay GeometryOverlay
+        internal GeometryOverlay GeometryOverlay
         {
-            get { return _geometryOverlay ?? (_geometryOverlay = GeometryOverlay.Default); }
+            get { return _geometryOverlay ?? (_geometryOverlay = NtsGeometryServices.Instance.GeometryOverlay); }
             set
             {
                 if (_geometryOverlay != null)
                     throw new InvalidOperationException("GeometryOverlay already set.");
 
                 if (value == null)
-                    value = GeometryOverlay.Default;
+                    value = NtsGeometryServices.Instance.GeometryOverlay;
 
                 _geometryOverlay = value;
             }

--- a/src/NetTopologySuite/Geometries/GeometryFactoryEx.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactoryEx.cs
@@ -45,10 +45,17 @@ namespace NetTopologySuite.Geometries
         /// Constructs a GeometryFactory that generates Geometries having the given
         /// PrecisionModel, spatial-reference ID, and CoordinateSequence implementation.
         /// </summary>
+        public GeometryFactoryEx(PrecisionModel precisionModel, int srid, CoordinateSequenceFactory coordinateSequenceFactory, GeometryOverlay geometryOverlay)
+            : base(precisionModel, srid, coordinateSequenceFactory, geometryOverlay)
+        { }
+
+        /// <summary>
+        /// Constructs a GeometryFactory that generates Geometries having the given
+        /// PrecisionModel, spatial-reference ID, and CoordinateSequence implementation.
+        /// </summary>
         public GeometryFactoryEx(PrecisionModel precisionModel, int srid, CoordinateSequenceFactory coordinateSequenceFactory)
             : base(precisionModel, srid, coordinateSequenceFactory)
         { }
-
         /// <summary>
         /// Constructs a GeometryFactory that generates Geometries having the given
         /// CoordinateSequence implementation, a double-precision floating PrecisionModel and a

--- a/src/NetTopologySuite/Geometries/GeometryOverlay.cs
+++ b/src/NetTopologySuite/Geometries/GeometryOverlay.cs
@@ -16,7 +16,7 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Gets a value indicating a geometry overlay operation class that uses old NTS overlay operation set.
         /// </summary>
-        public static GeometryOverlay Old
+        public static GeometryOverlay Legacy
         {
             get { return OverlayV1.Instance; }
         }
@@ -30,13 +30,32 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
-        /// 
+        /// Computes a <c>Geometry</c> representing the overlay of geometries <c>a</c> and <c>b</c>
+        /// using the spatial function defined by <c>opCode</c>.
         /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
-        /// <param name="opCode"></param>
-        /// <returns></returns>
-        protected abstract Geometry Overlay(Geometry a, Geometry b, SpatialFunction opCode);
+        /// <param name="a">The 1st geometry</param>
+        /// <param name="b">The 2nd geometry</param>
+        /// <param name="opCode">The spatial function for the overlay operation</param>
+        /// <returns>The computed geometry</returns>
+        protected Geometry Overlay(Geometry a, Geometry b, SpatialFunction opCode)
+        {
+            if (!Equals(a.Factory.GeometryOverlay, this))
+                throw new ArgumentException("Geometry has different GeometryOverlay operation assigned", nameof(a));
+            if (!Equals(b.Factory.GeometryOverlay, this))
+                throw new ArgumentException("Geometry has different GeometryOverlay operation assigned", nameof(b));
+
+            return OverlayInternal(a, b, opCode);
+        }
+
+        /// <summary>
+        /// Actual implementation of the overlay computation for geometries <c>a</c> and <c>b</c>
+        /// using the spatial function defined by <c>opCode</c>.
+        /// </summary>
+        /// <param name="a">The 1st geometry</param>
+        /// <param name="b">The 2nd geometry</param>
+        /// <param name="opCode">The spatial function for the overlay operation</param>
+        /// <returns>The computed geometry</returns>
+        protected abstract Geometry OverlayInternal(Geometry a, Geometry b, SpatialFunction opCode);
 
         /// <summary>
         /// Computes a <c>Geometry</c> representing the point-set which is
@@ -187,7 +206,7 @@ namespace NetTopologySuite.Geometries
             {
             }
 
-            protected override Geometry Overlay(Geometry geom0, Geometry geom1, SpatialFunction opCode)
+            protected override Geometry OverlayInternal(Geometry geom0, Geometry geom1, SpatialFunction opCode)
             {
                 return SnapIfNeededOverlayOp.Overlay(geom0, geom1, opCode);
             }
@@ -207,7 +226,7 @@ namespace NetTopologySuite.Geometries
             {
             }
 
-            protected override Geometry Overlay(Geometry geom0, Geometry geom1, SpatialFunction opCode)
+            protected override Geometry OverlayInternal(Geometry geom0, Geometry geom1, SpatialFunction opCode)
             {
                 return OverlayNGRobust.Overlay(geom0, geom1, opCode);
             }

--- a/src/NetTopologySuite/Geometries/GeometryOverlay.cs
+++ b/src/NetTopologySuite/Geometries/GeometryOverlay.cs
@@ -95,15 +95,15 @@ namespace NetTopologySuite.Geometries
         public virtual Geometry Union(Geometry a, Geometry b)
         {
             // handle empty geometry cases
-            if (a.IsEmpty || b.IsEmpty)
+            if (a.IsEmpty || (b == null || b.IsEmpty))
             {
                 // both empty - check dimensions
-                if (a.IsEmpty && b.IsEmpty)
+                if (a.IsEmpty && (b == null || b.IsEmpty))
                     return OverlayOp.CreateEmptyResult(SpatialFunction.Union, a, b, a.Factory);
 
                 // special case: if either input is empty ==> result = other arg
                 if (a.IsEmpty) return b.Copy();
-                if (b.IsEmpty) return a.Copy();
+                if (b == null || b.IsEmpty) return a.Copy();
             }
 
             // TODO: optimize if envelopes of geometries do not intersect
@@ -130,7 +130,7 @@ namespace NetTopologySuite.Geometries
         {
             // special case: if A.isEmpty ==> empty; if B.isEmpty ==> A
             if (a.IsEmpty) return OverlayOp.CreateEmptyResult(SpatialFunction.Difference, a, b, a.Factory);
-            if (b.IsEmpty) return a.Copy();
+            if (b == null || b.IsEmpty) return a.Copy();
 
             CheckNotGeometryCollection(a, b);
 
@@ -154,15 +154,15 @@ namespace NetTopologySuite.Geometries
         public virtual Geometry SymmetricDifference(Geometry a, Geometry b)
         {
             // handle empty geometry cases
-            if (a.IsEmpty || b.IsEmpty)
+            if (a.IsEmpty || (b == null || b.IsEmpty))
             {
                 // both empty - check dimensions
-                if (a.IsEmpty && b.IsEmpty)
+                if (a.IsEmpty && (b == null || b.IsEmpty))
                     return OverlayOp.CreateEmptyResult(SpatialFunction.SymDifference, a, b, a.Factory);
 
                 // special case: if either input is empty ==> result = other arg
                 if (a.IsEmpty) return b.Copy();
-                if (b.IsEmpty) return a.Copy();
+                if (b == null || b.IsEmpty) return a.Copy();
             }
 
             CheckNotGeometryCollection(a, b);

--- a/src/NetTopologySuite/Geometries/GeometryOverlay.cs
+++ b/src/NetTopologySuite/Geometries/GeometryOverlay.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using NetTopologySuite.Geometries.Utilities;
+using NetTopologySuite.Operation.Overlay;
+using NetTopologySuite.Operation.Overlay.Snap;
+using NetTopologySuite.Operation.OverlayNG;
+using NetTopologySuite.Operation.Union;
+
+namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// A class that encapsulates geometry overlay functionality
+    /// </summary>
+    public abstract class GeometryOverlay
+    {
+        private static GeometryOverlay _default;
+
+        /// <summary>
+        /// Gets a value indicating the default geometry overlay operation
+        /// </summary>
+        public static GeometryOverlay Default
+        {
+            get => _default ?? Old;
+            set => _default = value;
+        }
+
+        /// <summary>
+        /// Gets a value indicating a geometry overlay operation class that uses old NTS overlay operation set.
+        /// </summary>
+        public static GeometryOverlay Old
+        {
+            get { return OverlayV1.Instance; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating a geometry overlay operation class that uses next-generation NTS overlay operation set.
+        /// </summary>
+        public static GeometryOverlay NG
+        {
+            get { return OverlayV2.Instance; }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="opCode"></param>
+        /// <returns></returns>
+        protected abstract Geometry Overlay(Geometry a, Geometry b, SpatialFunction opCode);
+
+        /// <summary>
+        /// Computes a <c>Geometry</c> representing the point-set which is
+        /// common to both <c>a</c> and <c>b</c> Geometry.
+        /// </summary>
+        /// <param name="a">The 1st <c>Geometry</c></param>
+        /// <param name="b">The 2nd <c>Geometry</c></param>
+        /// <returns>A geometry representing the point-set common to the two <c>Geometry</c>s.</returns>
+        /// <seealso cref="Geometry.Intersection"/>
+        public virtual Geometry Intersection(Geometry a, Geometry b)
+        {
+            /**
+             * TODO: MD - add optimization for P-A case using Point-In-Polygon
+             */
+            // special case: if one input is empty ==> empty
+            if (a.IsEmpty || b.IsEmpty)
+                return OverlayOp.CreateEmptyResult(SpatialFunction.Intersection, a, b, a.Factory);
+
+            // compute for GCs
+            // (An inefficient algorithm, but will work)
+            // TODO: improve efficiency of computation for GCs
+            if (a.OgcGeometryType == OgcGeometryType.GeometryCollection)
+            {
+                var g2 = b;
+                return GeometryCollectionMapper.Map(
+                    (GeometryCollection) a, g => g.Intersection(g2));
+            }
+
+            // No longer needed since GCs are handled by previous code
+            //CheckNotGeometryCollection(a, b);
+
+            return Overlay(a, b, SpatialFunction.Intersection);
+        }
+
+        /// <summary>
+        /// Computes a <c>Geometry</c> representing the point-set
+        /// which is contained in both input <c>Geometry</c>s .
+        /// </summary>
+        /// <param name="a">The 1st <c>Geometry</c></param>
+        /// <param name="b">The 2nd <c>Geometry</c></param>
+        /// <returns>A point-set combining the points of
+        /// <c>Geometry</c>'s <c>a</c> and <c>b</c>.
+        /// </returns>
+        /// <seealso cref="Geometry.Union(Geometry)"/>
+        public virtual Geometry Union(Geometry a, Geometry b)
+        {
+            // handle empty geometry cases
+            if (a.IsEmpty || b.IsEmpty)
+            {
+                // both empty - check dimensions
+                if (a.IsEmpty && b.IsEmpty)
+                    return OverlayOp.CreateEmptyResult(SpatialFunction.Union, a, b, a.Factory);
+
+                // special case: if either input is empty ==> result = other arg
+                if (a.IsEmpty) return b.Copy();
+                if (b.IsEmpty) return a.Copy();
+            }
+
+            // TODO: optimize if envelopes of geometries do not intersect
+
+            CheckNotGeometryCollection(a, b);
+
+            return Overlay(a, b, SpatialFunction.Union);
+        }
+
+
+        /// <summary>
+        /// Computes a <c>Geometry</c> representing the closure of the point-set
+        /// of the points contained in this <c>Geometry</c> that are not contained in
+        /// the <c>other</c> Geometry.
+        /// </summary>
+        /// <param name="a">The 1st <c>Geometry</c></param>
+        /// <param name="b">The 2nd <c>Geometry</c></param>
+        /// <returns>
+        /// A Geometry representing the point-set difference
+        /// of <c>Geometry</c>'s <c>a</c> and <c>b</c>.
+        /// </returns>
+        /// <seealso cref="Geometry.Difference(Geometry)"/>
+        public virtual Geometry Difference(Geometry a, Geometry b)
+        {
+            // special case: if A.isEmpty ==> empty; if B.isEmpty ==> A
+            if (a.IsEmpty) return OverlayOp.CreateEmptyResult(SpatialFunction.Difference, a, b, a.Factory);
+            if (b.IsEmpty) return a.Copy();
+
+            CheckNotGeometryCollection(a, b);
+
+            return Overlay(a, b, SpatialFunction.Difference);
+        }
+
+
+        /// <summary>
+        /// Computes a <c>Geometry</c> representing the closure of the point-set
+        /// which is the union of the points in <c>Geometry</c> <c>a</c> which are not
+        /// contained in the Geometry  <c>b</c>,
+        /// with the points in the <c>b</c> Geometry not contained in the <c>Geometry</c> <c>a</c>.
+        /// </summary>
+        /// <param name="a">The 1st <c>Geometry</c></param>
+        /// <param name="b">The 2nd <c>Geometry</c></param>
+        /// <returns>
+        /// A Geometry representing the point-set symmetric difference
+        /// of <c>Geometry</c>'s <c>a</c> and <c>b</c>.
+        /// </returns>
+        /// <seealso cref="Geometry.SymmetricDifference(Geometry)"/>
+        public virtual Geometry SymmetricDifference(Geometry a, Geometry b)
+        {
+            // handle empty geometry cases
+            if (a.IsEmpty || b.IsEmpty)
+            {
+                // both empty - check dimensions
+                if (a.IsEmpty && b.IsEmpty)
+                    return OverlayOp.CreateEmptyResult(SpatialFunction.SymDifference, a, b, a.Factory);
+
+                // special case: if either input is empty ==> result = other arg
+                if (a.IsEmpty) return b.Copy();
+                if (b.IsEmpty) return a.Copy();
+            }
+
+            CheckNotGeometryCollection(a, b);
+
+            return Overlay(a, b, SpatialFunction.SymDifference);
+        }
+
+        /// <summary>
+        /// Computes the union of all the elements in the <c>Geometry</c> <c>a</c>.
+        /// </summary>
+        /// <param name="a">The <c>Geometry</c></param>
+        /// <returns>The union of <c>a</c></returns>
+        /// <seealso cref="Geometry.Union()"/>
+        public abstract Geometry Union(Geometry a);
+
+
+        private static void CheckNotGeometryCollection(Geometry a, Geometry b)
+        {
+            if (a.OgcGeometryType == OgcGeometryType.GeometryCollection)
+                throw new ArgumentException("Operation does not support GeometryCollection arguments", nameof(a));
+            if (b.OgcGeometryType == OgcGeometryType.GeometryCollection)
+                throw new ArgumentException("Operation does not support GeometryCollection arguments", nameof(b));
+        }
+
+#region Standard implementations
+
+        private sealed class OverlayV1 : GeometryOverlay
+        {
+            public static GeometryOverlay Instance { get; } = new OverlayV1();
+
+            private OverlayV1()
+            {
+            }
+
+            protected override Geometry Overlay(Geometry geom0, Geometry geom1, SpatialFunction opCode)
+            {
+                return SnapIfNeededOverlayOp.Overlay(geom0, geom1, opCode);
+            }
+
+            public override Geometry Union(Geometry a)
+            {
+                return UnaryUnionOp.Union(a);
+            }
+        }
+
+        private sealed class OverlayV2 : GeometryOverlay
+        {
+            public static GeometryOverlay Instance { get; } = new OverlayV2();
+
+            private OverlayV2()
+            {
+            }
+
+            protected override Geometry Overlay(Geometry geom0, Geometry geom1, SpatialFunction opCode)
+            {
+                return OverlayNGRobust.Overlay(geom0, geom1, opCode);
+            }
+
+            public override Geometry Union(Geometry a)
+            {
+                return OverlayNGRobust.Union(a);
+            }
+        }
+#endregion
+    }
+}

--- a/src/NetTopologySuite/Geometries/GeometryOverlay.cs
+++ b/src/NetTopologySuite/Geometries/GeometryOverlay.cs
@@ -10,6 +10,7 @@ namespace NetTopologySuite.Geometries
     /// <summary>
     /// A class that encapsulates geometry overlay functionality
     /// </summary>
+    [Serializable]
     public abstract class GeometryOverlay
     {
         private static GeometryOverlay _default;
@@ -186,8 +187,9 @@ namespace NetTopologySuite.Geometries
                 throw new ArgumentException("Operation does not support GeometryCollection arguments", nameof(b));
         }
 
-#region Standard implementations
+        #region Standard implementations
 
+        [Serializable]
         private sealed class OverlayV1 : GeometryOverlay
         {
             public static GeometryOverlay Instance { get; } = new OverlayV1();
@@ -207,6 +209,7 @@ namespace NetTopologySuite.Geometries
             }
         }
 
+        [Serializable]
         private sealed class OverlayV2 : GeometryOverlay
         {
             public static GeometryOverlay Instance { get; } = new OverlayV2();

--- a/src/NetTopologySuite/Geometries/GeometryOverlay.cs
+++ b/src/NetTopologySuite/Geometries/GeometryOverlay.cs
@@ -37,25 +37,7 @@ namespace NetTopologySuite.Geometries
         /// <param name="b">The 2nd geometry</param>
         /// <param name="opCode">The spatial function for the overlay operation</param>
         /// <returns>The computed geometry</returns>
-        protected Geometry Overlay(Geometry a, Geometry b, SpatialFunction opCode)
-        {
-            if (!Equals(a.Factory.GeometryOverlay, this))
-                throw new ArgumentException("Geometry has different GeometryOverlay operation assigned", nameof(a));
-            if (!Equals(b.Factory.GeometryOverlay, this))
-                throw new ArgumentException("Geometry has different GeometryOverlay operation assigned", nameof(b));
-
-            return OverlayInternal(a, b, opCode);
-        }
-
-        /// <summary>
-        /// Actual implementation of the overlay computation for geometries <c>a</c> and <c>b</c>
-        /// using the spatial function defined by <c>opCode</c>.
-        /// </summary>
-        /// <param name="a">The 1st geometry</param>
-        /// <param name="b">The 2nd geometry</param>
-        /// <param name="opCode">The spatial function for the overlay operation</param>
-        /// <returns>The computed geometry</returns>
-        protected abstract Geometry OverlayInternal(Geometry a, Geometry b, SpatialFunction opCode);
+        protected abstract Geometry Overlay(Geometry a, Geometry b, SpatialFunction opCode);
 
         /// <summary>
         /// Computes a <c>Geometry</c> representing the point-set which is
@@ -206,7 +188,7 @@ namespace NetTopologySuite.Geometries
             {
             }
 
-            protected override Geometry OverlayInternal(Geometry geom0, Geometry geom1, SpatialFunction opCode)
+            protected override Geometry Overlay(Geometry geom0, Geometry geom1, SpatialFunction opCode)
             {
                 return SnapIfNeededOverlayOp.Overlay(geom0, geom1, opCode);
             }
@@ -214,6 +196,11 @@ namespace NetTopologySuite.Geometries
             public override Geometry Union(Geometry a)
             {
                 return UnaryUnionOp.Union(a);
+            }
+
+            public override string ToString()
+            {
+                return "Legacy";
             }
         }
 
@@ -226,7 +213,7 @@ namespace NetTopologySuite.Geometries
             {
             }
 
-            protected override Geometry OverlayInternal(Geometry geom0, Geometry geom1, SpatialFunction opCode)
+            protected override Geometry Overlay(Geometry geom0, Geometry geom1, SpatialFunction opCode)
             {
                 return OverlayNGRobust.Overlay(geom0, geom1, opCode);
             }
@@ -235,7 +222,12 @@ namespace NetTopologySuite.Geometries
             {
                 return OverlayNGRobust.Union(a);
             }
+
+            public override string ToString()
+            {
+                return "NG";
+            }
         }
-#endregion
+        #endregion
     }
 }

--- a/src/NetTopologySuite/Geometries/GeometryOverlay.cs
+++ b/src/NetTopologySuite/Geometries/GeometryOverlay.cs
@@ -13,17 +13,6 @@ namespace NetTopologySuite.Geometries
     [Serializable]
     public abstract class GeometryOverlay
     {
-        private static GeometryOverlay _default;
-
-        /// <summary>
-        /// Gets a value indicating the default geometry overlay operation
-        /// </summary>
-        public static GeometryOverlay Default
-        {
-            get => _default ?? Old;
-            set => _default = value;
-        }
-
         /// <summary>
         /// Gets a value indicating a geometry overlay operation class that uses old NTS overlay operation set.
         /// </summary>

--- a/src/NetTopologySuite/IO/WKBReader.cs
+++ b/src/NetTopologySuite/IO/WKBReader.cs
@@ -79,6 +79,7 @@ namespace NetTopologySuite.IO
         private readonly PrecisionModel _precisionModel;
 
         private readonly NtsGeometryServices _geometryServices;
+
         /**
          * true if structurally invalid input should be reported rather than repaired.
          * At some point this could be made client-controllable.
@@ -90,6 +91,10 @@ namespace NetTopologySuite.IO
         /// </summary>
         public WKBReader() : this(NtsGeometryServices.Instance) { }
 
+        /// <summary>
+        /// Creates an instance of this class using the provided <c>NtsGeometryServices</c>
+        /// </summary>
+        /// <param name="services"></param>
         public WKBReader(NtsGeometryServices services)
         {
             services = services ?? NtsGeometryServices.Instance;
@@ -562,12 +567,21 @@ namespace NetTopologySuite.IO
             return factory.CreateGeometryCollection(geometries);
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating if a possibly encoded SRID value should be handled.
+        /// </summary>
         public bool HandleSRID { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating which ordinates can be handled.
+        /// </summary>
         public Ordinates AllowedOrdinates => Ordinates.XYZM & _sequenceFactory.Ordinates;
 
         private Ordinates _handleOrdinates;
 
+        /// <summary>
+        /// Gets a value indicating which ordinates should be handled.
+        /// </summary>
         public Ordinates HandleOrdinates
         {
             get => _handleOrdinates;

--- a/src/NetTopologySuite/NtsGeometryServices.cs
+++ b/src/NetTopologySuite/NtsGeometryServices.cs
@@ -9,6 +9,16 @@ namespace NetTopologySuite
     /// <summary>
     /// A geometry service provider class
     /// </summary>
+    /// <remarks>
+    /// When overriding this class, you need to provide a public constructor with the following arguments:
+    /// <list type="number">
+    /// <item><c>CoordinateSequenceFactory</c><description>A factory to create coordinate sequences</description></item>
+    /// <item><term><c>PrecisionModel</c></term><description>A precision model</description></item>
+    /// <item><term><c>int</c></term><description>spatial reference id (srid)</description></item>
+    /// <item><term><c>GeometryOverlay</c></term><description>A class that bundles an overlay operation function set</description></item>
+    /// </list>
+    /// <see cref="NtsGeometryServices(CoordinateSequenceFactory, PrecisionModel, int, GeometryOverlay)"/>
+    /// </remarks>
     public class NtsGeometryServices
     {
         private static volatile NtsGeometryServices s_instance = new NtsGeometryServices();
@@ -33,7 +43,8 @@ namespace NetTopologySuite
         {
         }
         /// <summary>
-        /// Creates an instance of this class, using the provided <see cref="CoordinateSequenceFactory"/>, <see cref="PrecisionModel"/> and spatial reference Id (<paramref name="srid"/>.
+        /// Creates an instance of this class, using the provided <see cref="CoordinateSequenceFactory"/>,
+        /// <see cref="PrecisionModel"/> and spatial reference Id (<paramref name="srid"/>).
         /// </summary>
         /// <param name="coordinateSequenceFactory">The coordinate sequence factory to use.</param>
         /// <param name="precisionModel">The precision model.</param>
@@ -44,7 +55,9 @@ namespace NetTopologySuite
         }
 
         /// <summary>
-        /// Creates an instance of this class, using the provided <see cref="CoordinateSequenceFactory"/>, <see cref="PrecisionModel"/> and spatial reference Id (<paramref name="srid"/>.
+        /// Creates an instance of this class, using the provided <see cref="CoordinateSequenceFactory"/>,
+        /// <see cref="PrecisionModel"/>, a spatial reference Id (<paramref name="srid"/>) and
+        /// a <see cref="Geometries.GeometryOverlay"/>.
         /// </summary>
         /// <param name="coordinateSequenceFactory">The coordinate sequence factory to use.</param>
         /// <param name="precisionModel">The precision model.</param>

--- a/src/NetTopologySuite/NtsGeometryServices.cs
+++ b/src/NetTopologySuite/NtsGeometryServices.cs
@@ -19,7 +19,7 @@ namespace NetTopologySuite
         /// Creates an instance of this class, using the <see cref="CoordinateArraySequenceFactory"/> as default and a <see cref="PrecisionModels.Floating"/> precision model. No <see cref="DefaultSRID"/> is specified
         /// </summary>
         public NtsGeometryServices()
-            : this(GeometryOverlay.Old)
+            : this(GeometryOverlay.Legacy)
         {
         }
 
@@ -39,7 +39,7 @@ namespace NetTopologySuite
         /// <param name="precisionModel">The precision model.</param>
         /// <param name="srid">The default spatial reference ID</param>
         public NtsGeometryServices(CoordinateSequenceFactory coordinateSequenceFactory, PrecisionModel precisionModel, int srid)
-            : this(coordinateSequenceFactory, precisionModel, srid, GeometryOverlay.Old)
+            : this(coordinateSequenceFactory, precisionModel, srid, GeometryOverlay.Legacy)
         {
         }
 

--- a/src/NetTopologySuite/NtsGeometryServices.cs
+++ b/src/NetTopologySuite/NtsGeometryServices.cs
@@ -12,9 +12,24 @@ namespace NetTopologySuite
     public class NtsGeometryServices
     {
         private static volatile NtsGeometryServices s_instance = new NtsGeometryServices();
+        private static GeometryOverlay _default;
+
+        /// <summary>
+        /// Gets a value indicating the default geometry overlay operation
+        /// </summary>
+        public static GeometryOverlay DefaultGeometryOverlay
+        {
+            get => _default ?? GeometryOverlay.Old;
+            set => _default = value;
+        }
 
         private readonly ConcurrentDictionary<GeometryFactoryKey, GeometryFactory> m_factories = new ConcurrentDictionary<GeometryFactoryKey, GeometryFactory>();
         private GeometryOverlay _geometryOverlay;
+
+        private static GeometryOverlay AssignGeometryOverlay()
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// Creates an instance of this class, using the <see cref="CoordinateArraySequenceFactory"/> as default and a <see cref="PrecisionModels.Floating"/> precision model. No <see cref="DefaultSRID"/> is specified
@@ -51,15 +66,18 @@ namespace NetTopologySuite
             set => s_instance = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating the operations to use for geometry overlay.  
+        /// </summary>
         public GeometryOverlay GeometryOverlay
         {
-            get { return _geometryOverlay ?? (_geometryOverlay = GeometryOverlay.Default); }
+            get { return _geometryOverlay ?? (_geometryOverlay = DefaultGeometryOverlay); }
             set
             {
                 if (_geometryOverlay != null)
                     throw new InvalidOperationException();
                 if (value == null)
-                    value = GeometryOverlay.Default;
+                    value = DefaultGeometryOverlay;
 
                 _geometryOverlay = value;
             }

--- a/src/NetTopologySuite/NtsGeometryServices.cs
+++ b/src/NetTopologySuite/NtsGeometryServices.cs
@@ -88,7 +88,7 @@ namespace NetTopologySuite
         /// Gets or sets a value indicating the operations to use for geometry overlay.  
         /// </summary>
         /// <returns>A set of geometry overlay functions.</returns>
-        internal GeometryOverlay GeometryOverlay { get; }
+        public GeometryOverlay GeometryOverlay { get; }
 
 
         /// <summary>

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -7,6 +7,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 {
     public class GeometryFactoryExTest : GeometryFactoryTest
     {
+        private static readonly NtsGeometryServices InstanceToUse = new NtsGeometryServicesEx();
         private NtsGeometryServices _oldInstance;
 
         private class NtsGeometryServicesEx : NtsGeometryServices
@@ -14,24 +15,25 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             protected override GeometryFactory CreateGeometryFactoryCore(PrecisionModel precisionModel, int srid,
                 CoordinateSequenceFactory coordinateSequenceFactory)
             {
-                return new GeometryFactoryEx(precisionModel, srid, coordinateSequenceFactory);
+                return new GeometryFactoryEx(precisionModel, srid, coordinateSequenceFactory, GeometryOverlay);
             }
         }
 
-        public GeometryFactoryExTest() : base(new GeometryFactoryEx(PrecModel, 0))
+        public GeometryFactoryExTest()
+            : base(InstanceToUse, new GeometryFactoryEx(PrecModel, 0))
         {
 
         }
 
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
+        [SetUp]
+        public void SetUp()
         {
             _oldInstance = NtsGeometryServices.Instance;
-            NtsGeometryServices.Instance = new NtsGeometryServicesEx();
+            NtsGeometryServices.Instance = InstanceToUse;
         }
 
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
+        [TearDown]
+        public void TearDown()
         {
             NtsGeometryServices.Instance = _oldInstance;
         }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -12,6 +12,15 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
         private class NtsGeometryServicesEx : NtsGeometryServices
         {
+            public NtsGeometryServicesEx() : base() {}
+
+            public NtsGeometryServicesEx(CoordinateSequenceFactory csFactory, PrecisionModel pm, int srid,
+                GeometryOverlay go) : base(csFactory,pm, srid, go)
+            {
+
+            }
+
+
             protected override GeometryFactory CreateGeometryFactoryCore(PrecisionModel precisionModel, int srid,
                 CoordinateSequenceFactory coordinateSequenceFactory)
             {

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
@@ -13,14 +13,16 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         private readonly GeometryFactory Factory;
         private readonly WKTReader _reader;
 
-        public GeometryFactoryTest() : this(new GeometryFactory())
+        public GeometryFactoryTest()
+            : this(NtsGeometryServices.Instance, NtsGeometryServices.Instance.CreateGeometryFactory())
         {
         }
 
-        public GeometryFactoryTest(GeometryFactory geometryFactory = null)
+        public GeometryFactoryTest(NtsGeometryServices ntsGeometryServices, GeometryFactory geometryFactory = null)
         {
             Factory = geometryFactory ?? new GeometryFactory();
-            _reader = new WKTReader(Factory);
+            _reader = new WKTReader(ntsGeometryServices);
+            _reader.Factory = geometryFactory ?? ntsGeometryServices.CreateGeometryFactory();
         }
 
         [Test]

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
@@ -20,9 +20,9 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
         public GeometryFactoryTest(NtsGeometryServices ntsGeometryServices, GeometryFactory geometryFactory = null)
         {
-            Factory = geometryFactory ?? new GeometryFactory();
+            Factory = geometryFactory ?? ntsGeometryServices.CreateGeometryFactory();
             _reader = new WKTReader(ntsGeometryServices);
-            _reader.Factory = geometryFactory ?? ntsGeometryServices.CreateGeometryFactory();
+            _reader.Factory = Factory;
         }
 
         [Test]

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryOverlayTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryOverlayTest.cs
@@ -3,59 +3,40 @@ using NUnit.Framework;
 
 namespace NetTopologySuite.Tests.NUnit.Geometries
 {
-    /**
- * Tests the behaviour of the {@link GeometryOverlay} class.
- * 
- * Currently does not test the reading of the system property.
- * 
- * @author mdavis
- *
- */
+    /// <summary>
+    /// Tests the behaviour of the <see cref="GeometryOverlay"/> class.
+    /// </summary>
     public class GeometryOverlayTest : GeometryTestCase
     {
-        private NtsGeometryServices _ngs;
-
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            _ngs = NtsGeometryServices.Instance;
-        }
-
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            NtsGeometryServices.Instance = _ngs;
-        }
-
         [Test]
         public void TestOverlayNGFixed()
         {
             //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_NG);
-            NtsGeometryServices.Instance = new NtsGeometryServices {GeometryOverlay = GeometryOverlay.NG};
-            var pmFixed = new PrecisionModel(1);
-            var expected = Read("POLYGON ((1 2, 4 1, 1 1, 1 2))");
+            var ntsGeometryServices = new NtsGeometryServices(GeometryOverlay.NG);
+            var expected = Read(ntsGeometryServices, "POLYGON ((1 2, 4 1, 1 1, 1 2))");
 
-            CheckIntersectionPM(pmFixed, expected);
+            var pmFixed = new PrecisionModel(1);
+            CheckIntersectionPM(ntsGeometryServices, pmFixed, expected);
         }
 
         [Test]
         public void TestOverlayNGFloat()
         {
             //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_NG);
-            NtsGeometryServices.Instance = new NtsGeometryServices {GeometryOverlay = GeometryOverlay.NG};
-            var pmFloat = new PrecisionModel();
-            var expected = Read("POLYGON ((1 1, 1 2, 4 1.25, 4 1, 1 1))");
+            var ntsGeometryServices = new NtsGeometryServices(GeometryOverlay.NG);
+            var expected = Read(ntsGeometryServices, "POLYGON ((1 1, 1 2, 4 1.25, 4 1, 1 1))");
 
-            CheckIntersectionPM(pmFloat, expected);
+            var pmFloat = new PrecisionModel();
+            CheckIntersectionPM(ntsGeometryServices, pmFloat, expected);
         }
 
-        private void CheckIntersectionPM(PrecisionModel pmFixed, Geometry expected)
+        private void CheckIntersectionPM(NtsGeometryServices ntsGeometryServices, PrecisionModel pmFixed, Geometry expected)
         {
-            var geomFactFixed = new GeometryFactory(pmFixed);
-            Assert.That(geomFactFixed.GeometryOverlay, Is.EqualTo(NtsGeometryServices.Instance.GeometryOverlay));
+            var ef = expected.Factory;
+            var geomFactFixed = new GeometryFactory(pmFixed, ef.SRID, ef.CoordinateSequenceFactory, ef.GeometryOverlay);
 
-            var a = Read(geomFactFixed, "POLYGON ((1 1, 1 2, 5 1, 1 1))");
-            var b = Read(geomFactFixed, "POLYGON ((0 3, 4 3, 4 0, 0 0, 0 3))");
+            var a = Read(ntsGeometryServices, geomFactFixed, "POLYGON ((1 1, 1 2, 5 1, 1 1))");
+            var b = Read(ntsGeometryServices, geomFactFixed, "POLYGON ((0 3, 4 3, 4 0, 0 0, 0 3))");
             var actual = a.Intersection(b);
             CheckEqual(expected, actual);
         }
@@ -65,23 +46,21 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         {
             // must set overlay method explicitly since order of tests is not deterministic
             //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_OLD);
-            NtsGeometryServices.Instance = new NtsGeometryServices {GeometryOverlay = GeometryOverlay.Old};
-            CheckIntersectionFails();
+            CheckIntersectionFails(new NtsGeometryServices(GeometryOverlay.Old));
         }
 
         [Test]
         public void TestOverlayNG()
         {
             //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_NG);
-            NtsGeometryServices.Instance = new NtsGeometryServices {GeometryOverlay = GeometryOverlay.NG};
-            CheckIntersectionSucceeds();
+            CheckIntersectionSucceeds(new NtsGeometryServices(GeometryOverlay.NG));
         }
 
-        private void CheckIntersectionFails()
+        private void CheckIntersectionFails(NtsGeometryServices ntsGeometryServices)
         {
             try
             {
-                TryIntersection();
+                TryIntersection(ntsGeometryServices);
                 Assert.Fail("Intersection operation should have failed but did not");
             }
             catch (TopologyException ex)
@@ -90,11 +69,11 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             }
         }
 
-        private void CheckIntersectionSucceeds()
+        private void CheckIntersectionSucceeds(NtsGeometryServices ntsGeometryServices)
         {
             try
             {
-                TryIntersection();
+                TryIntersection(ntsGeometryServices);
             }
             catch (TopologyException ex)
             {
@@ -102,11 +81,11 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             }
         }
 
-        private void TryIntersection()
+        private void TryIntersection(NtsGeometryServices ntsGeometryServices)
         {
-            var a = Read(NtsGeometryServices.Instance.CreateGeometryFactory(),
+            var a = Read(ntsGeometryServices,
                 "POLYGON ((-1120500.000000126 850931.058865365, -1120500.0000001257 851343.3885007716, -1120500.0000001257 851342.2386007707, -1120399.762684411 851199.4941312922, -1120500.000000126 850931.058865365))");
-            var b = Read(NtsGeometryServices.Instance.CreateGeometryFactory(),
+            var b = Read(ntsGeometryServices,
                 "POLYGON ((-1120500.000000126 851253.4627870625, -1120500.0000001257 851299.8179383819, -1120492.1498410008 851293.8417889411, -1120500.000000126 851253.4627870625))");
             var result = a.Intersection(b);
         }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryOverlayTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryOverlayTest.cs
@@ -1,0 +1,115 @@
+﻿using NetTopologySuite.Geometries;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries
+{
+    /**
+ * Tests the behaviour of the {@link GeometryOverlay} class.
+ * 
+ * Currently does not test the reading of the system property.
+ * 
+ * @author mdavis
+ *
+ */
+    public class GeometryOverlayTest : GeometryTestCase
+    {
+        private NtsGeometryServices _ngs;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _ngs = NtsGeometryServices.Instance;
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            NtsGeometryServices.Instance = _ngs;
+        }
+
+        [Test]
+        public void TestOverlayNGFixed()
+        {
+            //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_NG);
+            NtsGeometryServices.Instance = new NtsGeometryServices {GeometryOverlay = GeometryOverlay.NG};
+            var pmFixed = new PrecisionModel(1);
+            var expected = Read("POLYGON ((1 2, 4 1, 1 1, 1 2))");
+
+            CheckIntersectionPM(pmFixed, expected);
+        }
+
+        [Test]
+        public void TestOverlayNGFloat()
+        {
+            //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_NG);
+            NtsGeometryServices.Instance = new NtsGeometryServices {GeometryOverlay = GeometryOverlay.NG};
+            var pmFloat = new PrecisionModel();
+            var expected = Read("POLYGON ((1 1, 1 2, 4 1.25, 4 1, 1 1))");
+
+            CheckIntersectionPM(pmFloat, expected);
+        }
+
+        private void CheckIntersectionPM(PrecisionModel pmFixed, Geometry expected)
+        {
+            var geomFactFixed = new GeometryFactory(pmFixed);
+            Assert.That(geomFactFixed.GeometryOverlay, Is.EqualTo(GeometryOverlay.Default));
+
+            var a = Read(geomFactFixed, "POLYGON ((1 1, 1 2, 5 1, 1 1))");
+            var b = Read(geomFactFixed, "POLYGON ((0 3, 4 3, 4 0, 0 0, 0 3))");
+            var actual = a.Intersection(b);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestOverlayOld()
+        {
+            // must set overlay method explicitly since order of tests is not deterministic
+            //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_OLD);
+            NtsGeometryServices.Instance = new NtsGeometryServices {GeometryOverlay = GeometryOverlay.Old};
+            CheckIntersectionFails();
+        }
+
+        [Test]
+        public void TestOverlayNG()
+        {
+            //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_NG);
+            NtsGeometryServices.Instance = new NtsGeometryServices {GeometryOverlay = GeometryOverlay.NG};
+            CheckIntersectionSucceeds();
+        }
+
+        private void CheckIntersectionFails()
+        {
+            try
+            {
+                TryIntersection();
+                Assert.Fail("Intersection operation should have failed but did not");
+            }
+            catch (TopologyException ex)
+            {
+                // ignore - expected result
+            }
+        }
+
+        private void CheckIntersectionSucceeds()
+        {
+            try
+            {
+                TryIntersection();
+            }
+            catch (TopologyException ex)
+            {
+                Assert.Fail("Intersection operation failed.");
+            }
+        }
+
+        private void TryIntersection()
+        {
+            var a = Read(NtsGeometryServices.Instance.CreateGeometryFactory(),
+                "POLYGON ((-1120500.000000126 850931.058865365, -1120500.0000001257 851343.3885007716, -1120500.0000001257 851342.2386007707, -1120399.762684411 851199.4941312922, -1120500.000000126 850931.058865365))");
+            var b = Read(NtsGeometryServices.Instance.CreateGeometryFactory(),
+                "POLYGON ((-1120500.000000126 851253.4627870625, -1120500.0000001257 851299.8179383819, -1120492.1498410008 851293.8417889411, -1120500.000000126 851253.4627870625))");
+            var result = a.Intersection(b);
+        }
+    }
+
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryOverlayTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryOverlayTest.cs
@@ -52,7 +52,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         private void CheckIntersectionPM(PrecisionModel pmFixed, Geometry expected)
         {
             var geomFactFixed = new GeometryFactory(pmFixed);
-            Assert.That(geomFactFixed.GeometryOverlay, Is.EqualTo(GeometryOverlay.Default));
+            Assert.That(geomFactFixed.GeometryOverlay, Is.EqualTo(NtsGeometryServices.Instance.GeometryOverlay));
 
             var a = Read(geomFactFixed, "POLYGON ((1 1, 1 2, 5 1, 1 1))");
             var b = Read(geomFactFixed, "POLYGON ((0 3, 4 3, 4 0, 0 0, 0 3))");

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryOverlayTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryOverlayTest.cs
@@ -1,4 +1,6 @@
-﻿using NetTopologySuite.Geometries;
+﻿using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.Overlay;
 using NUnit.Framework;
 
 namespace NetTopologySuite.Tests.NUnit.Geometries
@@ -8,6 +10,42 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
     /// </summary>
     public class GeometryOverlayTest : GeometryTestCase
     {
+        private static (Geometry a, Geometry b) Create()
+        {
+            var i = NtsGeometryServices.Instance;
+            var gf = new GeometryFactory(i.DefaultPrecisionModel, 0, i.DefaultCoordinateSequenceFactory, GeometryOverlay.Legacy);
+            var p1 = gf.CreatePoint(new Coordinate(10, 10));
+            gf = new GeometryFactory(i.DefaultPrecisionModel, 0, i.DefaultCoordinateSequenceFactory, GeometryOverlay.NG);
+            var p2 = gf.CreatePoint(new Coordinate(11, 11));
+
+            return (p1, p2);
+        }
+
+        [TestCase(SpatialFunction.Intersection)]
+        [TestCase(SpatialFunction.Difference)]
+        [TestCase(SpatialFunction.Union)]
+        [TestCase(SpatialFunction.SymDifference)]
+        public void TestOverlayOfGeometriesWithDifferentGeometryOverlayFails(SpatialFunction opCode)
+        {
+            (var a, var b) = Create();
+
+            switch (opCode)
+            {
+                case SpatialFunction.Intersection:
+                    Assert.Throws<ArgumentException>(() => a.Intersection(b));
+                    break;
+                case SpatialFunction.Difference:
+                    Assert.Throws<ArgumentException>(() => a.Difference(b));
+                    break;
+                case SpatialFunction.Union:
+                    Assert.Throws<ArgumentException>(() => a.Union(b));
+                    break;
+                case SpatialFunction.SymDifference:
+                    Assert.Throws<ArgumentException>(() => a.SymmetricDifference(b));
+                    break;
+            }
+        }
+
         [Test]
         public void TestOverlayNGFixed()
         {
@@ -46,7 +84,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         {
             // must set overlay method explicitly since order of tests is not deterministic
             //GeometryOverlay.setOverlayImpl(GeometryOverlay.OVERLAY_PROPERTY_VALUE_OLD);
-            CheckIntersectionFails(new NtsGeometryServices(GeometryOverlay.Old));
+            CheckIntersectionFails(new NtsGeometryServices(GeometryOverlay.Legacy));
         }
 
         [Test]

--- a/test/NetTopologySuite.Tests.NUnit/GeometryTestCase.cs
+++ b/test/NetTopologySuite.Tests.NUnit/GeometryTestCase.cs
@@ -107,6 +107,40 @@ namespace NetTopologySuite.Tests.NUnit
             }
         }
 
+        /// <summary>
+        /// Reads a <see cref="Geometry"/> from a WKT string using a custom <see cref="GeometryFactory"/>.
+        /// </summary>
+        /// <param name="ntsGeometryServices">The geometry services class to use.</param>
+        /// <param name="wkt">The WKT string</param>
+        /// <returns>The geometry read</returns>
+        protected static Geometry Read(NtsGeometryServices ntsGeometryServices, string wkt) =>
+            Read(ntsGeometryServices, ntsGeometryServices.CreateGeometryFactory(), wkt);
+
+        /// <summary>
+        /// Reads a <see cref="Geometry"/> from a WKT string using a custom <see cref="GeometryFactory"/>.
+        /// </summary>
+        /// <param name="ntsGeometryServices">The geometry services class to use.</param>
+        /// <param name="factory">The geometry factory class that serves as a template.</param>
+        /// <param name="wkt">The WKT string</param>
+        /// <returns>The geometry read</returns>
+        protected static Geometry Read(NtsGeometryServices ntsGeometryServices, GeometryFactory factory, string wkt)
+        {
+            var reader = new WKTReader(ntsGeometryServices);
+            try
+            {
+                reader.Factory = factory;
+                return reader.Read(wkt);
+            }
+            catch (ArgumentException e)
+            {
+                throw new AssertionException(e.Message, e);
+            }
+            catch (ParseException e)
+            {
+                throw new AssertionException(e.Message, e);
+            }
+        }
+
         protected Geometry Read(string wkt)
         {
             //return Read(_readerWKT, wkt);

--- a/test/NetTopologySuite.Tests.NUnit/Operation/Union/CascadedPolygonUnionTester.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/Union/CascadedPolygonUnionTester.cs
@@ -76,7 +76,7 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Union
                     //        System.out.println("Adding geom #" + count);
                 }
             }
-            Console.Write("\n");
+            Console.WriteLine("\nDone!");
             return unionAll;
         }
 


### PR DESCRIPTION
With https://github.com/locationtech/jts/commit/31cb7b640a8b9552b912a6ac96a6e5795b6c0957 JTS delegated computation of  Geometry overlay functions to a special class (`GeometryOverlay`). It controls which algorithm to use by evaluating a system property.

In regard to #447 and the multiple compaints abount distance and area computations in EF context we should consider to take another approach and delegate these operations to the GeometryFactory.

