### PR TITLE
Reuse the objects to improve the performance of parsing WKTs.

### DIFF
--- a/src/NetTopologySuite/ApiCompatBaseline.txt
+++ b/src/NetTopologySuite/ApiCompatBaseline.txt
@@ -1,0 +1,3 @@
+Compat issues with assembly NetTopologySuite:
+CannotChangeAttribute : Attribute 'System.Runtime.CompilerServices.IteratorStateMachineAttribute' on 'RTools_NTS.Util.StreamTokenizer.GetEnumerator()' changed from '[IteratorStateMachineAttribute(typeof(StreamTokenizer.<GetEnumerator>d__33))]' in the contract to '[IteratorStateMachineAttribute(typeof(StreamTokenizer.<GetEnumerator>d__34))]' in the implementation.
+Total Issues: 1

--- a/src/NetTopologySuite/IO/WKTReader.cs
+++ b/src/NetTopologySuite/IO/WKTReader.cs
@@ -44,6 +44,8 @@ namespace NetTopologySuite.IO
 
         private static readonly CoordinateSequenceFactory CoordinateSequenceFactoryXYZM = CoordinateArraySequenceFactory.Instance;
 
+        private static readonly StreamTokenizerSettings tokenizerSettings;
+
         private NtsGeometryServices _ntsGeometryServices;
 
         private int? _overriddenDefaultSRID;
@@ -55,6 +57,23 @@ namespace NetTopologySuite.IO
          * true if structurally invalid input should be reported rather than repaired.
          */
         private bool _isStrict = true;
+
+        static WKTReader()
+        {
+            tokenizerSettings = new StreamTokenizerSettings();
+            tokenizerSettings.SetDefaults();
+            // set tokenizer to NOT parse numbers
+            tokenizerSettings.ResetCharTypeTable();
+            tokenizerSettings.WordChars('a', 'z');
+            tokenizerSettings.WordChars('A', 'Z');
+            ////tokenizer.Settings.WordChars(128 + 32, 255);
+            tokenizerSettings.WordChars('0', '9');
+            tokenizerSettings.WordChars('-', '-');
+            tokenizerSettings.WordChars('+', '+');
+            tokenizerSettings.WordChars('.', '.');
+            tokenizerSettings.WhitespaceChars(0, ' ');
+            tokenizerSettings.CommentChar('#');
+        }
 
         /// <summary>
         /// Creates a <c>WKTReader</c> that creates objects using a basic GeometryFactory.
@@ -203,19 +222,7 @@ namespace NetTopologySuite.IO
 
         internal TokenStream Tokenizer(TextReader reader)
         {
-            var tokenizer = new StreamTokenizer(reader);
-
-            // set tokenizer to NOT parse numbers
-            tokenizer.Settings.ResetCharTypeTable();
-            tokenizer.Settings.WordChars('a', 'z');
-            tokenizer.Settings.WordChars('A', 'Z');
-            ////tokenizer.Settings.WordChars(128 + 32, 255);
-            tokenizer.Settings.WordChars('0', '9');
-            tokenizer.Settings.WordChars('-', '-');
-            tokenizer.Settings.WordChars('+', '+');
-            tokenizer.Settings.WordChars('.', '.');
-            tokenizer.Settings.WhitespaceChars(0, ' ');
-            tokenizer.Settings.CommentChar('#');
+            var tokenizer = new StreamTokenizer(reader, tokenizerSettings);
             return new TokenStream(tokenizer.GetEnumerator());
         }
 

--- a/src/NetTopologySuite/Utilities/RToolsUtil/StreamTokenizer.cs
+++ b/src/NetTopologySuite/Utilities/RToolsUtil/StreamTokenizer.cs
@@ -705,6 +705,18 @@ namespace RTools_NTS.Util
         }
 
         /// <summary>
+        /// Construct and set this object's TextReader to the one specified.
+        /// </summary>
+        /// <param name="sr">The TextReader to read from.</param>
+        /// <param name="tokenizerSettings">Tokenizer settings.</param>
+        public StreamTokenizer(TextReader sr, StreamTokenizerSettings tokenizerSettings)
+        {
+            settings = tokenizerSettings;
+            Initialize();
+            textReader = sr;
+        }
+
+        /// <summary>
         /// Construct and set a string to tokenize.
         /// </summary>
         /// <param name="str">The string to tokenize.</param>
@@ -723,8 +735,11 @@ namespace RTools_NTS.Util
             nextTokenSb = new CharBuffer(1024);
 
             InitializeStream();
-            settings = new StreamTokenizerSettings();
-            settings.SetDefaults();
+            if (null == settings)
+            {
+                settings = new StreamTokenizerSettings();
+                settings.SetDefaults();
+            }
 
             expSb = new CharBuffer();
             tmpSb = new CharBuffer();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->

### Description
Currently new StreamTokenizerSettings object is allocated with every WKT parsing. This shows up as hot path for Point and Line WKT parsing. To avoid allocation of these objects, instantiate it one time and reuse it for all WKT parsing.

