### PR TITLE
Setting SRID copies the factory more faithfully.

### DIFF
--- a/src/NetTopologySuite/Geometries/Geometry.cs
+++ b/src/NetTopologySuite/Geometries/Geometry.cs
@@ -242,8 +242,7 @@ namespace NetTopologySuite.Geometries
                     return;
 
                 // Adjust the geometry factory
-                _factory = NtsGeometryServices.Instance.CreateGeometryFactory(
-                    _factory.PrecisionModel, value, _factory.CoordinateSequenceFactory);
+                _factory = _factory.WithSRID(value);
 
                 var collection = this as GeometryCollection;
                 if (collection == null) return;

--- a/src/NetTopologySuite/Geometries/GeometryFactory.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactory.cs
@@ -703,6 +703,24 @@ namespace NetTopologySuite.Geometries
             return editor.Edit(g, operation);
         }
 
+        /// <summary>
+        /// Returns a new <see cref="GeometryFactory"/> whose <see cref="GeometryFactory.SRID"/> is
+        /// the given value and whose other values and behavior are, as near as we possibly can make
+        /// it, the same as our own.
+        /// </summary>
+        /// <param name="srid">
+        /// The <see cref="GeometryFactory.SRID"/> for the result.
+        /// </param>
+        /// <returns>
+        /// The cloned instance.
+        /// </returns>
+        public virtual GeometryFactory WithSRID(int srid)
+        {
+            return _srid == srid
+                ? this
+                : _services.CreateGeometryFactory(_precisionModel, srid, _coordinateSequenceFactory);
+        }
+
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString()
         {

--- a/src/NetTopologySuite/Geometries/GeometryFactoryEx.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactoryEx.cs
@@ -209,16 +209,12 @@ namespace NetTopologySuite.Geometries
         /// <inheritdoc />
         public override GeometryFactory WithSRID(int srid)
         {
-            var clone = base.WithSRID(srid);
-            if (!(clone is GeometryFactoryEx cloneEx))
-            {
-                cloneEx = new GeometryFactoryEx(PrecisionModel, srid, CoordinateSequenceFactory, GeometryServices);
-            }
+            var clone = new GeometryFactoryEx(PrecisionModel, srid, CoordinateSequenceFactory, GeometryServices);
 
             // ensure that the value is initialized, to minimize the confusion when this is copied.
             _ = _polygonShellRingOrientation.Value;
-            cloneEx._polygonShellRingOrientation = _polygonShellRingOrientation;
-            return cloneEx;
+            clone._polygonShellRingOrientation = _polygonShellRingOrientation;
+            return clone;
         }
 
         /// <summary>

--- a/src/NetTopologySuite/IO/GML2/GMLReader.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLReader.cs
@@ -496,8 +496,9 @@ namespace NetTopologySuite.IO.GML2
 
         protected virtual GeometryFactory GetFactory(string srsName, GeometryFactory gfDefault)
         {
+            var factory = gfDefault ?? Factory;
             if (string.IsNullOrWhiteSpace(srsName))
-                return gfDefault ?? Factory;
+                return factory;
 
             if (!int.TryParse(srsName, out int srid))
             {
@@ -505,13 +506,10 @@ namespace NetTopologySuite.IO.GML2
                 if (match.Success)
                     srid = int.Parse(match.Groups[1].Value);
                 else
-                    return gfDefault ?? Factory;
+                    return factory;
             }
 
-            return NtsGeometryServices.Instance.CreateGeometryFactory(
-                gfDefault.PrecisionModel,
-                srid,
-                gfDefault.CoordinateSequenceFactory);
+            return factory.WithSRID(srid);
         }
 
         protected static string RemoveUnneccessaryWhitespace(string text)

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -106,7 +106,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         }
 
         [Test]
-        [Description("https://github.com/NetTopologySuite/NetTopologySuite/issues/437")]
+        [Category("GitHub Issue")]
+        [Category("Issue437")]
         public void SettingSRIDShouldCopyFactoryFaithfully()
         {
             var gf = new GeometryFactoryEx

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
+
 using NUnit.Framework;
 
 namespace NetTopologySuite.Tests.NUnit.Geometries
@@ -110,20 +112,26 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         [Category("Issue437")]
         public void SettingSRIDShouldCopyFactoryFaithfully()
         {
-            var gf = new GeometryFactoryEx
+            var pm = new PrecisionModel(10);
+            const int initialSRID = 0;
+            var csf = PackedCoordinateSequenceFactory.FloatFactory;
+            const LinearRingOrientation orientation = LinearRingOrientation.Clockwise;
+
+            var gf = new GeometryFactoryEx(pm, initialSRID, csf)
             {
-                OrientationOfExteriorRing = LinearRingOrientation.Clockwise,
+                OrientationOfExteriorRing = orientation,
             };
 
             var env = new Envelope(-10, 10, -8, 8);
             var g = gf.ToGeometry(env);
 
-            g.SRID = 4326;
+            const int expectedSRID = 4326;
+            g.SRID = expectedSRID;
             Assert.That(g.Factory, Is.InstanceOf<GeometryFactoryEx>()
-                                     .With.Property(nameof(GeometryFactoryEx.SRID)).EqualTo(4326)
-                                     .With.Property(nameof(GeometryFactoryEx.OrientationOfExteriorRing)).EqualTo(LinearRingOrientation.Clockwise)
-                                     .With.Property(nameof(GeometryFactoryEx.PrecisionModel)).EqualTo(gf.PrecisionModel)
-                                     .With.Property(nameof(GeometryFactoryEx.CoordinateSequenceFactory)).EqualTo(gf.CoordinateSequenceFactory));
+                                     .With.Property(nameof(GeometryFactoryEx.SRID)).EqualTo(expectedSRID)
+                                     .With.Property(nameof(GeometryFactoryEx.OrientationOfExteriorRing)).EqualTo(orientation)
+                                     .With.Property(nameof(GeometryFactoryEx.PrecisionModel)).EqualTo(pm)
+                                     .With.Property(nameof(GeometryFactoryEx.CoordinateSequenceFactory)).EqualTo(csf));
         }
 
         private static void TestShellRingOrientationEnforcement(LinearRingOrientation ringOrientation)

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryExTest.cs
@@ -105,6 +105,26 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             Assert.IsTrue(((Polygon)gf.ToGeometry(env)).Shell.IsCCW);
         }
 
+        [Test]
+        [Description("https://github.com/NetTopologySuite/NetTopologySuite/issues/437")]
+        public void SettingSRIDShouldCopyFactoryFaithfully()
+        {
+            var gf = new GeometryFactoryEx
+            {
+                OrientationOfExteriorRing = LinearRingOrientation.Clockwise,
+            };
+
+            var env = new Envelope(-10, 10, -8, 8);
+            var g = gf.ToGeometry(env);
+
+            g.SRID = 4326;
+            Assert.That(g.Factory, Is.InstanceOf<GeometryFactoryEx>()
+                                     .With.Property(nameof(GeometryFactoryEx.SRID)).EqualTo(4326)
+                                     .With.Property(nameof(GeometryFactoryEx.OrientationOfExteriorRing)).EqualTo(LinearRingOrientation.Clockwise)
+                                     .With.Property(nameof(GeometryFactoryEx.PrecisionModel)).EqualTo(gf.PrecisionModel)
+                                     .With.Property(nameof(GeometryFactoryEx.CoordinateSequenceFactory)).EqualTo(gf.CoordinateSequenceFactory));
+        }
+
         private static void TestShellRingOrientationEnforcement(LinearRingOrientation ringOrientation)
         {
             var gf = new GeometryFactoryEx();

--- a/test/NetTopologySuite.Tests.NUnit/IO/GML2/GMLReaderTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/GML2/GMLReaderTest.cs
@@ -136,28 +136,31 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML2
         [Category("Issue437")]
         public void CustomGeometryFactoryShouldBeAllowedWithSRID()
         {
+            var pm = new PrecisionModel(10);
+            const int initialSRID = 0;
+            var csf = PackedCoordinateSequenceFactory.FloatFactory;
+            const LinearRingOrientation orientation = LinearRingOrientation.Clockwise;
+
+            var gf = new GeometryFactoryEx(pm, initialSRID, csf)
+            {
+                OrientationOfExteriorRing = orientation,
+            };
+
             const int expectedSRID = 4326;
             string xml = $@"
 <gml:Point srsName='urn:ogc:def:crs:EPSG::{expectedSRID}' xmlns:gml='http://www.opengis.net/gml'>
   <gml:coordinates>45.67, 65.43</gml:coordinates>
 </gml:Point>";
 
-            var pm = new PrecisionModel(10);
-            var csf = PackedCoordinateSequenceFactory.DoubleFactory;
-            var orientation = LinearRingOrientation.Clockwise;
-            var gr = new GMLReader(new GeometryFactoryEx(pm, 0, csf)
-            {
-                OrientationOfExteriorRing = orientation,
-            });
-
+            var gr = new GMLReader(gf);
             foreach (var readMethod in GetReadMethods())
             {
                 var pt = (Point)readMethod(gr, xml);
-                Assert.That(pt.Factory, Is.InstanceOf<GeometryFactoryEx>());
-                Assert.That(pt.Factory.PrecisionModel, Is.EqualTo(pm));
-                Assert.That(pt.Factory.SRID, Is.EqualTo(expectedSRID));
-                Assert.That(pt.Factory.CoordinateSequenceFactory, Is.EqualTo(csf));
-                Assert.That(((GeometryFactoryEx)pt.Factory).OrientationOfExteriorRing, Is.EqualTo(orientation));
+                Assert.That(pt.Factory, Is.InstanceOf<GeometryFactoryEx>()
+                                          .With.Property(nameof(GeometryFactoryEx.SRID)).EqualTo(expectedSRID)
+                                          .With.Property(nameof(GeometryFactoryEx.OrientationOfExteriorRing)).EqualTo(orientation)
+                                          .With.Property(nameof(GeometryFactoryEx.PrecisionModel)).EqualTo(pm)
+                                          .With.Property(nameof(GeometryFactoryEx.CoordinateSequenceFactory)).EqualTo(csf));
             }
         }
 


### PR DESCRIPTION
GeometryFactory now has a `WithSRID` method, which `GeometryFactoryEx` overrides.
Base class still uses `NtsGeometryServices` to share instances where possible.
`GmlReader` uses this method too, so this resolves #437