### PR TITLE
Fix #469: Geo collections now validate against XML schema of GML 2

### DIFF
--- a/src/NetTopologySuite/IO/GML2/GMLWriter.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLWriter.cs
@@ -408,7 +408,12 @@ namespace NetTopologySuite.IO.GML2
             return InitValue + CoordSize;
         }
 
-        protected string GetEpsCode(int srid) {
+        /// <summary>
+        /// Provides the EPSG code exposing the SRID of the geometry
+        /// </summary>
+        /// <param name="srid">The SRID of the geometry</param>
+        /// <returns></returns>
+        protected virtual string GetEpsgCode(int srid) {
             return $"EPSG:{srid}";
         }
     }

--- a/src/NetTopologySuite/IO/GML2/GMLWriter.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLWriter.cs
@@ -221,7 +221,7 @@ namespace NetTopologySuite.IO.GML2
             if (_gmlVersion == GMLVersion.Two)
             {
                 // Required in version 2
-                writer.WriteAttributeString("srsName", GetEpsCode(multiPoint.Factory.SRID));
+                writer.WriteAttributeString("srsName", GetEpsgCode(multiPoint.Factory.SRID));
             }
             for (int i = 0; i < multiPoint.NumGeometries; i++)
             {
@@ -243,7 +243,7 @@ namespace NetTopologySuite.IO.GML2
             if (_gmlVersion == GMLVersion.Two)
             {
                 // Required in version 2
-                writer.WriteAttributeString("srsName", GetEpsCode(multiLineString.Factory.SRID));
+                writer.WriteAttributeString("srsName", GetEpsgCode(multiLineString.Factory.SRID));
             }
             for (int i = 0; i < multiLineString.NumGeometries; i++)
             {
@@ -265,7 +265,7 @@ namespace NetTopologySuite.IO.GML2
             if (_gmlVersion == GMLVersion.Two)
             {
                 // Required in version 2
-                writer.WriteAttributeString("srsName", GetEpsCode(multiPolygon.Factory.SRID));
+                writer.WriteAttributeString("srsName", GetEpsgCode(multiPolygon.Factory.SRID));
             }
             for (int i = 0; i < multiPolygon.NumGeometries; i++)
             {
@@ -287,7 +287,7 @@ namespace NetTopologySuite.IO.GML2
             if (_gmlVersion == GMLVersion.Two)
             {
                 // Required in version 2
-                writer.WriteAttributeString("srsName", GetEpsCode(geometryCollection.Factory.SRID));
+                writer.WriteAttributeString("srsName", GetEpsgCode(geometryCollection.Factory.SRID));
             }
             for (int i = 0; i < geometryCollection.NumGeometries; i++)
             {

--- a/src/NetTopologySuite/IO/GML2/GMLWriter.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLWriter.cs
@@ -218,6 +218,11 @@ namespace NetTopologySuite.IO.GML2
         protected void Write(MultiPoint multiPoint, XmlWriter writer)
         {
             writer.WriteStartElement(GMLElements.gmlPrefix, "MultiPoint", GMLElements.gmlNS);
+            if (_gmlVersion == GMLVersion.Two)
+            {
+                // Required in version 2
+                writer.WriteAttributeString("srsName", GetEpsCode(multiPoint.Factory.SRID));
+            }
             for (int i = 0; i < multiPoint.NumGeometries; i++)
             {
                 writer.WriteStartElement("pointMember", GMLElements.gmlNS);
@@ -235,6 +240,11 @@ namespace NetTopologySuite.IO.GML2
         protected void Write(MultiLineString multiLineString, XmlWriter writer)
         {
             writer.WriteStartElement(GMLElements.gmlPrefix, "MultiLineString", GMLElements.gmlNS);
+            if (_gmlVersion == GMLVersion.Two)
+            {
+                // Required in version 2
+                writer.WriteAttributeString("srsName", GetEpsCode(multiLineString.Factory.SRID));
+            }
             for (int i = 0; i < multiLineString.NumGeometries; i++)
             {
                 writer.WriteStartElement("lineStringMember", GMLElements.gmlNS);
@@ -252,6 +262,11 @@ namespace NetTopologySuite.IO.GML2
         protected void Write(MultiPolygon multiPolygon, XmlWriter writer)
         {
             writer.WriteStartElement(GMLElements.gmlPrefix, "MultiPolygon", GMLElements.gmlNS);
+            if (_gmlVersion == GMLVersion.Two)
+            {
+                // Required in version 2
+                writer.WriteAttributeString("srsName", GetEpsCode(multiPolygon.Factory.SRID));
+            }
             for (int i = 0; i < multiPolygon.NumGeometries; i++)
             {
                 writer.WriteStartElement("polygonMember", GMLElements.gmlNS);
@@ -269,6 +284,11 @@ namespace NetTopologySuite.IO.GML2
         protected void Write(GeometryCollection geometryCollection, XmlWriter writer)
         {
             writer.WriteStartElement(GMLElements.gmlPrefix, "MultiGeometry", GMLElements.gmlNS);
+            if (_gmlVersion == GMLVersion.Two)
+            {
+                // Required in version 2
+                writer.WriteAttributeString("srsName", GetEpsCode(geometryCollection.Factory.SRID));
+            }
             for (int i = 0; i < geometryCollection.NumGeometries; i++)
             {
                 writer.WriteStartElement("geometryMember", GMLElements.gmlNS);
@@ -386,6 +406,10 @@ namespace NetTopologySuite.IO.GML2
         protected int SetByteStreamLength(Point point)
         {
             return InitValue + CoordSize;
+        }
+
+        protected string GetEpsCode(int srid) {
+            return $"EPSG:{srid}";
         }
     }
 }

--- a/test/NetTopologySuite.Samples.Console/Tests/Various/Issue469Tests.cs
+++ b/test/NetTopologySuite.Samples.Console/Tests/Various/Issue469Tests.cs
@@ -1,0 +1,114 @@
+﻿using NetTopologySuite.IO;
+using NetTopologySuite.IO.GML2;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Schema;
+using NetTopologySuite.Geometries;
+using System.IO;
+
+namespace NetTopologySuite.Samples.Tests.Various
+{
+    public class Issue469Tests
+    {
+        [Test, Category("Issue469")]
+        public void Issue469MultiPolygon()
+        {
+            int srid = 31370;
+            var geometry = new WKTReader(new NtsGeometryServices(new PrecisionModel(), srid)).Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
+
+            var gmlWriter = new GMLWriter();
+            var reader = gmlWriter.Write(geometry);
+            var document = XDocument.Load(reader);
+
+            document.Validate(CreateSchemaSet(), (sender, args) =>
+            {
+                Assert.Fail(args.Message);
+            });
+
+            var element = document.Element(XName.Get($"{geometry.GeometryType}", "http://www.opengis.net/gml"));
+            var attribute = element.Attribute(XName.Get("srsName"));
+            Assert.IsNotNull(attribute);
+            Assert.AreEqual(attribute.Value, $"EPSG:{geometry.Factory.SRID}");
+            Assert.AreEqual(attribute.Value, $"EPSG:{srid}");
+        }
+
+        [Test, Category("Issue469")]
+        public void Issue469MultiLineString()
+        {
+            int srid = 31370;
+            var geometry = new WKTReader(new NtsGeometryServices(new PrecisionModel(), srid)).Read("MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
+
+            var gmlWriter = new GMLWriter();
+            var reader = gmlWriter.Write(geometry);
+            var document = XDocument.Load(reader);
+
+            document.Validate(CreateSchemaSet(), (sender, args) =>
+            {
+                Assert.Fail(args.Message);
+            });
+
+            var element = document.Element(XName.Get($"{geometry.GeometryType}", "http://www.opengis.net/gml"));
+            var attribute = element.Attribute(XName.Get("srsName"));
+            Assert.IsNotNull(attribute);
+            Assert.AreEqual(attribute.Value, $"EPSG:{geometry.Factory.SRID}");
+            Assert.AreEqual(attribute.Value, $"EPSG:{srid}");
+        }
+
+        [Test, Category("Issue469")]
+        public void Issue469MultiPoint()
+        {
+            int srid = 31370;
+            var geometry = new WKTReader(new NtsGeometryServices(new PrecisionModel(), srid)).Read("MULTIPOINT (10 40, 40 30, 20 20, 30 10)");
+
+            var gmlWriter = new GMLWriter();
+            var reader = gmlWriter.Write(geometry);
+            var document = XDocument.Load(reader);
+
+            document.Validate(CreateSchemaSet(), (sender, args) =>
+            {
+                Assert.Fail(args.Message);
+            });
+
+            var element = document.Element(XName.Get($"{geometry.GeometryType}", "http://www.opengis.net/gml"));
+            var attribute = element.Attribute(XName.Get("srsName"));
+            Assert.IsNotNull(attribute);
+            Assert.AreEqual(attribute.Value, $"EPSG:{geometry.Factory.SRID}");
+            Assert.AreEqual(attribute.Value, $"EPSG:{srid}");
+        }
+
+        [Test, Category("Issue469")]
+        public void Issue469GeometryCollection()
+        {
+            int srid = 31370;
+            var geometry = new WKTReader(new NtsGeometryServices(new PrecisionModel(), srid)).Read("GEOMETRYCOLLECTION (POINT (40 10), LINESTRING(10 10, 20 20, 10 40), POLYGON((40 40, 20 45, 45 30, 40 40)))");
+
+            var gmlWriter = new GMLWriter();
+            var reader = gmlWriter.Write(geometry);
+            var document = XDocument.Load(reader);
+
+            document.Validate(CreateSchemaSet(), (sender, args) =>
+            {
+                Assert.Fail(args.Message);
+            });
+
+            var element = document.Element(XName.Get("MultiGeometry", "http://www.opengis.net/gml"));
+            var attribute = element.Attribute(XName.Get("srsName"));
+            Assert.IsNotNull(attribute);
+            Assert.AreEqual(attribute.Value, $"EPSG:{geometry.Factory.SRID}");
+            Assert.AreEqual(attribute.Value, $"EPSG:{srid}");
+        }
+
+        private XmlSchemaSet CreateSchemaSet()
+        {
+            var schemaSet = new XmlSchemaSet();
+            schemaSet.Add("http://www.opengis.net/gml", "http://schemas.opengis.net/gml/2.1.2/geometry.xsd");
+            schemaSet.Add("http://www.w3.org/1999/xlink", "https://www.w3.org/1999/xlink.xsd");
+            schemaSet.Add("http://www.w3.org/XML/1998/namespace", "http://www.w3.org/2001/xml.xsd");
+            return schemaSet;
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description
Added a fix so the Geometry collections written to GML are now valid against the GML 2.1.2 spec described in the following xsd (http://schemas.opengis.net/gml/2.1.2/geometry.xsd). In here it is required to have an `srsName` attribute on the geometry collection element. (MultiPoint, MultiLineString, MultiPolygon, MultiGeometry) 
