### PR TITLE
Expose GML3 writing as GML3Writer.

### DIFF
--- a/src/NetTopologySuite/IO/GML2/GMLWriter.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLWriter.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
 using NetTopologySuite.Utilities;
 
 namespace NetTopologySuite.IO.GML2
@@ -121,6 +122,17 @@ namespace NetTopologySuite.IO.GML2
         {
             foreach (var coord in coordinates)
                 Write(coord, writer);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="coordinates"></param>
+        /// <param name="writer"></param>
+        [Obsolete("Use the overload that accepts a CoordinateSequence instead.")]
+        protected void WriteCoordinates(Coordinate[] coordinates, XmlWriter writer)
+        {
+            WriteCoordinates(new CoordinateArraySequence(coordinates), writer);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/IO/GML3/GML3Writer.cs
+++ b/src/NetTopologySuite/IO/GML3/GML3Writer.cs
@@ -1,0 +1,17 @@
+namespace NetTopologySuite.IO.GML3
+{
+    /// <summary>
+    /// Writes the GML representation of the features of NetTopologySuite model.
+    /// Uses GML 3.2.2 <c>Geometry.xsd</c> schema for base for features.
+    /// </summary>
+    public class GML3Writer : NetTopologySuite.IO.GML2.GMLWriter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GML3Writer"/> class.
+        /// </summary>
+        public GML3Writer()
+            : base(GML2.GMLVersion.Three)
+        {
+        }
+    }
+}

--- a/src/NetTopologySuite/IO/GML3/GML3Writer.cs
+++ b/src/NetTopologySuite/IO/GML3/GML3Writer.cs
@@ -2,7 +2,7 @@ namespace NetTopologySuite.IO.GML3
 {
     /// <summary>
     /// Writes the GML representation of the features of NetTopologySuite model.
-    /// Uses GML 3.2.2 <c>Geometry.xsd</c> schema for base for features.
+    /// Uses GML 3.2.2 <c>gml.xsd</c> schema for base for features.
     /// </summary>
     public class GML3Writer : GML2.GMLWriter
     {

--- a/src/NetTopologySuite/IO/GML3/GML3Writer.cs
+++ b/src/NetTopologySuite/IO/GML3/GML3Writer.cs
@@ -4,7 +4,7 @@ namespace NetTopologySuite.IO.GML3
     /// Writes the GML representation of the features of NetTopologySuite model.
     /// Uses GML 3.2.2 <c>Geometry.xsd</c> schema for base for features.
     /// </summary>
-    public class GML3Writer : NetTopologySuite.IO.GML2.GMLWriter
+    public class GML3Writer : GML2.GMLWriter
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GML3Writer"/> class.

--- a/test/NetTopologySuite.Tests.NUnit/IO/GML2/GMLWriterTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/GML2/GMLWriterTest.cs
@@ -1,9 +1,6 @@
 ﻿using NetTopologySuite.IO;
 using NetTopologySuite.IO.GML2;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml.Linq;
 using System.Xml.Schema;
 
@@ -12,63 +9,6 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML2
     [TestFixture]
     public class GMLWriterTest
     {
-        [Test]  
-        public void TestGML3MultiPolygon()
-        {
-            var geometry = new WKTReader().Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
-
-            var gmlWriter = new GMLWriter(GMLVersion.Three);
-            var reader = gmlWriter.Write(geometry);
-            var document = XDocument.Load(reader);
-
-            var multiSurfaceElement = document.Element(XName.Get("MultiSurface", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(multiSurfaceElement);
-
-            var surfaceMemberElement = multiSurfaceElement.Element(XName.Get("surfaceMember", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(surfaceMemberElement);
-
-            var posListElement = surfaceMemberElement.Element(XName.Get("Polygon", "http://www.opengis.net/gml"))
-                                                     .Element(XName.Get("exterior", "http://www.opengis.net/gml"))
-                                                     .Element(XName.Get("LinearRing", "http://www.opengis.net/gml"))
-                                                     .Element(XName.Get("posList", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(posListElement);
-        }
-
-        [Test]
-        public void TestGML3MultiLineString()
-        {
-            var geometry = new WKTReader().Read("MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
-
-            var gmlWriter = new GMLWriter(GMLVersion.Three);
-            var reader = gmlWriter.Write(geometry);
-            var document = XDocument.Load(reader);
-
-            var multiCurveElement = document.Element(XName.Get("MultiCurve", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(multiCurveElement);
-
-            var curveMemberElement = multiCurveElement.Element(XName.Get("curveMember", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(curveMemberElement);
-
-            var posListElement = curveMemberElement.Element(XName.Get("LineString", "http://www.opengis.net/gml"))
-                                                   .Element(XName.Get("posList", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(posListElement);
-        }
-
-
-        [Test]
-        public void TestGML3MultiPointWithPos()
-        {
-            var geometry = new WKTReader().Read("POINT (0 0)");
-
-            var gmlWriter = new GMLWriter(GMLVersion.Three);
-            var reader = gmlWriter.Write(geometry);
-            var document = XDocument.Load(reader);
-
-            var posElement = document.Element(XName.Get("Point", "http://www.opengis.net/gml")).Element(XName.Get("pos", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(posElement);
-            Assert.AreEqual(posElement.Value, "0 0");
-        }
-
         [Test]
         public void WriteEmptyMultiPolygon() {
 

--- a/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
@@ -298,6 +298,11 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
         {
             var document = new XDocument(element);
             var actual = new GMLReader().Read(document);
+
+            // multi-geometries implement IEnumerable<Geometry> such that the first element in the
+            // sequence is the instance itself, so the default NUnit equality constraint behavior
+            // would overflow the stack.  work around that by telling it to use the default equality
+            // comparer for the Geometry type, which properly just does Equals(object).
             Assert.That(actual, Is.EqualTo(expected).Using<Geometry>(EqualityComparer<Geometry>.Default));
         }
     }

--- a/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
@@ -1,6 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 
+using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
+using NetTopologySuite.IO.GML2;
 using NetTopologySuite.IO.GML3;
 
 using NUnit.Framework;
@@ -10,60 +18,287 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
     [TestFixture]
     public class GML3WriterTest
     {
-        [Test]
-        public void TestGML3MultiPolygon()
+        private static readonly XmlWriterSettings XmlWriterSettings = new XmlWriterSettings
         {
-            var geometry = new WKTReader().Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
+            CloseOutput = false,
+            NamespaceHandling = NamespaceHandling.OmitDuplicates,
+            Encoding = Encoding.UTF8,
+        };
 
-            var gmlWriter = new GML3Writer();
-            var reader = gmlWriter.Write(geometry);
-            var document = XDocument.Load(reader);
+        private static readonly WKTReader WKTReader = new WKTReader
+        {
+            IsOldNtsCoordinateSyntaxAllowed = false,
+            IsOldNtsMultiPointSyntaxAllowed = false,
+        };
 
-            var multiSurfaceElement = document.Element(XName.Get("MultiSurface", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(multiSurfaceElement);
+        [Test]
+        public void TestGML3Point()
+        {
+            var document = ToGML3(CreatePoint());
+            AssertPoint(document);
+        }
 
-            var surfaceMemberElement = multiSurfaceElement.Element(XName.Get("surfaceMember", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(surfaceMemberElement);
+        [Test]
+        public void TestGML3LineString()
+        {
+            var document = ToGML3(CreateLineString());
+            AssertLineString(document);
+        }
 
-            var posListElement = surfaceMemberElement.Element(XName.Get("Polygon", "http://www.opengis.net/gml"))
-                                                     .Element(XName.Get("exterior", "http://www.opengis.net/gml"))
-                                                     .Element(XName.Get("LinearRing", "http://www.opengis.net/gml"))
-                                                     .Element(XName.Get("posList", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(posListElement);
+        [Test]
+        public void TestGML3PolygonWithoutHoles()
+        {
+            var document = ToGML3(CreatePolygonWithoutHoles());
+            AssertPolygonWithoutHoles(document);
+        }
+
+        [Test]
+        public void TestGML3PolygonWithHoles()
+        {
+            var document = ToGML3(CreatePolygonWithHoles());
+            AssertPolygonWithHoles(document);
+        }
+
+        [Test]
+        public void TestGML3MultiPoint()
+        {
+            var document = ToGML3(CreateMultiPoint());
+            AssertMultiPoint(document);
         }
 
         [Test]
         public void TestGML3MultiLineString()
         {
-            var geometry = new WKTReader().Read("MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
-
-            var gmlWriter = new GML3Writer();
-            var reader = gmlWriter.Write(geometry);
-            var document = XDocument.Load(reader);
-
-            var multiCurveElement = document.Element(XName.Get("MultiCurve", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(multiCurveElement);
-
-            var curveMemberElement = multiCurveElement.Element(XName.Get("curveMember", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(curveMemberElement);
-
-            var posListElement = curveMemberElement.Element(XName.Get("LineString", "http://www.opengis.net/gml"))
-                                                   .Element(XName.Get("posList", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(posListElement);
+            var document = ToGML3(CreateMultiLineString());
+            AssertMultiLineString(document);
         }
 
         [Test]
-        public void TestGML3MultiPointWithPos()
+        public void TestGML3MultiPolygon()
         {
-            var geometry = new WKTReader().Read("POINT (0 0)");
+            var document = ToGML3(CreateMultiPolygon());
+            AssertMultiPolygon(document);
+        }
 
-            var gmlWriter = new GML3Writer();
-            var reader = gmlWriter.Write(geometry);
-            var document = XDocument.Load(reader);
+        [Test]
+        public void TestGML3GeometryCollection()
+        {
+            var document = ToGML3(CreateGeometryCollection());
+            AssertGeometryCollection(document);
+        }
 
-            var posElement = document.Element(XName.Get("Point", "http://www.opengis.net/gml")).Element(XName.Get("pos", "http://www.opengis.net/gml"));
-            Assert.IsNotNull(posElement);
-            Assert.AreEqual(posElement.Value, "0 0");
+        private static T NotNull<T>(T val)
+        {
+            Assert.That(val, Is.Not.Null);
+            return val;
+        }
+
+        private static XName GML3Name(string localName)
+        {
+            return XName.Get(localName, "http://www.opengis.net/gml");
+        }
+
+        private static XDocument ToGML3(Geometry geom)
+        {
+            using var ms = new MemoryStream();
+            using (var writer = XmlWriter.Create(ms, XmlWriterSettings))
+            {
+                new GML3Writer().Write(geom, writer);
+            }
+
+            ms.Position = 0;
+            return XDocument.Load(ms);
+        }
+
+        private static Geometry CreatePoint()
+        {
+            return WKTReader.Read("POINT (0 0)");
+        }
+
+        private static void AssertPoint(XContainer container)
+        {
+            var pointElement = NotNull(container.Element(GML3Name("Point")));
+            var posElement = NotNull(pointElement.Element(GML3Name("pos")));
+            Assert.That(posElement.Value, Is.EqualTo("0 0"));
+            AssertRoundTrip(pointElement, CreatePoint());
+        }
+
+        private static Geometry CreateLineString()
+        {
+            return WKTReader.Read("LINESTRING (1 1, 2 2, 3 3, 4 4, 5 5)");
+        }
+
+        private static void AssertLineString(XContainer container)
+        {
+            var lineStringElement = NotNull(container.Element(GML3Name("LineString")));
+            var posListElement = NotNull(lineStringElement.Element(GML3Name("posList")));
+            Assert.That(posListElement.Value, Is.EqualTo("1 1 2 2 3 3 4 4 5 5"));
+            AssertRoundTrip(lineStringElement, CreateLineString());
+        }
+
+        private static Geometry CreatePolygonWithoutHoles()
+        {
+            return WKTReader.Read("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
+        }
+
+        private static void AssertPolygonWithoutHoles(XContainer container)
+        {
+            var polygonElement = NotNull(container.Element(GML3Name("Polygon")));
+            var exteriorElement = NotNull(polygonElement.Element(GML3Name("exterior")));
+            var exteriorLinearRingElement = NotNull(exteriorElement.Element(GML3Name("LinearRing")));
+            var exteriorPosListElement = NotNull(exteriorLinearRingElement.Element(GML3Name("posList")));
+            Assert.That(exteriorPosListElement.Value, Is.EqualTo("0 0 0 1 1 1 1 0 0 0"));
+            Assert.That(polygonElement.Elements(GML3Name("interior")), Is.Empty);
+            AssertRoundTrip(polygonElement, CreatePolygonWithoutHoles());
+        }
+
+        private static Geometry CreatePolygonWithHoles()
+        {
+            return WKTReader.Read("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0), (0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2 0.1, 0.1 0.1), (0.4 0.4, 0.4 0.6, 0.6 0.6, 0.6 0.4, 0.4 0.4))");
+        }
+
+        private static void AssertPolygonWithHoles(XContainer container)
+        {
+            var polygonElement = NotNull(container.Element(GML3Name("Polygon")));
+            var exteriorElement = NotNull(polygonElement.Element(GML3Name("exterior")));
+            var exteriorLinearRingElement = NotNull(exteriorElement.Element(GML3Name("LinearRing")));
+            var exteriorPosListElement = NotNull(exteriorLinearRingElement.Element(GML3Name("posList")));
+            Assert.That(exteriorPosListElement.Value, Is.EqualTo("0 0 0 1 1 1 1 0 0 0"));
+            var interiorPosListValues =
+                from interiorElement in polygonElement.Elements(GML3Name("interior"))
+                let interiorLinearRingElement = NotNull(interiorElement.Element(GML3Name("LinearRing")))
+                let interiorPosListElement = NotNull(interiorLinearRingElement.Element(GML3Name("posList")))
+                select interiorPosListElement.Value;
+            Assert.That(interiorPosListValues, Is.EqualTo(new[]
+            {
+                "0.1 0.1 0.1 0.2 0.2 0.2 0.2 0.1 0.1 0.1",
+                "0.4 0.4 0.4 0.6 0.6 0.6 0.6 0.4 0.4 0.4",
+            }));
+            AssertRoundTrip(polygonElement, CreatePolygonWithHoles());
+        }
+
+        private static Geometry CreateMultiPoint()
+        {
+            return WKTReader.Read("MULTIPOINT ((1 1), (2 2), (3 3))");
+        }
+
+        private static void AssertMultiPoint(XContainer container)
+        {
+            var multiPointElement = NotNull(container.Element(GML3Name("MultiPoint")));
+            var posValues =
+                from pointMemberElement in multiPointElement.Elements(GML3Name("pointMember"))
+                let pointElement = NotNull(pointMemberElement.Element(GML3Name("Point")))
+                let posElement = NotNull(pointElement.Element(GML3Name("pos")))
+                select posElement.Value;
+            Assert.That(posValues, Is.EqualTo(new[]
+            {
+                "1 1",
+                "2 2",
+                "3 3",
+            }));
+            AssertRoundTrip(multiPointElement, CreateMultiPoint());
+        }
+
+        private static Geometry CreateMultiLineString()
+        {
+            return WKTReader.Read("MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
+        }
+
+        private static void AssertMultiLineString(XContainer container)
+        {
+            var multiCurveElement = NotNull(container.Element(GML3Name("MultiCurve")));
+            var posListValues =
+                from curveMemberElement in multiCurveElement.Elements(GML3Name("curveMember"))
+                let lineStringElement = NotNull(curveMemberElement.Element(GML3Name("LineString")))
+                let posListElement = NotNull(lineStringElement.Element(GML3Name("posList")))
+                select posListElement.Value;
+            Assert.That(posListValues, Is.EqualTo(new[]
+            {
+                "10 10 20 20 10 40",
+                "40 40 30 30 40 20 30 10",
+            }));
+            AssertRoundTrip(multiCurveElement, CreateMultiLineString());
+        }
+
+        private static Geometry CreateMultiPolygon()
+        {
+            return WKTReader.Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
+        }
+
+        private static void AssertMultiPolygon(XContainer container)
+        {
+            var multiSurfaceElement = NotNull(container.Element(GML3Name("MultiSurface")));
+            var posListValues =
+                from surfaceMemberElement in multiSurfaceElement.Elements(GML3Name("surfaceMember"))
+                let polygonElement = NotNull(surfaceMemberElement.Element(GML3Name("Polygon")))
+                let exteriorElement = NotNull(polygonElement.Element(GML3Name("exterior")))
+                let exteriorLinearRingElement = NotNull(exteriorElement.Element(GML3Name("LinearRing")))
+                let exteriorPosListElement = NotNull(exteriorLinearRingElement.Element(GML3Name("posList")))
+                // prepend a dummy so we can handle polygons without holes.  we'll skip it later to compensate.
+                from interiorElement in polygonElement.Elements(GML3Name("interior")).Prepend(DummyInteriorElement())
+                let interiorLinearRingElement = NotNull(interiorElement.Element(GML3Name("LinearRing")))
+                let interiorPosListElement = NotNull(interiorLinearRingElement.Element(GML3Name("posList")))
+                group NotNull(interiorPosListElement.Value) by exteriorPosListElement into grp
+                select (grp.Key.Value, grp.Skip(1).ToArray());
+            Assert.That(posListValues, Is.EqualTo(new[]
+            {
+                ("40 40 20 45 45 30 40 40", Array.Empty<string>()),
+                ("20 35 10 30 10 10 30 5 45 20 20 35", new[] { "30 20 20 15 20 25 30 20" }),
+            }));
+            AssertRoundTrip(multiSurfaceElement, CreateMultiPolygon());
+
+            static XElement DummyInteriorElement()
+            {
+                return new XElement(
+                    GML3Name("interior"),
+                    new XElement(
+                        GML3Name("LinearRing"),
+                        new XElement(
+                            GML3Name("posList"),
+                            "it doesn't matter what I put here")));
+            }
+        }
+
+        private static GeometryCollection CreateGeometryCollection()
+        {
+            Geometry[] geoms =
+            {
+                CreatePoint(),
+                CreateLineString(),
+                CreatePolygonWithoutHoles(),
+                CreatePolygonWithHoles(),
+                CreateMultiPoint(),
+                CreateMultiLineString(),
+                CreateMultiPolygon(),
+            };
+
+            return geoms[0].Factory.CreateGeometryCollection(geoms);
+        }
+
+        private static void AssertGeometryCollection(XContainer container)
+        {
+            var multiGeometryElement = NotNull(container.Element(GML3Name("MultiGeometry")));
+            var elements = new Queue<XElement>(multiGeometryElement.Elements(GML3Name("geometryMember")));
+            Assert.That(elements, Has.Count.EqualTo(7));
+            Assert.Multiple(
+                () =>
+                {
+                    AssertPoint(elements.Dequeue());
+                    AssertLineString(elements.Dequeue());
+                    AssertPolygonWithoutHoles(elements.Dequeue());
+                    AssertPolygonWithHoles(elements.Dequeue());
+                    AssertMultiPoint(elements.Dequeue());
+                    AssertMultiLineString(elements.Dequeue());
+                    AssertMultiPolygon(elements.Dequeue());
+                });
+            AssertRoundTrip(multiGeometryElement, CreateGeometryCollection());
+        }
+
+        private static void AssertRoundTrip(XElement element, Geometry expected)
+        {
+            var document = new XDocument(element);
+            var actual = new GMLReader().Read(document);
+            Assert.That(actual, Is.EqualTo(expected).Using<Geometry>(EqualityComparer<Geometry>.Default));
         }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
@@ -1,0 +1,69 @@
+using System.Xml.Linq;
+
+using NetTopologySuite.IO;
+using NetTopologySuite.IO.GML3;
+
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.IO.GML3
+{
+    [TestFixture]
+    public class GML3WriterTest
+    {
+        [Test]
+        public void TestGML3MultiPolygon()
+        {
+            var geometry = new WKTReader().Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
+
+            var gmlWriter = new GML3Writer();
+            var reader = gmlWriter.Write(geometry);
+            var document = XDocument.Load(reader);
+
+            var multiSurfaceElement = document.Element(XName.Get("MultiSurface", "http://www.opengis.net/gml"));
+            Assert.IsNotNull(multiSurfaceElement);
+
+            var surfaceMemberElement = multiSurfaceElement.Element(XName.Get("surfaceMember", "http://www.opengis.net/gml"));
+            Assert.IsNotNull(surfaceMemberElement);
+
+            var posListElement = surfaceMemberElement.Element(XName.Get("Polygon", "http://www.opengis.net/gml"))
+                                                     .Element(XName.Get("exterior", "http://www.opengis.net/gml"))
+                                                     .Element(XName.Get("LinearRing", "http://www.opengis.net/gml"))
+                                                     .Element(XName.Get("posList", "http://www.opengis.net/gml"));
+            Assert.IsNotNull(posListElement);
+        }
+
+        [Test]
+        public void TestGML3MultiLineString()
+        {
+            var geometry = new WKTReader().Read("MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
+
+            var gmlWriter = new GML3Writer();
+            var reader = gmlWriter.Write(geometry);
+            var document = XDocument.Load(reader);
+
+            var multiCurveElement = document.Element(XName.Get("MultiCurve", "http://www.opengis.net/gml"));
+            Assert.IsNotNull(multiCurveElement);
+
+            var curveMemberElement = multiCurveElement.Element(XName.Get("curveMember", "http://www.opengis.net/gml"));
+            Assert.IsNotNull(curveMemberElement);
+
+            var posListElement = curveMemberElement.Element(XName.Get("LineString", "http://www.opengis.net/gml"))
+                                                   .Element(XName.Get("posList", "http://www.opengis.net/gml"));
+            Assert.IsNotNull(posListElement);
+        }
+
+        [Test]
+        public void TestGML3MultiPointWithPos()
+        {
+            var geometry = new WKTReader().Read("POINT (0 0)");
+
+            var gmlWriter = new GML3Writer();
+            var reader = gmlWriter.Write(geometry);
+            var document = XDocument.Load(reader);
+
+            var posElement = document.Element(XName.Get("Point", "http://www.opengis.net/gml")).Element(XName.Get("pos", "http://www.opengis.net/gml"));
+            Assert.IsNotNull(posElement);
+            Assert.AreEqual(posElement.Value, "0 0");
+        }
+    }
+}


### PR DESCRIPTION
I've looked through the GML3 schema files and determined that our writer is properly handling a valid subset of the GML3 spec.  This PR includes some engineering tweaks that I noticed when checking this:
1. As alluded to in #341, GML3 writing is now publicly exposed via the `NetTopologySuite.IO.GML3` namespace, rather than the `NetTopologySuite.IO.GML2` namespace (even though all the code is implemented in that one).
1. I've tweaked some methods to limit unnecessary allocations and copying (particularly, we now write using `CoordinateSequence` instead of `Coordinate[]`)
1. Using pattern matching to make the type-based dispatch slightly more streamlined
1. Added fairly comprehensive NUnit test coverage for all the geometry types

As a side note `NetTopologySuite.IO.GML2.GmlReader` **does not** sufficiently cover the parts of the GML3 spec, and I would like to re-engineer it at a later time, but that's out of the scope of this PR.

Resolves #341