### PR TITLE
Deviate from JTS in extra-dimension coordinate handling.

### DIFF
--- a/src/NetTopologySuite/Geometries/CoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateSequenceFactory.cs
@@ -38,14 +38,36 @@ namespace NetTopologySuite.Geometries
         /// <returns>A coordinate sequence.</returns>
         public virtual CoordinateSequence Create(Coordinate[] coordinates)
         {
-            var result = Create(coordinates?.Length ?? 0, CoordinateArrays.Dimension(coordinates), CoordinateArrays.Measures(coordinates));
+            int dimension = CoordinateArrays.Dimension(coordinates);
+            int measures = CoordinateArrays.Measures(coordinates);
+            var result = Create(coordinates?.Length ?? 0, dimension, measures);
             if (coordinates != null)
             {
+                int spatial = dimension - measures;
                 for (int i = 0; i < coordinates.Length; i++)
                 {
-                    for (int dim = 0; dim < result.Dimension; dim++)
+                    var coord = coordinates[i];
+                    int coordDimension = Coordinates.Dimension(coord);
+                    int coordMeasures = Coordinates.Measures(coord);
+                    int coordSpatial = coordDimension - coordMeasures;
+                    for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
                     {
-                        result.SetOrdinate(i, dim, coordinates[i][dim]);
+                        result.SetOrdinate(i, dim, coord[dim]);
+                    }
+
+                    for (int dim = coordSpatial; dim < spatial; dim++)
+                    {
+                        result.SetOrdinate(i, dim, Coordinate.NullOrdinate);
+                    }
+
+                    for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
+                    {
+                        result.SetOrdinate(i, spatial + measure, coord[coordSpatial + measure]);
+                    }
+
+                    for (int measure = coordMeasures; measure < measures; measure++)
+                    {
+                        result.SetOrdinate(i, spatial + measure, Coordinate.NullOrdinate);
                     }
                 }
             }

--- a/src/NetTopologySuite/Geometries/CoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateSequenceFactory.cs
@@ -111,6 +111,7 @@ namespace NetTopologySuite.Geometries
         /// <param name="dimension">the dimension of the coordinates in the sequence
         /// (if user-specifiable, otherwise ignored)</param>
         /// <returns>A coordinate sequence</returns>
+        [Obsolete("Use an overload that accepts measures.  This overload will be removed in a future release.")]
         public CoordinateSequence Create(int size, int dimension) => Create(size, dimension, 0);
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/CoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateSequenceFactory.cs
@@ -31,7 +31,7 @@ namespace NetTopologySuite.Geometries
         public Ordinates Ordinates { get; }
 
         /// <summary>
-        /// Returns a <see cref="CoordinateSequence" /> based on the given array; 
+        /// Returns a <see cref="CoordinateSequence" /> based on the given array;
         /// whether or not the array is copied is implementation-dependent.
         /// </summary>
         /// <param name="coordinates">A coordinates array, which may not be null nor contain null elements</param>
@@ -87,10 +87,10 @@ namespace NetTopologySuite.Geometries
         /// An error should not be thrown.
         /// </remarks>
         /// <param name="size"></param>
-        /// <param name="dimension">the dimension of the coordinates in the sequence 
+        /// <param name="dimension">the dimension of the coordinates in the sequence
         /// (if user-specifiable, otherwise ignored)</param>
         /// <returns>A coordinate sequence</returns>
-        public /*virtual*/ CoordinateSequence Create(int size, int dimension) => Create(size, dimension, Math.Max(0, dimension - 3));
+        public CoordinateSequence Create(int size, int dimension) => Create(size, dimension, 0);
 
         /// <summary>
         /// Creates a <see cref="CoordinateSequence" /> of the specified size and dimension

--- a/src/NetTopologySuite/Geometries/CoordinateSequences.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateSequences.cs
@@ -127,7 +127,7 @@ namespace NetTopologySuite.Geometries
 
         private static CoordinateSequence CreateClosedRing(CoordinateSequenceFactory fact, CoordinateSequence seq, int size)
         {
-            var newseq = fact.Create(size, seq.Dimension);
+            var newseq = fact.Create(size, seq.Dimension, seq.Measures);
             int n = seq.Count;
             Copy(seq, 0, newseq, 0, n);
             // fill remaining coordinates with start point
@@ -142,7 +142,7 @@ namespace NetTopologySuite.Geometries
         /// Because coordinate sequences are fix in size, extending is done by
         /// creating a new coordinate sequence of the requested size.
         /// <para/>
-        /// The new, trailing coordinate entries (if any) are filled with the last 
+        /// The new, trailing coordinate entries (if any) are filled with the last
         /// coordinate of the input sequence
         /// </summary>
         /// <param name="fact">The factory to use when creating the new sequence.</param>

--- a/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequence.cs
@@ -77,7 +77,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </summary>
         /// <param name="size">The size of the sequence to create.</param>
         public CoordinateArraySequence(int size)
-            : this(size, 2) { }
+            : this(size, 2, 0) { }
 
         /// <summary>
         /// Constructs a sequence of a given <paramref name="size"/>, populated

--- a/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequence.cs
@@ -105,7 +105,7 @@ namespace NetTopologySuite.Geometries.Implementation
         {
             Coordinates = new Coordinate[size];
             for (int i = 0; i < size; i++)
-                Coordinates[i] = CreateCoordinate();
+                Coordinates[i] = Geometries.Coordinates.Create(dimension, measures);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequence.cs
@@ -32,7 +32,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </remarks>
         /// <param name="coordinates">The coordinate array that will be referenced.</param>
         public CoordinateArraySequence(Coordinate[] coordinates)
-            : this(coordinates, CoordinateArrays.Dimension(coordinates), CoordinateArrays.Measures(coordinates)) { }
+            : this(coordinates, GetDimensionAndMeasures(coordinates, out int measures), measures) { }
 
         /// <summary>
         /// Constructs a sequence based on the given array
@@ -41,8 +41,9 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <remarks>The Array is not copied</remarks>
         /// <param name="coordinates">The coordinate array that will be referenced.</param>
         /// <param name="dimension">The dimension of the coordinates</param>
+        [Obsolete("Use an overload that accepts measures.  This overload will be removed in a future release.")]
         public CoordinateArraySequence(Coordinate[] coordinates, int dimension)
-            : this(coordinates, dimension, CoordinateArrays.Measures(coordinates))
+            : this(coordinates, GetDimensionAndMeasures(coordinates, out int measures), measures)
         {
         }
 
@@ -59,7 +60,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <param name="dimension">The dimension of the coordinates</param>
         /// <param name="measures">The number of measure ordinate values.</param>
         public CoordinateArraySequence(Coordinate[] coordinates, int dimension, int measures)
-            :base(coordinates?.Length ?? 0, dimension, measures)
+            : base(coordinates?.Length ?? 0, dimension, measures)
         {
             if (coordinates == null)
             {
@@ -84,6 +85,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </summary>
         /// <param name="size">The size of the sequence to create.</param>
         /// <param name="dimension">the dimension of the coordinates</param>
+        [Obsolete("Use an overload that accepts measures.  This overload will be removed in a future release.")]
         public CoordinateArraySequence(int size, int dimension)
             : base(size, dimension, 0)
         {
@@ -368,7 +370,7 @@ namespace NetTopologySuite.Geometries.Implementation
             {
                 coordinates[Count - i - 1] = Coordinates[i].Copy();
             }
-            return new CoordinateArraySequence(coordinates, Dimension);
+            return new CoordinateArraySequence(coordinates, Dimension, Measures);
         }
 
         /// <summary>
@@ -391,6 +393,13 @@ namespace NetTopologySuite.Geometries.Implementation
                 return strBuf.ToString();
             }
             else return "()";
+        }
+
+        private static int GetDimensionAndMeasures(Coordinate[] coords, out int measures)
+        {
+            int dimension;
+            (_, dimension, measures) = CoordinateSequenceFactory.GetCommonSequenceParameters(coords);
+            return dimension;
         }
     }
 }

--- a/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequenceFactory.cs
@@ -36,6 +36,8 @@ namespace NetTopologySuite.Geometries.Implementation
         {
             int spatial = dimension - measures;
 
+            // DEVIATION: JTS can't create Coordinate instances other than XY, XYZ, XYM, or XYZM.
+            // we can, so no need to clip spatial / measures.
             if (spatial < 2)
             {
                 spatial = 2; // handle bogus dimension

--- a/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequenceFactory.cs
@@ -36,17 +36,6 @@ namespace NetTopologySuite.Geometries.Implementation
         {
             int spatial = dimension - measures;
 
-            if (measures > 1)
-            {
-                measures = 1; // clip measures
-            }
-
-            if (spatial > 3)
-            {
-                spatial = 3; // clip spatial dimension
-                // throw new ArgumentException("spatial dimension must be <= 3");
-            }
-
             if (spatial < 2)
             {
                 spatial = 2; // handle bogus dimension

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
@@ -118,6 +118,13 @@ namespace NetTopologySuite.Geometries.Implementation
             return this.GetCoordinateCopy(index);
         }
 
+        private protected static int GetDimensionAndMeasures(Coordinate[] coords, out int measures)
+        {
+            int dimension;
+            (_, dimension, measures) = CoordinateSequenceFactory.GetCommonSequenceParameters(coords);
+            return dimension;
+        }
+
         [OnDeserialized]
         private void OnDeserialization(StreamingContext context)
         {
@@ -180,7 +187,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </summary>
         /// <param name="coords">An array of <see cref="Coordinate"/>s.</param>
         public PackedDoubleCoordinateSequence(Coordinate[] coords)
-            : this(coords, PackedCoordinateSequenceFactory.DefaultDimension)
+            : this(coords, GetDimensionAndMeasures(coords, out int measures), measures)
         { }
 
         /// <summary>
@@ -190,7 +197,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <param name="dimension">The total number of ordinates that make up a <see cref="Coordinate"/> in this sequence.</param>
         [Obsolete("Use an overload that accepts measures.  This overload will be removed in a future release.")]
         public PackedDoubleCoordinateSequence(Coordinate[] coords, int dimension)
-            : this(coords, dimension, PackedCoordinateSequenceFactory.DefaultMeasures)
+            : this(coords, GetDimensionAndMeasures(coords, out int measures), measures)
         {
         }
 
@@ -402,7 +409,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </summary>
         /// <param name="coords">An array of <see cref="Coordinate"/>s.</param>
         public PackedFloatCoordinateSequence(Coordinate[] coords)
-            : this(coords, PackedCoordinateSequenceFactory.DefaultDimension)
+            : this(coords, GetDimensionAndMeasures(coords, out int measures), measures)
         { }
 
         /// <summary>
@@ -412,7 +419,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <param name="dimension">The total number of ordinates that make up a <see cref="Coordinate"/> in this sequence.</param>
         [Obsolete("Use an overload that accepts measures.  This overload will be removed in a future release.")]
         public PackedFloatCoordinateSequence(Coordinate[] coords, int dimension)
-            : this(coords, dimension, PackedCoordinateSequenceFactory.DefaultMeasures)
+            : this(coords, GetDimensionAndMeasures(coords, out int measures), measures)
         {
         }
 
@@ -566,6 +573,5 @@ namespace NetTopologySuite.Geometries.Implementation
             }
             return new PackedDoubleCoordinateSequence(coords, dim, Measures);
         }
-
     }
 }

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
@@ -43,43 +43,7 @@ namespace NetTopologySuite.Geometries.Implementation
             var arr = GetCachedCoords();
             if(arr != null)
                  return arr[i];
-            return GetCoordinateInternal(i);
-        }
-
-        /// <summary>
-        /// Returns a copy of the i'th coordinate in this sequence.
-        /// This method optimizes the situation where the caller is
-        /// going to make a copy anyway - if the implementation
-        /// has already created a new Coordinate object, no further copy is needed.
-        /// </summary>
-        /// <param name="i">The index of the coordinate to retrieve.</param>
-        /// <returns>
-        /// A copy of the i'th coordinate in the sequence
-        /// </returns>
-        public sealed override Coordinate GetCoordinateCopy(int i)
-        {
-            return GetCoordinateInternal(i);
-        }
-
-        /// <summary>
-        /// Copies the i'th coordinate in the sequence to the supplied Coordinate.
-        /// Only the first two dimensions are copied.
-        /// </summary>
-        /// <param name="i">The index of the coordinate to copy.</param>
-        /// <param name="c">A Coordinate to receive the value.</param>
-        public sealed override void GetCoordinate(int i, Coordinate c)
-        {
-            c.X = GetOrdinate(i, 0);
-            c.Y = GetOrdinate(i, 1);
-            if (HasZ)
-            {
-                c.Z = GetZ(i);
-            }
-
-            if (HasM)
-            {
-                c.M = GetM(i);
-            }
+            return GetCoordinateCopy(i);
         }
 
         /// <summary>
@@ -100,7 +64,7 @@ namespace NetTopologySuite.Geometries.Implementation
 
             arr = new Coordinate[Count];
             for (int i = 0; i < arr.Length; i++)
-                arr[i] = GetCoordinateInternal(i);
+                arr[i] = GetCoordinateCopy(i);
 
             CoordRef = new WeakReference(arr);
             return arr;
@@ -132,69 +96,6 @@ namespace NetTopologySuite.Geometries.Implementation
             return null;
         }
 
-        /// <summary>
-        /// Returns ordinate X (0) of the specified coordinate.
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns>
-        /// The value of the X ordinate in the index'th coordinate.
-        /// </returns>
-        public sealed override double GetX(int index)
-        {
-            return GetOrdinate(index, 0);
-        }
-
-        /// <summary>
-        /// Returns ordinate Y (1) of the specified coordinate.
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns>
-        /// The value of the Y ordinate in the index'th coordinate.
-        /// </returns>
-        public sealed override double GetY(int index)
-        {
-            return GetOrdinate(index, 1);
-        }
-
-        /// <summary>
-        /// Returns ordinate Z of the specified coordinate if available.
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns>
-        /// The value of the Z ordinate in the index'th coordinate, or Double.NaN if not defined.
-        /// </returns>
-        public sealed override double GetZ(int index)
-        {
-            if (HasZ)
-            {
-                return GetOrdinate(index, 2);
-            }
-            else
-            {
-                return double.NaN;
-            }
-        }
-
-        /// <summary>
-        /// Returns ordinate M of the specified coordinate if available.
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns>
-        /// The value of the M ordinate in the index'th coordinate, or Double.NaN if not defined.
-        /// </returns>
-        public sealed override double GetM(int index)
-        {
-            if (HasM)
-            {
-                int mIndex = Dimension - Measures;
-                return GetOrdinate(index, mIndex);
-            }
-            else
-            {
-                return Coordinate.NullOrdinate;
-            }
-        }
-
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString()
         {
@@ -207,7 +108,11 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </summary>
         /// <param name="index">The coordinate index</param>
         /// <returns>The <see cref="Coordinate"/> at the given index</returns>
-        protected abstract Coordinate GetCoordinateInternal(int index);
+        [Obsolete("Unused.  This will be removed in a future release.")]
+        protected virtual Coordinate GetCoordinateInternal(int index)
+        {
+            return this.GetCoordinateCopy(index);
+        }
 
         [OnDeserialized]
         private void OnDeserialization(StreamingContext context)
@@ -280,7 +185,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <param name="coords">An array of <see cref="Coordinate"/>s.</param>
         /// <param name="dimension">The total number of ordinates that make up a <see cref="Coordinate"/> in this sequence.</param>
         public PackedDoubleCoordinateSequence(Coordinate[] coords, int dimension)
-            : this(coords, dimension, Math.Max(0, dimension - 3))
+            : this(coords, dimension, PackedCoordinateSequenceFactory.DefaultMeasures)
         {
         }
 
@@ -319,41 +224,6 @@ namespace NetTopologySuite.Geometries.Implementation
             : base(size, dimension, measures)
         {
             _coords = new double[size * Dimension];
-        }
-
-        /// <summary>
-        /// Returns a Coordinate representation of the specified coordinate, by always
-        /// building a new Coordinate object.
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
-        protected override Coordinate GetCoordinateInternal(int index)
-        {
-            double x = _coords[index * Dimension];
-            double y = _coords[index * Dimension + 1];
-            if (Dimension == 2 && Measures == 0)
-            {
-                return new Coordinate(x, y);
-            }
-            else if (Dimension == 3 && Measures == 0)
-            {
-                double z = _coords[index * Dimension + 2];
-                return new CoordinateZ(x, y, z);
-            }
-            else if (Dimension == 3 && Measures == 1)
-            {
-                double m = _coords[index * Dimension + 2];
-                return new CoordinateM(x, y, m);
-            }
-            else if (Dimension == 4)
-            {
-                double z = _coords[index * Dimension + 2];
-                double m = _coords[index * Dimension + 3];
-                return new CoordinateZM(x, y, z, m);
-            }
-
-            // note: JTS's "Coordinate" is our "CoordinateZ".
-            return new CoordinateZ(x, y);
         }
 
         /// <summary>
@@ -498,7 +368,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <param name="coords">An array of <see cref="Coordinate"/>s.</param>
         /// <param name="dimension">The total number of ordinates that make up a <see cref="Coordinate"/> in this sequence.</param>
         public PackedFloatCoordinateSequence(Coordinate[] coords, int dimension)
-            : this(coords, dimension, Math.Max(0, dimension - 3))
+            : this(coords, dimension, PackedCoordinateSequenceFactory.DefaultMeasures)
         {
         }
 
@@ -537,41 +407,6 @@ namespace NetTopologySuite.Geometries.Implementation
             : base(size, dimension, measures)
         {
             _coords = new float[size * Dimension];
-        }
-
-        /// <summary>
-        /// Returns a Coordinate representation of the specified coordinate, by always
-        /// building a new Coordinate object.
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
-        protected override Coordinate GetCoordinateInternal(int index)
-        {
-            double x = _coords[index * Dimension];
-            double y = _coords[index * Dimension + 1];
-            if (Dimension == 2 && Measures == 0)
-            {
-                return new Coordinate(x, y);
-            }
-            else if (Dimension == 3 && Measures == 0)
-            {
-                double z = _coords[index * Dimension + 2];
-                return new CoordinateZ(x, y, z);
-            }
-            else if (Dimension == 3 && Measures == 1)
-            {
-                double m = _coords[index * Dimension + 2];
-                return new CoordinateM(x, y, m);
-            }
-            else if (Dimension == 4)
-            {
-                double z = _coords[index * Dimension + 2];
-                double m = _coords[index * Dimension + 3];
-                return new CoordinateZM(x, y, z, m);
-            }
-
-            // note: JTS's "Coordinate" is our "CoordinateZ".
-            return new CoordinateZ(x, y);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
@@ -224,39 +224,47 @@ namespace NetTopologySuite.Geometries.Implementation
                 coords = Array.Empty<Coordinate>();
 
             _coords = new double[coords.Length * Dimension];
-            _coords.AsSpan().Fill(double.NaN);
             if (coords.Length == 0)
             {
                 return;
             }
 
-            int coordDimension;
-            int coordMeasures;
             if (dimensionAndMeasuresCameFromCoords)
             {
-                coordDimension = dimension;
-                coordMeasures = measures;
+                for (int i = 0; i < coords.Length; i++)
+                {
+                    int offset = i * dimension;
+
+                    var coord = coords[i];
+                    for (int dim = 0; dim < dimension; dim++)
+                    {
+                        _coords[offset + dim] = coord[dim];
+                    }
+                }
             }
             else
             {
-                (_, coordDimension, coordMeasures) = CoordinateSequenceFactory.GetCommonSequenceParameters(coords);
-            }
+                _coords.AsSpan().Fill(double.NaN);
 
-            int spatial = dimension - measures;
-            int coordSpatial = coordDimension - coordMeasures;
-            for (int i = 0; i < coords.Length; i++)
-            {
-                int offset = i * dimension;
-
-                var coord = coords[i];
-                for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
+                int spatial = dimension - measures;
+                for (int i = 0; i < coords.Length; i++)
                 {
-                    _coords[offset + dim] = coord[dim];
-                }
+                    int offset = i * dimension;
 
-                for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
-                {
-                    _coords[offset + spatial + measure] = coord[coordSpatial + measure];
+                    var coord = coords[i];
+                    int coordDimension = Coordinates.Dimension(coord);
+                    int coordMeasures = Coordinates.Measures(coord);
+                    int coordSpatial = coordDimension - coordMeasures;
+
+                    for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
+                    {
+                        _coords[offset + dim] = coord[dim];
+                    }
+
+                    for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
+                    {
+                        _coords[offset + spatial + measure] = coord[coordSpatial + measure];
+                    }
                 }
             }
         }
@@ -438,39 +446,47 @@ namespace NetTopologySuite.Geometries.Implementation
                 coords = Array.Empty<Coordinate>();
 
             _coords = new float[coords.Length * Dimension];
-            _coords.AsSpan().Fill(float.NaN);
             if (coords.Length == 0)
             {
                 return;
             }
 
-            int coordDimension;
-            int coordMeasures;
             if (dimensionAndMeasuresCameFromCoords)
             {
-                coordDimension = dimension;
-                coordMeasures = measures;
+                for (int i = 0; i < coords.Length; i++)
+                {
+                    int offset = i * dimension;
+
+                    var coord = coords[i];
+                    for (int dim = 0; dim < dimension; dim++)
+                    {
+                        _coords[offset + dim] = (float)coord[dim];
+                    }
+                }
             }
             else
             {
-                (_, coordDimension, coordMeasures) = CoordinateSequenceFactory.GetCommonSequenceParameters(coords);
-            }
+                _coords.AsSpan().Fill(float.NaN);
 
-            int spatial = dimension - measures;
-            int coordSpatial = coordDimension - coordMeasures;
-            for (int i = 0; i < coords.Length; i++)
-            {
-                int offset = i * dimension;
-
-                var coord = coords[i];
-                for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
+                int spatial = dimension - measures;
+                for (int i = 0; i < coords.Length; i++)
                 {
-                    _coords[offset + dim] = (float)coord[dim];
-                }
+                    int offset = i * dimension;
 
-                for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
-                {
-                    _coords[offset + spatial + measure] = (float)coord[coordSpatial + measure];
+                    var coord = coords[i];
+                    int coordDimension = Coordinates.Dimension(coord);
+                    int coordMeasures = Coordinates.Measures(coord);
+                    int coordSpatial = coordDimension - coordMeasures;
+
+                    for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
+                    {
+                        _coords[offset + dim] = (float)coord[dim];
+                    }
+
+                    for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
+                    {
+                        _coords[offset + spatial + measure] = (float)coord[coordSpatial + measure];
+                    }
                 }
             }
         }

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
@@ -188,6 +188,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </summary>
         /// <param name="coords">An array of <see cref="Coordinate"/>s.</param>
         /// <param name="dimension">The total number of ordinates that make up a <see cref="Coordinate"/> in this sequence.</param>
+        [Obsolete("Use an overload that accepts measures.  This overload will be removed in a future release.")]
         public PackedDoubleCoordinateSequence(Coordinate[] coords, int dimension)
             : this(coords, dimension, PackedCoordinateSequenceFactory.DefaultMeasures)
         {
@@ -200,32 +201,8 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <param name="dimension">The total number of ordinates that make up a <see cref="Coordinate"/> in this sequence.</param>
         /// <param name="measures">The number of measure-ordinates each <see cref="Coordinate"/> in this sequence has.</param>
         public PackedDoubleCoordinateSequence(Coordinate[] coords, int dimension, int measures)
-            : base(coords?.Length ?? 0, dimension, measures)
+            : this(coords, dimension, measures, false)
         {
-            if (coords == null)
-                coords = new Coordinate[0];
-
-            _coords = new double[coords.Length * Dimension];
-            _coords.AsSpan().Fill(double.NaN);
-            int spatial = Spatial;
-            for (int i = 0; i < coords.Length; i++)
-            {
-                int offset = i * dimension;
-
-                var coord = coords[i];
-                int coordDimension = Coordinates.Dimension(coord);
-                int coordMeasures = Coordinates.Measures(coord);
-                int coordSpatial = coordDimension - coordMeasures;
-                for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
-                {
-                    _coords[offset + dim] = coord[dim];
-                }
-
-                for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
-                {
-                    _coords[offset + spatial + measure] = coord[coordSpatial + measure];
-                }
-            }
         }
 
         /// <summary>
@@ -238,6 +215,50 @@ namespace NetTopologySuite.Geometries.Implementation
             : base(size, dimension, measures)
         {
             _coords = new double[size * Dimension];
+        }
+
+        internal PackedDoubleCoordinateSequence(Coordinate[] coords, int dimension, int measures, bool dimensionAndMeasuresCameFromCoords)
+            : base(coords?.Length ?? 0, dimension, measures)
+        {
+            if (coords == null)
+                coords = Array.Empty<Coordinate>();
+
+            _coords = new double[coords.Length * Dimension];
+            _coords.AsSpan().Fill(double.NaN);
+            if (coords.Length == 0)
+            {
+                return;
+            }
+
+            int coordDimension;
+            int coordMeasures;
+            if (dimensionAndMeasuresCameFromCoords)
+            {
+                coordDimension = dimension;
+                coordMeasures = measures;
+            }
+            else
+            {
+                (_, coordDimension, coordMeasures) = CoordinateSequenceFactory.GetCommonSequenceParameters(coords);
+            }
+
+            int spatial = dimension - measures;
+            int coordSpatial = coordDimension - coordMeasures;
+            for (int i = 0; i < coords.Length; i++)
+            {
+                int offset = i * dimension;
+
+                var coord = coords[i];
+                for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
+                {
+                    _coords[offset + dim] = coord[dim];
+                }
+
+                for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
+                {
+                    _coords[offset + spatial + measure] = coord[coordSpatial + measure];
+                }
+            }
         }
 
         /// <summary>
@@ -381,6 +402,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// </summary>
         /// <param name="coords">An array of <see cref="Coordinate"/>s.</param>
         /// <param name="dimension">The total number of ordinates that make up a <see cref="Coordinate"/> in this sequence.</param>
+        [Obsolete("Use an overload that accepts measures.  This overload will be removed in a future release.")]
         public PackedFloatCoordinateSequence(Coordinate[] coords, int dimension)
             : this(coords, dimension, PackedCoordinateSequenceFactory.DefaultMeasures)
         {
@@ -393,32 +415,8 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <param name="dimension">The total number of ordinates that make up a <see cref="Coordinate"/> in this sequence.</param>
         /// <param name="measures">The number of measure-ordinates each <see cref="Coordinate"/> in this sequence has.</param>
         public PackedFloatCoordinateSequence(Coordinate[] coords, int dimension, int measures)
-            : base(coords?.Length ?? 0, dimension, measures)
+            : this(coords, dimension, measures, false)
         {
-            if (coords == null)
-                coords = new Coordinate[0];
-
-            _coords = new float[coords.Length * Dimension];
-            _coords.AsSpan().Fill(float.NaN);
-            int spatial = Spatial;
-            for (int i = 0; i < coords.Length; i++)
-            {
-                int offset = i * dimension;
-
-                var coord = coords[i];
-                int coordDimension = Coordinates.Dimension(coord);
-                int coordMeasures = Coordinates.Measures(coord);
-                int coordSpatial = coordDimension - coordMeasures;
-                for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
-                {
-                    _coords[offset + dim] = (float)coord[dim];
-                }
-
-                for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
-                {
-                    _coords[offset + spatial + measure] = (float)coord[coordSpatial + measure];
-                }
-            }
         }
 
         /// <summary>
@@ -431,6 +429,50 @@ namespace NetTopologySuite.Geometries.Implementation
             : base(size, dimension, measures)
         {
             _coords = new float[size * Dimension];
+        }
+
+        internal PackedFloatCoordinateSequence(Coordinate[] coords, int dimension, int measures, bool dimensionAndMeasuresCameFromCoords)
+            : base(coords?.Length ?? 0, dimension, measures)
+        {
+            if (coords == null)
+                coords = Array.Empty<Coordinate>();
+
+            _coords = new float[coords.Length * Dimension];
+            _coords.AsSpan().Fill(float.NaN);
+            if (coords.Length == 0)
+            {
+                return;
+            }
+
+            int coordDimension;
+            int coordMeasures;
+            if (dimensionAndMeasuresCameFromCoords)
+            {
+                coordDimension = dimension;
+                coordMeasures = measures;
+            }
+            else
+            {
+                (_, coordDimension, coordMeasures) = CoordinateSequenceFactory.GetCommonSequenceParameters(coords);
+            }
+
+            int spatial = dimension - measures;
+            int coordSpatial = coordDimension - coordMeasures;
+            for (int i = 0; i < coords.Length; i++)
+            {
+                int offset = i * dimension;
+
+                var coord = coords[i];
+                for (int dim = 0, dimEnd = Math.Min(spatial, coordSpatial); dim < dimEnd; dim++)
+                {
+                    _coords[offset + dim] = (float)coord[dim];
+                }
+
+                for (int measure = 0, measureEnd = Math.Min(measures, coordMeasures); measure < measureEnd; measure++)
+                {
+                    _coords[offset + spatial + measure] = (float)coord[coordSpatial + measure];
+                }
+            }
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequenceFactory.cs
@@ -121,7 +121,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <returns>A packed coordinate sequence of <see cref="Type"/></returns>
         public CoordinateSequence Create(double[] packedCoordinates, int dimension)
         {
-            return Create(packedCoordinates, dimension, Math.Max(DefaultMeasures, dimension - 3));
+            return Create(packedCoordinates, dimension, DefaultMeasures);
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <returns>A packed coordinate sequence of <see cref="Type"/></returns>
         public CoordinateSequence Create(float[] packedCoordinates, int dimension)
         {
-            return Create(packedCoordinates, dimension, Math.Max(DefaultMeasures, dimension - 3));
+            return Create(packedCoordinates, dimension, DefaultMeasures);
         }
 
         /// <summary>
@@ -166,13 +166,6 @@ namespace NetTopologySuite.Geometries.Implementation
             return new PackedFloatCoordinateSequence(packedCoordinates, dimension, measures);
         }
 
-        /*
-        /// <inheritdoc />
-        public override CoordinateSequence Create(int size, int dimension)
-        {
-            return Create(size, dimension, Math.Max(DefaultMeasures, dimension - 3));
-        }
-         */
         /// <inheritdoc />
         public override CoordinateSequence Create(int size, int dimension, int measures)
         {

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequenceFactory.cs
@@ -83,15 +83,9 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <returns></returns>
         public override CoordinateSequence Create(Coordinate[] coordinates)
         {
-            int dimension = DefaultDimension;
-            int measures = DefaultMeasures;
-            if (coordinates != null && coordinates.Length > 0 && coordinates[0] != null)
-            {
-                var first = coordinates[0];
-                dimension = Coordinates.Dimension(first);
-                measures = Coordinates.Measures(first);
-            }
-
+            // DEVIATION: JTS just uses the first coordinate, but other
+            int dimension = CoordinateArrays.Dimension(coordinates);
+            int measures = CoordinateArrays.Measures(coordinates);
             if (_type == PackedType.Double)
                 return new PackedDoubleCoordinateSequence(coordinates, dimension, measures);
             return new PackedFloatCoordinateSequence(coordinates, dimension, measures);

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequenceFactory.cs
@@ -83,12 +83,11 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <returns></returns>
         public override CoordinateSequence Create(Coordinate[] coordinates)
         {
-            // DEVIATION: JTS just uses the first coordinate, but other
-            int dimension = CoordinateArrays.Dimension(coordinates);
-            int measures = CoordinateArrays.Measures(coordinates);
+            // DEVIATION: JTS just uses the first coordinate, which can be lossy.
+            (_, int dimension, int measures) = GetCommonSequenceParameters(coordinates);
             if (_type == PackedType.Double)
-                return new PackedDoubleCoordinateSequence(coordinates, dimension, measures);
-            return new PackedFloatCoordinateSequence(coordinates, dimension, measures);
+                return new PackedDoubleCoordinateSequence(coordinates, dimension, measures, true);
+            return new PackedFloatCoordinateSequence(coordinates, dimension, measures, true);
         }
 
         /// <summary>
@@ -102,8 +101,8 @@ namespace NetTopologySuite.Geometries.Implementation
             int dimension = coordSeq.Dimension;
             int measures = coordSeq.Measures;
             if (_type == PackedType.Double)
-                return new PackedDoubleCoordinateSequence(coordSeq.ToCoordinateArray(), dimension, measures);
-            return new PackedFloatCoordinateSequence(coordSeq.ToCoordinateArray(), dimension, measures);
+                return new PackedDoubleCoordinateSequence(coordSeq.ToCoordinateArray(), dimension, measures, true);
+            return new PackedFloatCoordinateSequence(coordSeq.ToCoordinateArray(), dimension, measures, true);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/IO/WKTReader.cs
+++ b/src/NetTopologySuite/IO/WKTReader.cs
@@ -363,7 +363,7 @@ namespace NetTopologySuite.IO
             // if the sequences array is empty or null create an empty sequence
             if (sequences == null || sequences.Count == 0)
             {
-                return factory.CoordinateSequenceFactory.Create(0, ToDimension(ordinateFlags));
+                return factory.CoordinateSequenceFactory.Create(0, ToDimension(ordinateFlags), OrdinatesUtility.OrdinatesToMeasures(ordinateFlags));
             }
 
             if (sequences.Count == 1)

--- a/test/NetTopologySuite.Samples.Console/LinearReferencing/LinearReferencingExample.cs
+++ b/test/NetTopologySuite.Samples.Console/LinearReferencing/LinearReferencingExample.cs
@@ -89,7 +89,7 @@ Geometry InsertPoint(Geometry geom, Coordinate point)
     var element = (LineString) geom.GetGeometryN(ll.ComponentIndex);
     var oldSeq = element.CoordinateSequence;
     var newSeq = element.Factory.CoordinateSequenceFactory.Create(
-        oldSeq.Count + 1, oldSeq.Dimension);
+        oldSeq.Count + 1, oldSeq.Dimension, oldSeq.Measures);
 
             int j = 0;
     if (ll.SegmentIndex == 0 && ll.SegmentFraction == 0)

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateSequencesTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateSequencesTest.cs
@@ -14,13 +14,13 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             new[]{63.01,52.57},new[]{32.9,44.44}, new[]{79.36,29.8}, new[]{38.17,88.0}, new[]{19.31,49.71},new[]{57.03,19.28},
             new[]{63.76,77.35},new[]{45.26,85.15},new[]{51.71,50.38},new[]{92.16,19.85},new[]{64.18,27.7}, new[]{64.74,65.1},
             new[]{80.07,13.55},new[]{55.54,94.07}};
-        
+
         [Test]
         public void TestCopyToLargerDim()
         {
             var csFactory = new PackedCoordinateSequenceFactory();
             var cs2D = CreateTestSequence(csFactory, 10, 2);
-            var cs3D = csFactory.Create(10, 3);
+            var cs3D = csFactory.Create(10, 3, 0);
             CoordinateSequences.Copy(cs2D, 0, cs3D, 0, cs3D.Count);
             Assert.IsTrue(CoordinateSequences.IsEqual(cs2D, cs3D));
         }
@@ -30,7 +30,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         {
             var csFactory = new PackedCoordinateSequenceFactory();
             var cs3D = CreateTestSequence(csFactory, 10, 3);
-            var cs2D = csFactory.Create(10, 2);
+            var cs2D = csFactory.Create(10, 2, 0);
             CoordinateSequences.Copy(cs3D, 0, cs2D, 0, cs2D.Count);
             Assert.IsTrue(CoordinateSequences.IsEqual(cs2D, cs3D));
         }
@@ -107,7 +107,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
         private static CoordinateSequence CreateSequenceFromOrdinates(CoordinateSequenceFactory csFactory, int dim)
         {
-            var sequence = csFactory.Create(ordinateValues.Length, dim);
+            var sequence = csFactory.Create(ordinateValues.Length, dim, 0);
             for (int i = 0; i < ordinateValues.Length; i++)
             {
                 sequence.SetOrdinate(i, Ordinate.X, ordinateValues[i][0]);
@@ -118,7 +118,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
         private static CoordinateSequence CreateTestSequence(CoordinateSequenceFactory csFactory, int size, int dim)
         {
-            var cs = csFactory.Create(size, dim);
+            var cs = csFactory.Create(size, dim, 0);
             // initialize with a data signature where coords look like [1, 10, 100, ...]
             for (int i = 0; i < size; i++)
                 for (int d = 0; d < dim; d++)
@@ -154,8 +154,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
                 return;
             }
 
-            var fullCopy = factory.Create(sequence.Count, dimension);
-            var partialCopy = factory.Create(sequence.Count - 5, dimension);
+            var fullCopy = factory.Create(sequence.Count, dimension, 0);
+            var partialCopy = factory.Create(sequence.Count - 5, dimension, 0);
 
             // act
             CoordinateSequences.Copy(sequence, 0, fullCopy, 0, sequence.Count);
@@ -301,7 +301,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
             if (num > 4) num = 4;
 
-            var sequence = factory.Create(num, dimension);
+            var sequence = factory.Create(num, dimension, 0);
             if (num == 0) return FillNonPlanarDimensions(sequence);
 
             sequence.SetOrdinate(0, Ordinate.X, 10);
@@ -355,7 +355,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             const double angleCircle = 2 * Math.PI;
             const double angleStep = angleCircle / numSegmentsCircle;
 
-            var sequence = factory.Create(numPoints, dimension);
+            var sequence = factory.Create(numPoints, dimension, 0);
             var pm = new PrecisionModel(100);
             double angle = startAngle;
             for (int i = 0; i < numPoints; i++)

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
@@ -62,11 +62,11 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             CheckEmpty(Factory.CreateEmpty(Dimension.Point), typeof(Point));
             CheckEmpty(Factory.CreateEmpty(Dimension.Curve), typeof(LineString));
             CheckEmpty(Factory.CreateEmpty(Dimension.Surface), typeof(Polygon));
-    
+
             CheckEmpty(Factory.CreatePoint(), typeof(Point));
             CheckEmpty(Factory.CreateLineString(), typeof(LineString));
             CheckEmpty(Factory.CreatePolygon(), typeof(Polygon));
-    
+
             CheckEmpty(Factory.CreateMultiPoint(), typeof(MultiPoint));
             CheckEmpty(Factory.CreateMultiLineString(), typeof(MultiLineString));
             CheckEmpty(Factory.CreateMultiPolygon(), typeof(MultiPolygon));
@@ -96,7 +96,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         public void TestCopyGeometryWithNonDefaultDimension()
         {
             var gf = new GeometryFactory(CoordinateArraySequenceFactory.Instance);
-            var mpSeq = gf.CoordinateSequenceFactory.Create(1, 2);
+            var mpSeq = gf.CoordinateSequenceFactory.Create(1, 2, 0);
             mpSeq.SetOrdinate(0, Ordinate.X, 50);
             mpSeq.SetOrdinate(0, Ordinate.Y, -2);
 

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/BasicCoordinateSequenceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/BasicCoordinateSequenceTest.cs
@@ -20,7 +20,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         [Test]
         public void TestCloneDimension2()
         {
-            var s1 = CoordinateArraySequenceFactory.Instance.Create(2, 2);
+            var s1 = CoordinateArraySequenceFactory.Instance.Create(2, 2, 0);
             s1.SetOrdinate(0, Ordinate.X, 1);
             s1.SetOrdinate(0, Ordinate.Y, 2);
             s1.SetOrdinate(1, Ordinate.X, 3);
@@ -35,7 +35,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         [Test]
         public void TestCloneDimension3()
         {
-            var s1 = CoordinateArraySequenceFactory.Instance.Create(2, 3);
+            var s1 = CoordinateArraySequenceFactory.Instance.Create(2, 3, 0);
             s1.SetOrdinate(0, Ordinate.X, 1);
             s1.SetOrdinate(0, Ordinate.Y, 2);
             s1.SetOrdinate(0, Ordinate.Z, 10);

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateArraySequenceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateArraySequenceTest.cs
@@ -12,32 +12,27 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         [Test]
         public void TestFactoryLimits()
         {
-            // Expected to clip dimension and measure value within factory limits
-
             var factory = (CoordinateArraySequenceFactory)CsFactory;
             var sequence = factory.Create(10, 4);
-            //Assert.That(sequence.Dimension, Is.EqualTo(3));
-            //Assert.That(sequence.Measures, Is.EqualTo(0));
             Assert.That(sequence.Dimension, Is.EqualTo(4));
-            Assert.That(sequence.Measures, Is.EqualTo(1));
-            Assert.That(sequence.HasZ);
-            //Assert.That(!sequence.HasM);
-            Assert.That(sequence.HasM);
-
-            sequence = factory.Create(10, 4, 0);
-            Assert.That(sequence.Dimension, Is.EqualTo(3));
             Assert.That(sequence.Measures, Is.EqualTo(0));
             Assert.That(sequence.HasZ);
             Assert.That(!sequence.HasM);
 
-            sequence = factory.Create(10, 4, 2); // note clip to spatial dimension
-            Assert.That(sequence.Dimension, Is.EqualTo(3));
-            Assert.That(sequence.Measures, Is.EqualTo(1));
+            sequence = factory.Create(10, 4, 0);
+            Assert.That(sequence.Dimension, Is.EqualTo(4));
+            Assert.That(sequence.Measures, Is.EqualTo(0));
+            Assert.That(sequence.HasZ);
+            Assert.That(!sequence.HasM);
+
+            sequence = factory.Create(10, 4, 2);
+            Assert.That(sequence.Dimension, Is.EqualTo(4));
+            Assert.That(sequence.Measures, Is.EqualTo(2));
             Assert.That(!sequence.HasZ);
             Assert.That(sequence.HasM);
 
             sequence = factory.Create(10, 5, 1);
-            Assert.That(sequence.Dimension, Is.EqualTo(4));
+            Assert.That(sequence.Dimension, Is.EqualTo(5));
             Assert.That(sequence.Measures, Is.EqualTo(1));
             Assert.That(sequence.HasZ);
             Assert.That(sequence.HasM);

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateArraySequenceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateArraySequenceTest.cs
@@ -13,7 +13,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         public void TestFactoryLimits()
         {
             var factory = (CoordinateArraySequenceFactory)CsFactory;
-            var sequence = factory.Create(10, 4);
+            var sequence = factory.Create(10, 4, 0);
             Assert.That(sequence.Dimension, Is.EqualTo(4));
             Assert.That(sequence.Measures, Is.EqualTo(0));
             Assert.That(sequence.HasZ);
@@ -38,7 +38,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
             Assert.That(sequence.HasM);
 
             // previously this clipped to dimension 3, measure 3
-            sequence = factory.Create(10, 1);
+            sequence = factory.Create(10, 1, 0);
             Assert.That(sequence.Dimension, Is.EqualTo(2));
             Assert.That(sequence.Measures, Is.EqualTo(0));
             Assert.That(!sequence.HasZ);
@@ -55,7 +55,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         public void TestDimensionAndMeasure()
         {
             var factory = CsFactory;
-            var seq = factory.Create(5, 2);
+            var seq = factory.Create(5, 2, 0);
             CoordinateSequence copy;
             Coordinate coord;
             Coordinate[] array;
@@ -76,7 +76,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
             copy = factory.Create(seq);
             Assert.That(IsEqual(copy, array), Is.True);
 
-            seq = factory.Create(5, 3);
+            seq = factory.Create(5, 3, 0);
             InitProgression(seq);
             Assert.That(seq.Dimension, Is.EqualTo(3));
             Assert.That(seq.HasZ, Is.True);

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateArraySequenceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateArraySequenceTest.cs
@@ -147,7 +147,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
 
             var array = new Coordinate[] { coord1, coord2, coord3, null };
             var seq = factory.Create(array);
-            Assert.That(seq.Dimension, Is.EqualTo(3));
+            Assert.That(seq.Dimension, Is.EqualTo(4));
             Assert.That(seq.Measures, Is.EqualTo(1));
             Assert.That(seq.GetCoordinate(0), Is.EqualTo(coord1));
             Assert.That(seq.GetCoordinate(1), Is.EqualTo(coord2));

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateSequenceTestBase.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateSequenceTestBase.cs
@@ -18,7 +18,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         [Test]
         public void TestZeroLength()
         {
-            var seq = CsFactory.Create(0, 3);
+            var seq = CsFactory.Create(0, 3, 0);
             Assert.IsTrue(seq.Count == 0);
 
             var seq2 = CsFactory.Create((Coordinate[])null);
@@ -30,7 +30,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         {
             var coords = CreateArray(Size);
 
-            var seq = CsFactory.Create(Size, 3);
+            var seq = CsFactory.Create(Size, 3, 0);
             for (int i = 0; i < seq.Count; i++)
             {
                 seq.SetOrdinate(i, Ordinate.X, coords[i].X);
@@ -48,7 +48,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         {
             var coords = CreateArray(Size);
 
-            var seq = CsFactory.Create(Size, 2);
+            var seq = CsFactory.Create(Size, 2, 0);
             for (int i = 0; i < seq.Count; i++)
             {
                 seq.SetOrdinate(i, Ordinate.X, coords[i].X);

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceDoubleTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceDoubleTest.cs
@@ -17,5 +17,33 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
             Assert.AreEqual(3.0, cs.GetOrdinate(0, Ordinate.M));
         }
 
+        [Test]
+        public void Test2dMeasuredCoordinateSequenceInitializedFromVariousCoordinates()
+        {
+            var extraMeasuresCoordinate = Coordinates.Create(4, 2);
+            extraMeasuresCoordinate.X = 6;
+            extraMeasuresCoordinate.Y = 7;
+            extraMeasuresCoordinate.M = 8;
+            Coordinate[] coords =
+            {
+                new Coordinate(1, 2),
+                new CoordinateZ(2, 3, 4),
+                new CoordinateM(3, 4, 5),
+                new CoordinateZ(4, 5, 6),
+                new CoordinateZM(5, 6, 7, 8),
+                extraMeasuresCoordinate,
+            };
+            double[] expected =
+            {
+                1, 2, double.NaN,
+                2, 3, double.NaN,
+                3, 4, 5,
+                4, 5, double.NaN,
+                5, 6, 8,
+                6, 7, 8,
+            };
+            var cs = new PackedDoubleCoordinateSequence(coords, 3, 1);
+            Assert.That(cs.GetRawCoordinates(), Is.EqualTo(expected));
+        }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceDoubleTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceDoubleTest.cs
@@ -12,7 +12,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         public void Test4dCoordinateSequence()
         {
             var cs = new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.PackedType.Double)
-                .Create(new[] { 0.0d, 1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d }, 4);
+                .Create(new[] { 0.0d, 1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d }, 4, 1);
             Assert.AreEqual(2.0, cs.GetOrdinate(0, Ordinate.Z));
             Assert.AreEqual(3.0, cs.GetOrdinate(0, Ordinate.M));
         }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceFloatTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceFloatTest.cs
@@ -12,7 +12,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         public void Test4dCoordinateSequence()
         {
             var cs = new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.PackedType.Float)
-                .Create(new [] { 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f }, 4);
+                .Create(new [] { 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f }, 4, 1);
             Assert.AreEqual(2.0, cs.GetOrdinate(0, Ordinate.Z));
             Assert.AreEqual(3.0, cs.GetOrdinate(0, Ordinate.M));
         }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceFloatTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceFloatTest.cs
@@ -16,5 +16,34 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
             Assert.AreEqual(2.0, cs.GetOrdinate(0, Ordinate.Z));
             Assert.AreEqual(3.0, cs.GetOrdinate(0, Ordinate.M));
         }
+
+        [Test]
+        public void Test2dMeasuredCoordinateSequenceInitializedFromVariousCoordinates()
+        {
+            var extraMeasuresCoordinate = Coordinates.Create(4, 2);
+            extraMeasuresCoordinate.X = 6;
+            extraMeasuresCoordinate.Y = 7;
+            extraMeasuresCoordinate.M = 8;
+            Coordinate[] coords =
+            {
+                new Coordinate(1, 2),
+                new CoordinateZ(2, 3, 4),
+                new CoordinateM(3, 4, 5),
+                new CoordinateZ(4, 5, 6),
+                new CoordinateZM(5, 6, 7, 8),
+                extraMeasuresCoordinate,
+            };
+            float[] expected =
+            {
+                1, 2, float.NaN,
+                2, 3, float.NaN,
+                3, 4, 5,
+                4, 5, float.NaN,
+                5, 6, 8,
+                6, 7, 8,
+            };
+            var cs = new PackedFloatCoordinateSequence(coords, 3, 1);
+            Assert.That(cs.GetRawCoordinates(), Is.EqualTo(expected));
+        }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceTest.cs
@@ -156,15 +156,13 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
 
             Assert.AreEqual(4, seq.Dimension, "Dimension should be 4");
             Assert.IsTrue(seq.HasZ, "Z should be present");
-            Assert.IsTrue(seq.HasM, "M should be present");
+            Assert.IsTrue(!seq.HasM, "M should not be present");
 
             var coord = seq.GetCoordinate(4);
-            Assert.IsTrue(coord is CoordinateZM);
-            var coordZM = (CoordinateZM)coord;
             Assert.AreEqual(4.0, coord.X);
             Assert.AreEqual(4.0, coord.Y);
-            Assert.AreEqual(4.0, coordZM.Z);
-            Assert.AreEqual(4.0, coordZM.M);
+            Assert.AreEqual(4.0, coord.Z);
+            Assert.AreEqual(4.0, coord[Ordinate.Spatial4]);
 
             var array = seq.ToCoordinateArray();
             Assert.AreEqual(coord, array[4]);

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/PackedCoordinateSequenceTest.cs
@@ -35,7 +35,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
 
         private void CheckDim2(int size, CoordinateSequenceFactory factory)
         {
-            var seq = factory.Create(size, 2);
+            var seq = factory.Create(size, 2, 0);
 
             InitProgression(seq);
 
@@ -66,7 +66,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
 
         private void CheckDim3(CoordinateSequenceFactory factory)
         {
-            var seq = factory.Create(5, 3);
+            var seq = factory.Create(5, 3, 0);
             InitProgression(seq);
 
             Assert.AreEqual(3, seq.Dimension, "Dimension should be 3");
@@ -151,7 +151,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
 
         public void CheckDim4(CoordinateSequenceFactory factory)
         {
-            var seq = factory.Create(5, 4);
+            var seq = factory.Create(5, 4, 0);
             InitProgression(seq);
 
             Assert.AreEqual(4, seq.Dimension, "Dimension should be 4");

--- a/test/NetTopologySuite.Tests.NUnit/IO/WKBTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/WKBTest.cs
@@ -217,10 +217,10 @@ namespace NetTopologySuite.Tests.NUnit.IO
         private static CoordinateSequence SetDimension(CoordinateSequenceFactory fact, CoordinateSequence seq,
             int dimension)
         {
-            if (seq.Dimension == dimension)
+            if (seq.Dimension == dimension && seq.Measures == 0)
                 return seq;
 
-            var res = fact.Create(seq.Count, dimension);
+            var res = fact.Create(seq.Count, dimension, 0);
             dimension = Math.Min(dimension, seq.Dimension);
             for (int i = 0; i < seq.Count; i++)
             {

--- a/test/NetTopologySuite.Tests.NUnit/IO/WKTReaderTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/WKTReaderTest.cs
@@ -562,7 +562,7 @@ namespace NetTopologySuite.Tests.NUnit.IO
 
             // create a sequence capable of storing all ordinate values.
             var res = GetCSFactory(ordinateFlags)
-                .Create(size, RequiredDimension(ordinateFlags));
+                .Create(size, RequiredDimension(ordinateFlags), OrdinatesUtility.OrdinatesToMeasures(ordinateFlags));
 
             // fill in values
             int k = 0;


### PR DESCRIPTION
- 4th spatial dimension is now accessible in all cases.
- Certain coordinate sequences now deviate from JTS to support more cases.

Resolves #461