### PR TITLE
Add IsStrict property to WK[B|T]Reader

### DIFF
--- a/src/NetTopologySuite/IO/WKBReader.cs
+++ b/src/NetTopologySuite/IO/WKBReader.cs
@@ -82,7 +82,6 @@ namespace NetTopologySuite.IO
 
         /*
          * true if structurally invalid input should be reported rather than repaired.
-         * At some point this could be made client-controllable.
          */
         private bool _isStrict;
 
@@ -614,12 +613,26 @@ namespace NetTopologySuite.IO
         }
 
         /// <summary>
+        /// Gets or sets a value indicating if the reader should attempt to repair malformed input.
+        /// </summary>
+        /// <remarks>
+        /// <i>Malformed</i> in this case means the ring has too few points (4),
+        /// or is not closed.
+        /// </remarks>
+        public bool IsStrict
+        {
+            get => _isStrict;
+            set => _isStrict = value;
+        }
+
+        /// <summary>
         /// Gets or sets whether invalid linear rings should be fixed
         /// </summary>
+        [Obsolete("Use !IsStrict")]
         public bool RepairRings
         {
-            get => !_isStrict;
-            set => _isStrict = !value;
+            get => !IsStrict;
+            set => IsStrict = !value;
         }
 
         /// <summary>

--- a/src/NetTopologySuite/IO/WKBReader.cs
+++ b/src/NetTopologySuite/IO/WKBReader.cs
@@ -80,7 +80,7 @@ namespace NetTopologySuite.IO
 
         private readonly NtsGeometryServices _geometryServices;
 
-        /**
+        /*
          * true if structurally invalid input should be reported rather than repaired.
          * At some point this could be made client-controllable.
          */
@@ -618,8 +618,8 @@ namespace NetTopologySuite.IO
         /// </summary>
         public bool RepairRings
         {
-            get => _isStrict;
-            set => _isStrict = value;
+            get => !_isStrict;
+            set => _isStrict = !value;
         }
 
         /// <summary>

--- a/src/NetTopologySuite/IO/WKTReader.cs
+++ b/src/NetTopologySuite/IO/WKTReader.cs
@@ -50,6 +50,10 @@ namespace NetTopologySuite.IO
 
         private bool _isAllowOldNtsCoordinateSyntax = true;
         private bool _isAllowOldNtsMultipointSyntax = true;
+
+        /*
+         * true if structurally invalid input should be reported rather than repaired.
+         */
         private bool _isStrict = true;
 
         /// <summary>
@@ -127,16 +131,16 @@ namespace NetTopologySuite.IO
         }
 
         /// <summary>
-        /// Gets or sets a value indicating of malformed rings should be repaired
+        /// Gets or sets a value indicating if the reader should attempt to repair malformed input.
         /// </summary>
         /// <remarks>
         /// <i>Malformed</i> in this case means the ring has too few points (4),
         /// or is not closed.
         /// </remarks>
-        public bool RepairRings
+        public bool IsStrict
         {
-            get => !_isStrict;
-            set => _isStrict = !value;
+            get => _isStrict;
+            set => _isStrict = value;
         }
 
         /// <summary>
@@ -774,7 +778,7 @@ namespace NetTopologySuite.IO
         private LineString ReadLineStringText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
         {
             var sequence = GetCoordinateSequence(factory, tokens, ordinateFlags);
-            if (!_isStrict && sequence.Count == 1)
+            if (!IsStrict && sequence.Count == 1)
                 sequence = CoordinateSequences.Extend(factory.CoordinateSequenceFactory, sequence, 2);
             return factory.CreateLineString(sequence);
         }
@@ -793,7 +797,7 @@ namespace NetTopologySuite.IO
         private LinearRing ReadLinearRingText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
         {
             var sequence = GetCoordinateSequence(factory, tokens, ordinateFlags);
-            if (RepairRings && !CoordinateSequences.IsRing(sequence))
+            if (!IsStrict && !CoordinateSequences.IsRing(sequence))
                 sequence = CoordinateSequences.EnsureValidRing(factory.CoordinateSequenceFactory, sequence);
             return factory.CreateLinearRing(sequence);
         }

--- a/test/NetTopologySuite.Samples.Console/Tests/Github/Issue327.cs
+++ b/test/NetTopologySuite.Samples.Console/Tests/Github/Issue327.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Samples.Tests.Github
+{
+    public class Issue327
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        [Description("Use of exceptions for flow control")]
+        public void Test(bool strict)
+        {
+            const string wktNonClosedPolygon1 = "POLYGON((10 10, 10 20, 20 20))";
+            const string wktNonClosedPolygon2 = "POLYGON((10 10, 10 20, 20 20, 20 10))";
+            const string wktInsufficientLineString = "LINESTRING(10 10)";
+
+            var wktReader = new WKTReader {RepairRings = !strict};
+            Geometry polygon1 = null, polygon2 = null, linestring = null;
+            if (strict)
+            {
+                Assert.That(() => polygon1 = wktReader.Read(wktNonClosedPolygon1), Throws.InstanceOf<ArgumentException>());
+                Assert.That(() => polygon2 = wktReader.Read(wktNonClosedPolygon2), Throws.InstanceOf<ArgumentException>());
+                Assert.That(() => linestring = wktReader.Read(wktInsufficientLineString), Throws.InstanceOf<ArgumentException>());
+            }
+            else
+            {
+                Assert.That(() => polygon1 = wktReader.Read(wktNonClosedPolygon1), Throws.Nothing);
+                Assert.That(polygon1, Is.Not.Null);
+                Assert.That(() => polygon2 = wktReader.Read(wktNonClosedPolygon2), Throws.Nothing);
+                Assert.That(polygon2, Is.Not.Null);
+                Assert.That(() => linestring = wktReader.Read(wktInsufficientLineString), Throws.Nothing);
+                Assert.That(linestring, Is.Not.Null);
+            }
+        }
+    }
+}

--- a/test/NetTopologySuite.Samples.Console/Tests/Github/Issue327.cs
+++ b/test/NetTopologySuite.Samples.Console/Tests/Github/Issue327.cs
@@ -16,7 +16,9 @@ namespace NetTopologySuite.Samples.Tests.Github
             const string wktNonClosedPolygon2 = "POLYGON((10 10, 10 20, 20 20, 20 10))";
             const string wktInsufficientLineString = "LINESTRING(10 10)";
 
-            var wktReader = new WKTReader {RepairRings = !strict};
+            var wktReader = new WKTReader {IsStrict = strict};
+            Assert.That(wktReader.IsStrict, Is.EqualTo(strict));
+
             Geometry polygon1 = null, polygon2 = null, linestring = null;
             if (strict)
             {


### PR DESCRIPTION
* Copied logic from WKBReader.
* Fix `WKBReader.RepairRing` value
* Mark `WKBReader.RepairRing` obsolete (in favor of `!WKBReader.IsStrict`)

relates to #327