### PR TITLE
Add a lower-level CoordinateSequence implementation

### DIFF
--- a/src/NetTopologySuite/Geometries/Implementation/RawCoordinateSequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/RawCoordinateSequence.cs
@@ -1,0 +1,435 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+
+namespace NetTopologySuite.Geometries.Implementation
+{
+    /// <summary>
+    /// An implementation of <see cref="CoordinateSequence"/> that packs its contents in a way that
+    /// can be customized by the creator.
+    /// </summary>
+    [Serializable]
+    public sealed class RawCoordinateSequence : CoordinateSequence, ISerializable
+    {
+        private readonly (Memory<double> Array, int DimensionCount)[] _rawData;
+
+        private readonly (int RawDataIndex, int DimensionIndex)[] _dimensionMap;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RawCoordinateSequence"/> class.
+        /// </summary>
+        /// <param name="rawData">
+        /// Contains the raw data for this sequence.
+        /// </param>
+        /// <param name="dimensionMap">
+        /// Contains a pair of indexes to tell us, for each dimension, where to find its data in
+        /// <paramref name="rawData"/>.
+        /// </param>
+        /// <param name="measures">
+        /// The value for <see cref="CoordinateSequence.Measures"/>.
+        /// </param>
+        public RawCoordinateSequence(Memory<double>[] rawData, (int RawDataIndex, int DimensionIndex)[] dimensionMap, int measures)
+            : base(GetCountIfValid(rawData, dimensionMap), dimensionMap.Length, measures)
+        {
+            _rawData = new (Memory<double> Array, int DimensionCount)[rawData.Length];
+            for (int i = 0; i < rawData.Length; i++)
+            {
+                _rawData[i].Array = rawData[i];
+                if (Count != 0)
+                {
+                    _rawData[i].DimensionCount = rawData[i].Length / Count;
+                }
+            }
+
+            _dimensionMap = dimensionMap;
+        }
+
+        private RawCoordinateSequence(int count, int dimension, int measures, (Memory<double> Array, int DimensionCount)[] rawData, (int RawDataIndex, int DimensionIndex)[] dimensionMap)
+            : base(count, dimension, measures)
+        {
+            _rawData = rawData;
+            _dimensionMap = dimensionMap;
+        }
+
+        private RawCoordinateSequence(SerializationInfo info, StreamingContext context)
+            : this(
+                info.GetInt32("count"),
+                info.GetInt32("dimension"),
+                info.GetInt32("measures"),
+                Array.ConvertAll(((double[] Array, int DimensionCount)[])info.GetValue("rawData", typeof((double[] Array, int DimensionCount)[])), tup => (tup.Array.AsMemory(), tup.DimensionCount)),
+                ((int RawDataIndex, int DimensionIndex)[])info.GetValue("dimensionMap", typeof((int RawDataIndex, int DimensionIndex)[])))
+        {
+        }
+
+        /// <summary>
+        /// Gets the underlying <see cref="Memory{T}"/> for the ordinates at the given index, along
+        /// with a "stride" value that represents how many slots there are between elements.
+        /// </summary>
+        /// <param name="ordinateIndex">
+        /// The index of the ordinate whose values to get, from
+        /// <see cref="CoordinateSequence.TryGetOrdinateIndex"/>.
+        /// </param>
+        /// <returns>
+        /// The underlying <see cref="Memory{T}"/> and stride.
+        /// </returns>
+        public (Memory<double> Array, int Stride) GetRawCoordinatesAndStride(int ordinateIndex)
+        {
+            if ((uint)ordinateIndex >= (uint)_dimensionMap.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ordinateIndex), ordinateIndex, $"Must be less than Dimension (use {nameof(TryGetOrdinateIndex)} to get the value to use for this if you are unsure).");
+            }
+
+            (int sourceIndex, int offset) = _dimensionMap[ordinateIndex];
+            (var array, int stride) = _rawData[sourceIndex];
+            return (array.Slice(offset), stride);
+        }
+
+        /// <inheritdoc />
+        public override double GetOrdinate(int index, int ordinateIndex)
+        {
+            return ValueRef(index, ordinateIndex);
+        }
+
+        /// <inheritdoc />
+        public override void SetOrdinate(int index, int ordinateIndex, double value)
+        {
+            ValueRef(index, ordinateIndex) = value;
+        }
+
+        /// <inheritdoc />
+        public override CoordinateSequence Copy()
+        {
+            var newRawData = _rawData.AsSpan().ToArray();
+
+            for (int i = 0; i < newRawData.Length; i++)
+            {
+                newRawData[i].Array = newRawData[i].Array.ToArray();
+            }
+
+            var newDimensionMap = _dimensionMap.AsSpan().ToArray();
+            return new RawCoordinateSequence(Count, Dimension, Measures, newRawData, newDimensionMap);
+        }
+
+        /// <inheritdoc />
+        public override CoordinateSequence Reversed()
+        {
+            var result = (RawCoordinateSequence)Copy();
+
+            var rawData = result._rawData;
+            for (int i = 0; i < rawData.Length; i++)
+            {
+                var span = rawData[i].Array.Span;
+                int chunkSize = rawData[i].DimensionCount;
+                switch (chunkSize)
+                {
+                    case 1:
+                        span.Reverse();
+                        break;
+
+                    case 2:
+                        MemoryMarshal.Cast<double, (double, double)>(span).Reverse();
+                        break;
+
+                    case 3:
+                        MemoryMarshal.Cast<double, (double, double, double)>(span).Reverse();
+                        break;
+
+                    case 4:
+                        MemoryMarshal.Cast<double, (double, double, double, double)>(span).Reverse();
+                        break;
+
+                    default:
+                        // those are the common sizes... we could keep going, but for the sake of
+                        // keeping this smallish, just reverse the raw array and then reverse each
+                        // individual coordinate's section within the array.
+                        span.Reverse();
+                        while (!span.IsEmpty)
+                        {
+                            span.Slice(0, chunkSize).Reverse();
+                            span = span.Slice(chunkSize);
+                        }
+
+                        break;
+                }
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public override Envelope ExpandEnvelope(Envelope env)
+        {
+            if (env is null)
+            {
+                throw new ArgumentNullException(nameof(env));
+            }
+
+            (var xsMem, int strideX) = GetRawCoordinatesAndStride(0);
+            (var ysMem, int strideY) = GetRawCoordinatesAndStride(1);
+            var xs = xsMem.Span;
+            var ys = ysMem.Span;
+            for (int x = 0, y = 0; x < xs.Length; x += strideX, y += strideY)
+            {
+                env.ExpandToInclude(xs[x], ys[y]);
+            }
+
+            return env;
+        }
+
+        /// <inheritdoc />
+        public override Coordinate[] ToCoordinateArray()
+        {
+            if (this.Count == 0)
+            {
+                return Array.Empty<Coordinate>();
+            }
+
+            var raw = new (ReadOnlyMemory<double> Memory, int Stride)[Dimension];
+            var rawArrays = new (double[] Array, int Offset, int Stride)[Dimension];
+            for (int i = 0; i < raw.Length; i++)
+            {
+                raw[i] = GetRawCoordinatesAndStride(i);
+
+                if (rawArrays is null)
+                {
+                    continue;
+                }
+
+                if (MemoryMarshal.TryGetArray(raw[i].Memory, out var arraySegment))
+                {
+                    rawArrays = null;
+                    continue;
+                }
+
+                rawArrays[i].Array = arraySegment.Array;
+                rawArrays[i].Offset = arraySegment.Offset;
+                rawArrays[i].Stride = raw[i].Stride;
+            }
+
+            var result = new Coordinate[Count];
+            if (rawArrays != null)
+            {
+                raw = null;
+                for (int i = 0; i < result.Length; i++)
+                {
+                    var coord = result[i] = CreateCoordinate();
+                    for (int j = 0; j < rawArrays.Length; j++)
+                    {
+                        ref var nxt = ref rawArrays[j];
+                        coord[j] = nxt.Array[nxt.Offset];
+                        nxt.Offset += nxt.Stride;
+                    }
+                }
+            }
+            else
+            {
+                // xs and ys can be special
+                var xs = raw[0].Memory.Span;
+                int strideX = raw[0].Stride;
+                var ys = raw[1].Memory.Span;
+                int strideY = raw[1].Stride;
+
+                int i = 0;
+                while (true)
+                {
+                    var coord = result[i] = CreateCoordinate();
+                    coord.X = xs[0];
+                    coord.Y = ys[0];
+
+                    for (int j = 2; j < raw.Length; j++)
+                    {
+                        coord[j] = raw[j].Memory.Span[0];
+                    }
+
+                    if (++i == result.Length)
+                    {
+                        break;
+                    }
+
+                    xs = xs.Slice(strideX);
+                    ys = ys.Slice(strideY);
+                    for (int j = 2; j < raw.Length; j++)
+                    {
+                        ref var nxt = ref raw[j];
+                        nxt.Memory = nxt.Memory.Slice(nxt.Stride);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("count", Count);
+            info.AddValue("dimension", Dimension);
+            info.AddValue("measures", Measures);
+            info.AddValue("rawData", Array.ConvertAll(_rawData, tup => (tup.Array.ToArray(), tup.DimensionCount)));
+            info.AddValue("dimensionMap", _dimensionMap);
+        }
+
+        private static int GetCountIfValid(Memory<double>[] rawData, (int RawDataIndex, int DimensionIndex)[] dimensionMap)
+        {
+            if (rawData is null)
+            {
+                throw new ArgumentNullException(nameof(rawData));
+            }
+
+            if (dimensionMap is null)
+            {
+                throw new ArgumentNullException(nameof(dimensionMap));
+            }
+
+            int dimensionCount = dimensionMap.Length;
+            if (dimensionCount == 0)
+            {
+                // base class requires at least 2 spatial dimensions, so it'll throw for us.
+                return 0;
+            }
+
+            int valueCount = 0;
+            foreach (var array in rawData)
+            {
+                valueCount += array.Length;
+            }
+
+            int count = Math.DivRem(valueCount, dimensionCount, out int remainder);
+            if (remainder != 0)
+            {
+                throw new ArgumentException("The sum of all array sizes must be an even multiple of the number of dimensions.");
+            }
+
+            if (count == 0)
+            {
+                // validation for empty is a lot different, because we can't start from the number
+                // of slots in the arrays of rawData.
+                ValidateEmpty(rawData, dimensionMap);
+                return count;
+            }
+
+            var scratchIntBuffer = rawData.Length < 20
+                ? stackalloc int[rawData.Length * 2]
+                : new int[rawData.Length * 2];
+
+            // for each array in rawData, calculate two values: the first value tells us the number
+            // of dimensions in the arrays before it, and the second value tells us the number of
+            // dimensions in that array itself.
+            var dimensionsBySourceArray = MemoryMarshal.Cast<int, (int DimensionOffset, int DimensionCount)>(scratchIntBuffer);
+
+            int dimensionsSoFar = 0;
+            for (int i = 0; i < rawData.Length; i++)
+            {
+                dimensionsBySourceArray[i].DimensionOffset = dimensionsSoFar;
+                dimensionsSoFar += dimensionsBySourceArray[i].DimensionCount = rawData[i].Length / count;
+            }
+
+            if (dimensionsSoFar != dimensionCount)
+            {
+                throw new ArgumentException("Inferred dimension count from raw data does not match the number of entries in dimension map.");
+            }
+
+            // now check to ensure that each dimension is actually represented in one (and only one)
+            // slot in rawData.  those counts that we just computed will let us check each dimension
+            // very quickly, using just a single array lookup and some comparisons.
+            var slotIsUsed = dimensionCount < 20
+                ? stackalloc bool[dimensionCount]
+                : new bool[dimensionCount];
+            slotIsUsed.Clear();
+            int usedSlotCount = 0;
+
+            foreach ((int rawDataIndex, int dimensionIndex) in dimensionMap)
+            {
+                if ((uint)rawDataIndex >= (uint)dimensionsBySourceArray.Length)
+                {
+                    throw new ArgumentException("Raw data index in dimension map must be less than the length of raw data.");
+                }
+
+                (int dimensionOffsetInSourceArray, int dimensionCountInSourceArray) = dimensionsBySourceArray[rawDataIndex];
+                if ((uint)dimensionIndex >= (uint)dimensionCountInSourceArray)
+                {
+                    throw new ArgumentException("Dimension index in dimension map must be a positive value that's less than the number of dimensions in the corresponding raw data slot.");
+                }
+
+                int slotIndex = dimensionOffsetInSourceArray + dimensionIndex;
+                if (slotIsUsed[slotIndex])
+                {
+                    throw new ArgumentException("Dimension map contains duplicate values.", nameof(dimensionMap));
+                }
+
+                slotIsUsed[slotIndex] = true;
+                ++usedSlotCount;
+            }
+
+            if (usedSlotCount != dimensionCount)
+            {
+                throw new ArgumentException("Dimension map does not cover all slots in raw data.");
+            }
+
+            return count;
+        }
+
+        private static void ValidateEmpty(Memory<double>[] rawData, (int RawDataIndex, int DimensionIndex)[] dimensionMap)
+        {
+            int dimensionCount = dimensionMap.Length;
+
+            var slotUsed = rawData.Length * dimensionCount < 400
+                ? stackalloc bool[rawData.Length * dimensionCount]
+                : new bool[rawData.Length * dimensionCount];
+            slotUsed.Clear();
+
+            foreach ((int rawDataIndex, int dimensionIndex) in dimensionMap)
+            {
+                if ((uint)rawDataIndex >= (uint)rawData.Length)
+                {
+                    throw new ArgumentException("Raw data index in dimension map must be less than the length of raw data.");
+                }
+
+                int slotIndex = (rawDataIndex * dimensionCount) + dimensionIndex;
+                if (slotUsed[slotIndex])
+                {
+                    throw new ArgumentException("Dimension map contains duplicate values.", nameof(dimensionMap));
+                }
+
+                slotUsed[slotIndex] = true;
+            }
+
+            int inferredDimensionCount = 0;
+            for (int i = 0; i < rawData.Length; i++)
+            {
+                int baseSlot = dimensionCount * i;
+                for (int j = 0; j < dimensionCount; j++)
+                {
+                    if (slotUsed[baseSlot + j])
+                    {
+                        ++inferredDimensionCount;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (inferredDimensionCount != dimensionCount)
+            {
+                throw new ArgumentException("Dimension map does not cover all slots in raw data.");
+            }
+        }
+
+        private static void Swap<T>(ref T a, ref T b)
+        {
+            var t = a;
+            a = b;
+            b = t;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ref double ValueRef(int index, int ordinateIndex)
+        {
+            (int sourceIndex, int offset) = _dimensionMap[ordinateIndex];
+            (var array, int stride) = _rawData[sourceIndex];
+            return ref array.Span[(index * stride) + offset];
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Implementation/RawCoordinateSequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/RawCoordinateSequence.cs
@@ -143,11 +143,9 @@ namespace NetTopologySuite.Geometries.Implementation
         {
             var result = (RawCoordinateSequence)Copy();
 
-            var rawData = result._rawData;
-            for (int i = 0; i < rawData.Length; i++)
+            foreach ((var array, int chunkSize) in result._rawData)
             {
-                var span = rawData[i].Array.Span;
-                int chunkSize = rawData[i].DimensionCount;
+                var span = array.Span;
                 switch (chunkSize)
                 {
                     case 1:
@@ -443,13 +441,6 @@ namespace NetTopologySuite.Geometries.Implementation
             {
                 throw new ArgumentException("Dimension map does not cover all slots in raw data.");
             }
-        }
-
-        private static void Swap<T>(ref T a, ref T b)
-        {
-            var t = a;
-            a = b;
-            b = t;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/NetTopologySuite/Geometries/Implementation/RawCoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/RawCoordinateSequenceFactory.cs
@@ -1,0 +1,552 @@
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Implementation
+{
+    /// <summary>
+    /// Factory for creating <see cref="RawCoordinateSequence"/> instances.
+    /// </summary>
+    public sealed class RawCoordinateSequenceFactory : CoordinateSequenceFactory
+    {
+        private readonly Ordinates _ordinatesInGroups;
+
+        private readonly Ordinates[] _ordinateGroups;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RawCoordinateSequenceFactory"/> class.
+        /// </summary>
+        /// <param name="ordinateGroups">
+        /// A sequence of zero or more <see cref="Ordinates"/> flags representing ordinate values
+        /// that should be allocated together.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="ordinateGroups"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when a given flag appears in more than one element of
+        /// <paramref name="ordinateGroups"/>.
+        /// </exception>
+        /// <remarks>
+        /// Any flags not represented in <paramref name="ordinateGroups"/>, and any spatial or
+        /// measure dimensions beyond the 16th, will be allocated together, SoA-style.
+        /// <para/>
+        /// Elements without any bits set will be silently ignored.
+        /// </remarks>
+        public RawCoordinateSequenceFactory(IEnumerable<Ordinates> ordinateGroups)
+        {
+            if (ordinateGroups is null)
+            {
+                throw new ArgumentNullException(nameof(ordinateGroups));
+            }
+
+            var seenOrdinates = Ordinates.None;
+            var ordinateGroupsList = new List<Ordinates>();
+            foreach (var ordinateGroup in ordinateGroups)
+            {
+                if ((ordinateGroup & seenOrdinates) != Ordinates.None)
+                {
+                    throw new ArgumentException("Each ordinate may show up in at most one group.", nameof(ordinateGroups));
+                }
+
+                seenOrdinates |= ordinateGroup;
+
+                if (OrdinatesUtility.OrdinatesToDimension(ordinateGroup) < 2)
+                {
+                    // it would have been equally correct to omit this
+                    continue;
+                }
+
+                _ordinatesInGroups |= ordinateGroup;
+                ordinateGroupsList.Add(ordinateGroup);
+            }
+
+            _ordinateGroups = ordinateGroupsList.ToArray();
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given arrays for reading
+        /// and writing X and Y data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="x">
+        /// An array of X values, laid out as
+        /// <c>[x0, x1, x2, ..., xn]</c>.
+        /// </param>
+        /// <param name="y">
+        /// An array of Y values, laid out as
+        /// <c>[y0, y1, y2, ..., yn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given arrays.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the input arrays do not contain data for the same number of coordinates.
+        /// </exception>
+        public static RawCoordinateSequence CreateXY(Memory<double> x, Memory<double> y)
+        {
+            if (x.Length != y.Length)
+            {
+                throw new ArgumentException("Arrays must contain data for the same number of coordinates.");
+            }
+
+            Memory<double>[] rawData = { x, y };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (1, 0) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 0);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given array for reading
+        /// and writing X and Y data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="xy">
+        /// An array of X and Y values, laid out as
+        /// <c>[x0, y0, x1, y1, x2, y2, ..., xn, yn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given array.
+        /// </returns>
+        /// <remarks>
+        /// The resulting instance is essentially a <see cref="PackedDoubleCoordinateSequence"/>
+        /// with slightly more overhead, so the main reason to prefer this over that one would be if
+        /// you <b>really</b> need to avoid copying the data to fit it into that format.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the length of <paramref name="xy"/> is not a multiple of 2.
+        /// </exception>
+        public static RawCoordinateSequence CreateXY(Memory<double> xy)
+        {
+            if (xy.Length % 2 != 0)
+            {
+                throw new ArgumentException("Length must be a multiple of 2.", nameof(xy));
+            }
+
+            Memory<double>[] rawData = { xy };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (0, 1) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 0);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given arrays for reading
+        /// and writing X, Y, and Z data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="x">
+        /// An array of X values, laid out as
+        /// <c>[x0, x1, x2, ..., xn]</c>.
+        /// </param>
+        /// <param name="y">
+        /// An array of Y values, laid out as
+        /// <c>[y0, y1, y2, ..., yn]</c>.
+        /// </param>
+        /// <param name="z">
+        /// An array of Z values, laid out as
+        /// <c>[z0, z1, z2, ..., zn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given arrays.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the input arrays do not contain data for the same number of coordinates.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYZ(Memory<double> x, Memory<double> y, Memory<double> z)
+        {
+            if (x.Length != y.Length || x.Length != z.Length)
+            {
+                throw new ArgumentException("Arrays must contain data for the same number of coordinates.");
+            }
+
+            Memory<double>[] rawData = { x, y, z };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (1, 0), (2, 0) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 0);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given array for reading
+        /// and writing X, Y, and Z data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="xy">
+        /// An array of X and Y values, laid out as
+        /// <c>[x0, y0, x1, y1, x2, y2, ..., xn, yn]</c>.
+        /// </param>
+        /// <param name="z">
+        /// An array of Z values, laid out as
+        /// <c>[z0, z1, z2, ..., zn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given array.
+        /// </returns>
+        /// <remarks>
+        /// The resulting instance is essentially a <see cref="DotSpatialAffineCoordinateSequence"/>
+        /// with slightly more overhead, so the main reason to prefer this over that one would be if
+        /// you <b>really</b> need to avoid copying the data to fit it into that format.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the length of <paramref name="xy"/> is not a multiple of 2, or when the
+        /// input arrays do not contain data for the same number of coordinates.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYZ(Memory<double> xy, Memory<double> z)
+        {
+            if (xy.Length % 2 != 0)
+            {
+                throw new ArgumentException("Length must be a multiple of 2.", nameof(xy));
+            }
+
+            if (xy.Length != z.Length * 2)
+            {
+                throw new ArgumentException("Arrays must contain data for the same number of coordinates.");
+            }
+
+            Memory<double>[] rawData = { xy, z };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (0, 1), (1, 0) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 0);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given array for reading
+        /// and writing X, Y, and Z data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="xyz">
+        /// An array of X, Y, and Z values, laid out as
+        /// <c>[x0, y0, z0, x1, y1, z1, x2, y2, z2, ..., xn, yn, zn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given array.
+        /// </returns>
+        /// <remarks>
+        /// The resulting instance is essentially a <see cref="PackedDoubleCoordinateSequence"/>
+        /// with slightly more overhead, so the main reason to prefer this over that one would be if
+        /// you <b>really</b> need to avoid copying the data to fit it into that format.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the length of <paramref name="xyz"/> is not a multiple of 3.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYZ(Memory<double> xyz)
+        {
+            if (xyz.Length % 3 != 0)
+            {
+                throw new ArgumentException("Length must be a multiple of 3.", nameof(xyz));
+            }
+
+            Memory<double>[] rawData = { xyz };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (0, 1), (0, 2) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 0);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given arrays for reading
+        /// and writing X, Y, and M data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="x">
+        /// An array of X values, laid out as
+        /// <c>[x0, x1, x2, ..., xn]</c>.
+        /// </param>
+        /// <param name="y">
+        /// An array of Y values, laid out as
+        /// <c>[y0, y1, y2, ..., yn]</c>.
+        /// </param>
+        /// <param name="m">
+        /// An array of M values, laid out as
+        /// <c>[m0, m1, m2, ..., mn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given arrays.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the input arrays do not contain data for the same number of coordinates.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYM(Memory<double> x, Memory<double> y, Memory<double> m)
+        {
+            if (x.Length != y.Length || x.Length != m.Length)
+            {
+                throw new ArgumentException("Arrays must contain data for the same number of coordinates.");
+            }
+
+            Memory<double>[] rawData = { x, y, m };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (1, 0), (2, 0) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 1);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given array for reading
+        /// and writing X, Y, and M data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="xy">
+        /// An array of X and Y values, laid out as
+        /// <c>[x0, y0, x1, y1, x2, y2, ..., xn, yn]</c>.
+        /// </param>
+        /// <param name="m">
+        /// An array of M values, laid out as
+        /// <c>[m0, m1, m2, ..., mn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given array.
+        /// </returns>
+        /// <remarks>
+        /// The resulting instance is essentially a <see cref="DotSpatialAffineCoordinateSequence"/>
+        /// with slightly more overhead, so the main reason to prefer this over that one would be if
+        /// you <b>really</b> need to avoid copying the data to fit it into that format.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the length of <paramref name="xy"/> is not a multiple of 2, or when the
+        /// input arrays do not contain data for the same number of coordinates.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYM(Memory<double> xy, Memory<double> m)
+        {
+            if (xy.Length % 2 != 0)
+            {
+                throw new ArgumentException("Length must be a multiple of 2.", nameof(xy));
+            }
+
+            if (xy.Length != m.Length * 2)
+            {
+                throw new ArgumentException("Arrays must contain data for the same number of coordinates.");
+            }
+
+            Memory<double>[] rawData = { xy, m };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (0, 1), (1, 0) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 1);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given array for reading
+        /// and writing X, Y, and M data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="xym">
+        /// An array of X, Y, and M values, laid out as
+        /// <c>[x0, y0, m0, x1, y1, m1, x2, y2, m2, ..., xn, yn, mn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given array.
+        /// </returns>
+        /// <remarks>
+        /// The resulting instance is essentially a <see cref="PackedDoubleCoordinateSequence"/>
+        /// with slightly more overhead, so the main reason to prefer this over that one would be if
+        /// you <b>really</b> need to avoid copying the data to fit it into that format.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the length of <paramref name="xym"/> is not a multiple of 3.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYM(Memory<double> xym)
+        {
+            if (xym.Length % 3 != 0)
+            {
+                throw new ArgumentException("Length must be a multiple of 3.", nameof(xym));
+            }
+
+            Memory<double>[] rawData = { xym };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (0, 1), (0, 2) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 1);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given arrays for reading
+        /// and writing X, Y, Z, and M data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="x">
+        /// An array of X values, laid out as
+        /// <c>[x0, x1, x2, ..., xn]</c>.
+        /// </param>
+        /// <param name="y">
+        /// An array of Y values, laid out as
+        /// <c>[y0, y1, y2, ..., yn]</c>.
+        /// </param>
+        /// <param name="z">
+        /// An array of Z values, laid out as
+        /// <c>[z0, z1, z2, ..., zn]</c>.
+        /// </param>
+        /// <param name="m">
+        /// An array of M values, laid out as
+        /// <c>[m0, m1, m2, ..., mn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given arrays.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the input arrays do not contain data for the same number of coordinates.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYZM(Memory<double> x, Memory<double> y, Memory<double> z, Memory<double> m)
+        {
+            if (x.Length != y.Length || x.Length != z.Length || x.Length != m.Length)
+            {
+                throw new ArgumentException("Arrays must contain data for the same number of coordinates.");
+            }
+
+            Memory<double>[] rawData = { x, y, z, m };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (1, 0), (2, 0), (3, 0) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 1);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given array for reading
+        /// and writing X, Y, Z, and M data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="xy">
+        /// An array of X and Y values, laid out as
+        /// <c>[x0, y0, x1, y1, x2, y2, ..., xn, yn]</c>.
+        /// </param>
+        /// <param name="z">
+        /// An array of Z values, laid out as
+        /// <c>[z0, z1, z2, ..., zn]</c>.
+        /// </param>
+        /// <param name="m">
+        /// An array of M values, laid out as
+        /// <c>[m0, m1, m2, ..., mn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given array.
+        /// </returns>
+        /// <remarks>
+        /// The resulting instance is essentially a <see cref="DotSpatialAffineCoordinateSequence"/>
+        /// with slightly more overhead, so the main reason to prefer this over that one would be if
+        /// you <b>really</b> need to avoid copying the data to fit it into that format.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the length of <paramref name="xy"/> is not a multiple of 2, or when the
+        /// input arrays do not contain data for the same number of coordinates.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYZM(Memory<double> xy, Memory<double> z, Memory<double> m)
+        {
+            if (xy.Length % 2 != 0)
+            {
+                throw new ArgumentException("Length must be a multiple of 2.", nameof(xy));
+            }
+
+            if (xy.Length != z.Length * 2 || z.Length != m.Length)
+            {
+                throw new ArgumentException("Arrays must contain data for the same number of coordinates.");
+            }
+
+            Memory<double>[] rawData = { xy, z, m };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (0, 1), (1, 0), (2, 0) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 1);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RawCoordinateSequence"/> that uses the given array for reading
+        /// and writing X, Y, Z, and M data ignoring the <see cref="Ordinates"/> flags that were passed
+        /// into the constructor for this factory instance.
+        /// </summary>
+        /// <param name="xyzm">
+        /// An array of X, Y, Z, and M values, laid out as
+        /// <c>[x0, y0, z0, m0, x1, y1, z1, m1, x2, y2, z2, m2, ..., xn, yn, zn, mn]</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RawCoordinateSequence"/> instance that's backed by the given array.
+        /// </returns>
+        /// <remarks>
+        /// The resulting instance is essentially a <see cref="PackedDoubleCoordinateSequence"/>
+        /// with slightly more overhead, so the main reason to prefer this over that one would be if
+        /// you <b>really</b> need to avoid copying the data to fit it into that format.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the length of <paramref name="xyzm"/> is not a multiple of 4.
+        /// </exception>
+        public static RawCoordinateSequence CreateXYZM(Memory<double> xyzm)
+        {
+            if (xyzm.Length % 4 != 0)
+            {
+                throw new ArgumentException("Length must be a multiple of 4.", nameof(xyzm));
+            }
+
+            Memory<double>[] rawData = { xyzm };
+            (int RawDataIndex, int DimensionIndex)[] dimensionMap = { (0, 0), (0, 1), (0, 2), (0, 3) };
+            return new RawCoordinateSequence(rawData, dimensionMap, measures: 1);
+        }
+
+        /// <inheritdoc />
+        public override CoordinateSequence Create(int size, int dimension, int measures)
+        {
+            int spatial = dimension - measures;
+            var ordinatesInGroups = _ordinatesInGroups;
+            var ordinatesInResult = Ordinates.None;
+            double[] underlyingData = new double[size * dimension];
+            var rawDataList = new List<Memory<double>>(dimension);
+            var remainingRawData = underlyingData.AsMemory();
+            var dimensionMap = new (int RawDataIndex, int DimensionIndex)[dimension];
+
+            for (int i = 0; i < spatial; i++)
+            {
+                if (i <= 16)
+                {
+                    var flag = (Ordinates)((int)Ordinates.Spatial1 << i);
+                    ordinatesInResult |= flag;
+                    if ((ordinatesInGroups & flag) != Ordinates.None)
+                    {
+                        continue;
+                    }
+                }
+
+                dimensionMap[i].RawDataIndex = rawDataList.Count;
+                rawDataList.Add(remainingRawData.Slice(0, size));
+                remainingRawData = remainingRawData.Slice(size);
+            }
+
+            for (int i = 0; i < measures; i++)
+            {
+                if (i <= 16)
+                {
+                    var flag = (Ordinates)((int)Ordinates.Measure1 << i);
+                    ordinatesInResult |= flag;
+                    if ((ordinatesInGroups & flag) != Ordinates.None)
+                    {
+                        continue;
+                    }
+                }
+
+                dimensionMap[spatial + i].RawDataIndex = rawDataList.Count;
+                rawDataList.Add(remainingRawData.Slice(0, size));
+                remainingRawData = remainingRawData.Slice(size);
+            }
+
+            if ((ordinatesInResult & ordinatesInGroups) == Ordinates.None)
+            {
+                return new RawCoordinateSequence(rawDataList.ToArray(), dimensionMap, measures);
+            }
+
+            foreach (var overallOrdinateGroup in _ordinateGroups)
+            {
+                var ordinateGroup = overallOrdinateGroup & ordinatesInResult;
+                if (ordinateGroup == Ordinates.None)
+                {
+                    continue;
+                }
+
+                int dimCountForGroup = 0;
+                for (int i = 0; i < spatial && i < 16; i++)
+                {
+                    if ((ordinateGroup & (Ordinates)((int)Ordinates.Spatial1 << i)) == Ordinates.None)
+                    {
+                        continue;
+                    }
+
+                    dimensionMap[i].RawDataIndex = rawDataList.Count;
+                    dimensionMap[i].DimensionIndex = dimCountForGroup++;
+                }
+
+                for (int i = 0; i < measures && i < 16; i++)
+                {
+                    if ((ordinateGroup & (Ordinates)((int)Ordinates.Measure1 << i)) == Ordinates.None)
+                    {
+                        continue;
+                    }
+
+                    dimensionMap[spatial + i].RawDataIndex = rawDataList.Count;
+                    dimensionMap[spatial + i].DimensionIndex = dimCountForGroup++;
+                }
+
+                rawDataList.Add(remainingRawData.Slice(0, size * dimCountForGroup));
+                remainingRawData = remainingRawData.Slice(size * dimCountForGroup);
+            }
+
+            return new RawCoordinateSequence(rawDataList.ToArray(), dimensionMap, measures);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateSequenceReversedTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/CoordinateSequenceReversedTest.cs
@@ -1,4 +1,5 @@
 ﻿using NetTopologySuite.Geometries;
+
 using NUnit.Framework;
 
 namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
@@ -37,6 +38,114 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
         {
             var csf = new NetTopologySuite.Geometries.Implementation.PackedFloatCoordinateSequence(
                 new[] { 0f, 0f, 1f, 4f, 10f, 10f, 2f, 3f, 10f, 0f, 3f, 2f, 0d, 0d, 4d, 1d }, 4, 1);
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceX_Y()
+        {
+            var csf = NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory.CreateXY(
+                new[] { 0d, 1d, 10d, 2d, 10d, 3d, 0d, 4d },
+                new[] { 0d, 4d, 10d, 3d, 0d, 2d, 0d, 1d });
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceXY()
+        {
+            var csf = NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory.CreateXY(
+                new[] { 0d, 0d, 1d, 4d, 10d, 10d, 2d, 3d, 10d, 0d, 3d, 2d, 0d, 0d, 4d, 1d });
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceX_Y_Z()
+        {
+            var csf = NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory.CreateXYZ(
+                new[] { 0d, 1d, 10d, 2d, 10d, 3d, 0d, 4d },
+                new[] { 0d, 4d, 10d, 3d, 0d, 2d, 0d, 1d },
+                new[] { 8d, 7d, 6d, 5d, 4d, 3d, 2d, 1d });
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceXY_Z()
+        {
+            var csf = NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory.CreateXYZ(
+                new[] { 0d, 0d, 1d, 4d, 10d, 10d, 2d, 3d, 10d, 0d, 3d, 2d, 0d, 0d, 4d, 1d },
+                new[] { 8d, 7d, 6d, 5d, 4d, 3d, 2d, 1d });
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceXYZ()
+        {
+            var csf = NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory.CreateXYZ(
+                new[] { 0d, 0d, 8d, 1d, 4d, 7d, 10d, 10d, 6d, 2d, 3d, 5d, 10d, 0d, 4d, 3d, 2d, 3d, 0d, 0d, 2d, 4d, 1d, 1d });
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceX_Y_Z_M()
+        {
+            var csf = NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory.CreateXYZM(
+                new[] { 0d, 1d, 10d, 2d, 10d, 3d, 0d, 4d },
+                new[] { 0d, 4d, 10d, 3d, 0d, 2d, 0d, 1d },
+                new[] { 8d, 7d, 6d, 5d, 4d, 3d, 2d, 1d },
+                new[] { -1d, -2d, -3d, -4d, -5d, -6d, -7d, -8d });
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceXY_Z_M()
+        {
+            var csf = NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory.CreateXYZM(
+                new[] { 0d, 0d, 1d, 4d, 10d, 10d, 2d, 3d, 10d, 0d, 3d, 2d, 0d, 0d, 4d, 1d },
+                new[] { 8d, 7d, 6d, 5d, 4d, 3d, 2d, 1d },
+                new[] { -1d, -2d, -3d, -4d, -5d, -6d, -7d, -8d });
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceXYZM()
+        {
+            var csf = NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory.CreateXYZM(
+                new[] { 0d, 0d, 8d, -1d, 1d, 4d, 7d, -2d, 10d, 10d, 6d, -3d, 2d, 3d, 5d, -4d, 10d, 0d, 4d, -5d, 3d, 2d, 3d, -6d, 0d, 0d, 2d, -7d, 4d, 1d, 1d, -8d });
+            var csr = csf.Reversed();
+            DoTest(csf, csr);
+        }
+
+        [Test]
+        public void TestRawCoordinateSequenceHighlyAtypical()
+        {
+            // 6 spatial dimensions plus 4 measures = 10 total dimensions.
+            // sprinkle their data throughout the various arrays that we create.
+            // note that Measure3 is not represented, so it goes by itself.
+            Ordinates[] ordinateGroups =
+            {
+                Ordinates.X | Ordinates.M,
+                Ordinates.Y | Ordinates.Z,
+                Ordinates.Spatial4 | Ordinates.Spatial5 | Ordinates.Measure2,
+                Ordinates.Spatial6 | Ordinates.Measure4,
+            };
+            var factory = new NetTopologySuite.Geometries.Implementation.RawCoordinateSequenceFactory(ordinateGroups);
+            var csf = factory.Create(102, 10, 4);
+            for (int i = 0; i < csf.Count; i++)
+            {
+                for (int j = 0; j < csf.Dimension; j++)
+                {
+                    csf.SetOrdinate(i, j, (i * 391) - (j * 23));
+                }
+            }
+
             var csr = csf.Reversed();
             DoTest(csf, csr);
         }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/RawCoordinateSequenceFactoryTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/RawCoordinateSequenceFactoryTest.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
+
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
+{
+    public sealed class RawCoordinateSequenceFactoryTest
+    {
+        [Test]
+        public void TestCreateX_Y()
+        {
+            double[] expectedXFull = { double.NaN, 1, 2, 3, 4, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedYFull = { double.NaN, 9, 8, 7, 6, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedX = expectedXFull.AsMemory(1, 4);
+            var expectedY = expectedYFull.AsMemory(1, 4);
+            var seq = RawCoordinateSequenceFactory.CreateXY(expectedX, expectedY);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedX, 1), (Ordinate.Y, expectedY, 1));
+        }
+
+        [Test]
+        public void TestCreateXY()
+        {
+            double[] expectedXYFull = { double.NaN, 1, 9, 2, 8, 3, 7, 4, 6, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedXY = expectedXYFull.AsMemory(1, 8);
+            var seq = RawCoordinateSequenceFactory.CreateXY(expectedXY);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedXY[..^1], 2), (Ordinate.Y, expectedXY[1..], 2));
+        }
+
+        [Test]
+        public void TestCreateX_Y_Z()
+        {
+            double[] expectedXFull = { double.NaN, 1, 2, 3, 4, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedYFull = { double.NaN, 9, 8, 7, 6, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedZFull = { double.NaN, 5, 5, 5, 5, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedX = expectedXFull.AsMemory(1, 4);
+            var expectedY = expectedYFull.AsMemory(1, 4);
+            var expectedZ = expectedZFull.AsMemory(1, 4);
+            var seq = RawCoordinateSequenceFactory.CreateXYZ(expectedX, expectedY, expectedZ);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedX, 1), (Ordinate.Y, expectedY, 1), (Ordinate.Z, expectedZ, 1));
+        }
+
+        [Test]
+        public void TestCreateXY_Z()
+        {
+            double[] expectedXYFull = { double.NaN, 1, 9, 2, 8, 3, 7, 4, 6, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedZFull = { double.NaN, 5, 5, 5, 5, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedXY = expectedXYFull.AsMemory(1, 8);
+            var expectedZ = expectedZFull.AsMemory(1, 4);
+            var seq = RawCoordinateSequenceFactory.CreateXYZ(expectedXY, expectedZ);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedXY[..^1], 2), (Ordinate.Y, expectedXY[1..], 2), (Ordinate.Z, expectedZ, 1));
+        }
+
+        [Test]
+        public void TestCreateXYZ()
+        {
+            double[] expectedXYZFull = { double.NaN, 1, 9, 5, 2, 8, 5, 3, 7, 5, 4, 6, 5, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedXYZ = expectedXYZFull.AsMemory(1, 12);
+            var seq = RawCoordinateSequenceFactory.CreateXYZ(expectedXYZ);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedXYZ[..^2], 3), (Ordinate.Y, expectedXYZ[1..^1], 3), (Ordinate.Z, expectedXYZ[2..], 3));
+        }
+
+        [Test]
+        public void TestCreateX_Y_M()
+        {
+            double[] expectedXFull = { double.NaN, 1, 2, 3, 4, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedYFull = { double.NaN, 9, 8, 7, 6, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedMFull = { double.NaN, 5, 5, 5, 5, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedX = expectedXFull.AsMemory(1, 4);
+            var expectedY = expectedYFull.AsMemory(1, 4);
+            var expectedZ = expectedMFull.AsMemory(1, 4);
+            var seq = RawCoordinateSequenceFactory.CreateXYM(expectedX, expectedY, expectedZ);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedX, 1), (Ordinate.Y, expectedY, 1), (Ordinate.M, expectedZ, 1));
+        }
+
+        [Test]
+        public void TestCreateXY_M()
+        {
+            double[] expectedXYFull = { double.NaN, 1, 9, 2, 8, 3, 7, 4, 6, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedMFull = { double.NaN, 5, 5, 5, 5, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedXY = expectedXYFull.AsMemory(1, 8);
+            var expectedZ = expectedMFull.AsMemory(1, 4);
+            var seq = RawCoordinateSequenceFactory.CreateXYM(expectedXY, expectedZ);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedXY[..^1], 2), (Ordinate.Y, expectedXY[1..], 2), (Ordinate.M, expectedZ, 1));
+        }
+
+        [Test]
+        public void TestCreateXYM()
+        {
+            double[] expectedXYMFull = { double.NaN, 1, 9, 5, 2, 8, 5, 3, 7, 5, 4, 6, 5, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedXYM = expectedXYMFull.AsMemory(1, 12);
+            var seq = RawCoordinateSequenceFactory.CreateXYM(expectedXYM);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedXYM[..^2], 3), (Ordinate.Y, expectedXYM[1..^1], 3), (Ordinate.M, expectedXYM[2..], 3));
+        }
+
+        [Test]
+        public void TestCreateX_Y_Z_M()
+        {
+            double[] expectedXFull = { double.NaN, 1, 2, 3, 4, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedYFull = { double.NaN, 9, 8, 7, 6, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedZFull = { double.NaN, 5, 5, 5, 5, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedMFull = { double.NaN, 0, 0, 0, 0, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedX = expectedXFull.AsMemory(1, 4);
+            var expectedY = expectedYFull.AsMemory(1, 4);
+            var expectedZ = expectedZFull.AsMemory(1, 4);
+            var expectedM = expectedMFull.AsMemory(1, 4);
+            var seq = RawCoordinateSequenceFactory.CreateXYZM(expectedX, expectedY, expectedZ, expectedM);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedX, 1), (Ordinate.Y, expectedY, 1), (Ordinate.Z, expectedZ, 1), (Ordinate.M, expectedM, 1));
+        }
+
+        [Test]
+        public void TestCreateXY_Z_M()
+        {
+            double[] expectedXYFull = { double.NaN, 1, 9, 2, 8, 3, 7, 4, 6, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedZFull = { double.NaN, 5, 5, 5, 5, double.PositiveInfinity, double.NegativeInfinity };
+            double[] expectedMFull = { double.NaN, 0, 0, 0, 0, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedXY = expectedXYFull.AsMemory(1, 8);
+            var expectedZ = expectedZFull.AsMemory(1, 4);
+            var expectedM = expectedMFull.AsMemory(1, 4);
+            var seq = RawCoordinateSequenceFactory.CreateXYZM(expectedXY, expectedZ, expectedM);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedXY[..^1], 2), (Ordinate.Y, expectedXY[1..], 2), (Ordinate.Z, expectedZ, 1), (Ordinate.M, expectedM, 1));
+        }
+
+        [Test]
+        public void TestCreateXYZM()
+        {
+            double[] expectedXYZMFull = { double.NaN, 1, 9, 5, 0, 2, 8, 5, 0, 3, 7, 5, 0, 4, 6, 5, 0, double.PositiveInfinity, double.NegativeInfinity };
+
+            var expectedXYZM = expectedXYZMFull.AsMemory(1, 16);
+            var seq = RawCoordinateSequenceFactory.CreateXYZM(expectedXYZM);
+            AssertRawCoordinates(seq, (Ordinate.X, expectedXYZM[..^3], 4), (Ordinate.Y, expectedXYZM[1..^2], 4), (Ordinate.Z, expectedXYZM[2..^1], 4), (Ordinate.M, expectedXYZM[3..], 4));
+        }
+
+        [Test]
+        public void TestCreateHighlyAtypical()
+        {
+            // 6 spatial dimensions plus 4 measures = 10 total dimensions.
+            // sprinkle their data throughout the various arrays that we create.
+            // note that Measure3 is not represented, so it goes by itself.
+            Ordinates[] ordinateGroups =
+            {
+                Ordinates.X | Ordinates.M,
+                Ordinates.Y | Ordinates.Z,
+                Ordinates.Spatial4 | Ordinates.Spatial5 | Ordinates.Measure2,
+                Ordinates.Spatial6 | Ordinates.Measure4,
+            };
+            var factory = new RawCoordinateSequenceFactory(ordinateGroups);
+            var untypedSeq = factory.Create(102, 10, 4);
+            Assert.That(untypedSeq, Is.InstanceOf<RawCoordinateSequence>());
+            var seq = (RawCoordinateSequence)untypedSeq;
+
+            // The data should be grouped according to what we requested.
+            AssertOrdinateGroup(Ordinate.X, Ordinate.M);
+            AssertOrdinateGroup(Ordinate.Y, Ordinate.Z);
+            AssertOrdinateGroup(Ordinate.Spatial4, Ordinate.Spatial5, Ordinate.Measure2);
+            AssertOrdinateGroup(Ordinate.Spatial6, Ordinate.Measure4);
+            AssertOrdinateGroup(Ordinate.Measure3);
+
+            // set all the values...
+            for (int i = 0; i < seq.Count; i++)
+            {
+                for (int j = 0; j < seq.Dimension; j++)
+                {
+                    seq.SetOrdinate(i, j, ExpectedOrdinateValue(i, j));
+                }
+            }
+
+            // ...and make sure that they all got set uniquely.
+            for (int i = 0; i < seq.Count; i++)
+            {
+                for (int j = 0; j < seq.Dimension; j++)
+                {
+                    Assert.That(seq.GetOrdinate(i, j), Is.EqualTo(ExpectedOrdinateValue(i, j)));
+                }
+            }
+
+            void AssertOrdinateGroup(params Ordinate[] ordinates)
+            {
+                int[] ordinateIndexes = new int[ordinates.Length];
+                Assert.Multiple(
+                    () =>
+                    {
+                        for (int i = 0; i < ordinates.Length; i++)
+                        {
+                            Assert.That(seq.TryGetOrdinateIndex(ordinates[i], out ordinateIndexes[i]));
+                        }
+                    });
+
+                // sort the ordinate indexes according to the order they appear in their array.
+                Span<int> toSort = ordinateIndexes;
+                while (toSort.Length > 1)
+                {
+                    int minIndex = 0;
+                    ref double min = ref FirstVal(toSort[minIndex]);
+                    for (int i = 1; i < toSort.Length; i++)
+                    {
+                        ref double nxt = ref FirstVal(toSort[i]);
+                        if (Unsafe.IsAddressLessThan(ref nxt, ref min))
+                        {
+                            min = ref nxt;
+                            minIndex = i;
+                        }
+                    }
+
+                    if (minIndex != 0)
+                    {
+                        (toSort[0], toSort[minIndex]) = (toSort[minIndex], toSort[0]);
+                    }
+
+                    toSort = toSort[1..];
+                }
+
+                // ensure that each ordinate's raw data comes immediately after the previous one's
+                int minOrdinateIndex = ordinateIndexes[0];
+                ref double prev = ref FirstVal(minOrdinateIndex);
+                for (int i = 1; i < ordinateIndexes.Length; i++)
+                {
+                    ref double curr = ref FirstVal(ordinateIndexes[i]);
+                    Assert.That(Unsafe.AreSame(ref Unsafe.Add(ref prev, 1), ref curr));
+                    prev = ref curr;
+                }
+
+                // ensure that there are no gaps between the raw data for two coordinates.
+                Assert.That(
+                    Unsafe.AreSame(
+                        ref Unsafe.Add(ref prev, 1),
+                        ref SecondVal(minOrdinateIndex)));
+
+                ref double FirstVal(int ordinateIndex)
+                {
+                    var array = seq.GetRawCoordinatesAndStride(ordinateIndex).Array;
+                    return ref MemoryMarshal.GetReference(array.Span);
+                }
+
+                ref double SecondVal(int ordinateIndex)
+                {
+                    (var array, int stride) = seq.GetRawCoordinatesAndStride(ordinateIndex);
+                    return ref array.Span[stride];
+                }
+            }
+
+            double ExpectedOrdinateValue(double i, double j)
+            {
+                return (i * seq.Dimension) + j;
+            }
+        }
+
+        private static void AssertRawCoordinates(RawCoordinateSequence seq, params (Ordinate ordinate, ReadOnlyMemory<double> Memory, int Stride)[] allExpected)
+        {
+            Assert.That(seq.Dimension, Is.EqualTo(allExpected.Length));
+            Assert.Multiple(
+                () =>
+                {
+                    for (int i = 0; i < allExpected.Length; i++)
+                    {
+                        (var ordinate, var expectedMemory, int expectedStride) = allExpected[i];
+                        if (seq.TryGetOrdinateIndex(ordinate, out int ordinateIndex))
+                        {
+                            Assert.That(ordinateIndex, Is.EqualTo(i));
+                        }
+                        else
+                        {
+                            Assert.Fail("TryGetOrdinateIndex returned false for ordinate {0}", ordinate);
+                        }
+
+                        (var actualMemory, int actualStride) = seq.GetRawCoordinatesAndStride(i);
+                        Assert.That(actualStride, Is.EqualTo(expectedStride));
+                        if (expectedMemory.Length > actualMemory.Length)
+                        {
+                            Assert.Fail("Expected at least {0} elements for {1}, but got {2}", expectedMemory.Length, ordinate, actualMemory.Length);
+                        }
+                        else
+                        {
+                            Assert.That(actualMemory.Slice(0, expectedMemory.Length), Is.EqualTo(expectedMemory));
+                        }
+                    }
+                });
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/RawCoordinateSequenceFactoryTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/RawCoordinateSequenceFactoryTest.cs
@@ -280,14 +280,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
 
                         (var actualMemory, int actualStride) = seq.GetRawCoordinatesAndStride(i);
                         Assert.That(actualStride, Is.EqualTo(expectedStride));
-                        if (expectedMemory.Length > actualMemory.Length)
-                        {
-                            Assert.Fail("Expected at least {0} elements for {1}, but got {2}", expectedMemory.Length, ordinate, actualMemory.Length);
-                        }
-                        else
-                        {
-                            Assert.That(actualMemory.Slice(0, expectedMemory.Length), Is.EqualTo(expectedMemory));
-                        }
+                        Assert.That(seq.GetRawCoordinatesAndStride(i), Is.EqualTo((expectedMemory, expectedStride)));
                     }
                 });
         }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/RawCoordinateSequenceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/RawCoordinateSequenceTest.cs
@@ -19,6 +19,23 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
             var cs = CsFactory.Create(new[] { new Coordinate(0, 10) });
             Assert.That(cs.ToCoordinateArray, Throws.Nothing);
         }
+
+        [Test]
+        public void TestEmpty()
+        {
+            var untypedSeq = CsFactory.Create(0, Ordinates.AllOrdinates);
+            Assert.That(untypedSeq, Is.InstanceOf<RawCoordinateSequence>());
+            var seq = (RawCoordinateSequence)untypedSeq;
+            for (int i = 0; i < seq.Dimension; i++)
+            {
+                (var array, int stride) = seq.GetRawCoordinatesAndStride(i);
+                Assert.That(stride, Is.Not.Zero);
+                for (int j = 0; j < array.Length; j += stride)
+                {
+                    Assert.Fail("Array was supposed to be empty.");
+                }
+            }
+        }
     }
 
     public sealed class RawCoordinateSequenceTestSoA : RawCoordinateSequenceTest

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/RawCoordinateSequenceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Implementation/RawCoordinateSequenceTest.cs
@@ -1,0 +1,43 @@
+using System;
+
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
+
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Implementation
+{
+    public abstract class RawCoordinateSequenceTest : CoordinateSequenceTestBase
+    {
+        protected abstract Ordinates[] OrdinateGroups { get; }
+
+        protected sealed override CoordinateSequenceFactory CsFactory => new RawCoordinateSequenceFactory(OrdinateGroups);
+
+        [Test]
+        public void Test499()
+        {
+            var cs = CsFactory.Create(new[] { new Coordinate(0, 10) });
+            Assert.That(cs.ToCoordinateArray, Throws.Nothing);
+        }
+    }
+
+    public sealed class RawCoordinateSequenceTestSoA : RawCoordinateSequenceTest
+    {
+        protected override Ordinates[] OrdinateGroups => Array.Empty<Ordinates>();
+    }
+
+    public sealed class RawCoordinateSequenceTestAoS : RawCoordinateSequenceTest
+    {
+        protected override Ordinates[] OrdinateGroups => new[] { Ordinates.AllOrdinates };
+    }
+
+    public sealed class RawCoordinateSequenceTestMixed1 : RawCoordinateSequenceTest
+    {
+        protected override Ordinates[] OrdinateGroups => new[] { Ordinates.XY, Ordinates.Z | Ordinates.M };
+    }
+
+    public sealed class RawCoordinateSequenceTestMixed2 : RawCoordinateSequenceTest
+    {
+        protected override Ordinates[] OrdinateGroups => new[] { Ordinates.X | Ordinates.Z, Ordinates.Y | Ordinates.M };
+    }
+}


### PR DESCRIPTION
Note that "lower-level" does not necessarily mean that typical usage will be faster than when using other sequence types.  In fact, many use cases will see slower accesses, on average.

Rather, this sequence type is intended to provide callers with more flexibility to manage their own memory and data layout, reducing the number of situations where data must be copied in order to produce and consume the sequence.

The only known "blind spot" where copying is still needed even in sequential memory layouts is in situations where the underlying coordinate data is mixed in with non-coordinate data, e.g., if the sequence looks something like:
```
[x0, y0, z0, OTHER_STUFF, x1, y1, z1, OTHER_STUFF, ..., xn, yn, zn, OTHER_STUFF]
```

Otherwise, as long as your coordinate data is all laid out consistently and sequentially in virtual memory, this sequence should work for you.  You **may** need to implement your own `MemoryManager<double>` to make it work for you (e.g., if you produce and consume the entire sequence data in stack-only memory), but if you have something like `Memory<byte>` that you just need to convert to `Memory<double>`, check out [`MemoryExtensions.Cast<TFrom, TTo>`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.highperformance.memoryextensions.cast?view=win-comm-toolkit-dotnet-7.0) from the [`Microsoft.Toolkit.HighPerformance`](https://www.nuget.org/packages/Microsoft.Toolkit.HighPerformance) package.

Resolves #482.