### PR TITLE
Improve CoordinateSequences.Copy

### DIFF
--- a/src/NetTopologySuite/Geometries/CoordinateSequences.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateSequences.cs
@@ -103,29 +103,31 @@ namespace NetTopologySuite.Geometries
                     break;
 
                 // investigate spatial ordinate
-                var ordinate = (Ordinates)(1 << i);
+                var ordinateFlag = (Ordinates)(1 << i);
+                var ordinate = (Ordinate)i;
 
                 // is ordinate common to both sequences?
-                if ((commonOrdinates & ordinate) == ordinate)
+                if ((commonOrdinates & ordinateFlag) == ordinateFlag)
                 {
-                    seq0.TryGetOrdinateIndex((Ordinate)i, out int index);
+                    seq0.TryGetOrdinateIndex(ordinate, out int index);
                     srcIndexList.Add(index);
-                    seq1.TryGetOrdinateIndex((Ordinate)i, out index);
+                    seq1.TryGetOrdinateIndex(ordinate, out index);
                     destIndexList.Add(index);
-                    ordinatesChecked |= ordinate;
+                    ordinatesChecked |= ordinateFlag;
                 }
 
                 // investigate non-spatial ordinate
-                ordinate = (Ordinates)(1 << (i+16));
+                ordinateFlag = (Ordinates)(1 << (i+16));
+                ordinate = (Ordinate)(i + 16);
 
                 // is ordinate common to both sequences?
-                if ((commonOrdinates & ordinate) == ordinate)
+                if ((commonOrdinates & ordinateFlag) == ordinateFlag)
                 {
-                    seq0.TryGetOrdinateIndex((Ordinate)i, out int index);
+                    seq0.TryGetOrdinateIndex(ordinate, out int index);
                     srcIndexList.Add(index);
-                    seq1.TryGetOrdinateIndex((Ordinate)i, out index);
+                    seq1.TryGetOrdinateIndex(ordinate, out index);
                     destIndexList.Add(index);
-                    ordinatesChecked |= ordinate;
+                    ordinatesChecked |= ordinateFlag;
                 }
             }
 

--- a/src/NetTopologySuite/Geometries/CoordinateSequences.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateSequences.cs
@@ -73,66 +73,13 @@ namespace NetTopologySuite.Geometries
                     return;
             }
 
-            GetCommonOrdinateIndices(src, dest, out int[] srcIndices, out int[] destIndices);
+            // Test for max ordinate indices to copy
+            int minSpatial = Math.Min(src.Spatial, dest.Spatial);
+            int minMeasures = Math.Min(src.Measures, dest.Measures);
 
             // Copy one by one
             for (int i = 0; i < length; i++)
-                CopyCoord(src, srcPos + i, srcIndices, dest, destPos + i, destIndices);
-        }
-
-        /// <summary>
-        /// Get the common ordinate indices of two <c>CoordinateSequence</c>s.
-        /// </summary>
-        /// <param name="seq0">A <c>CoordinateSequence</c></param>
-        /// <param name="seq1">A <c>CoordinateSequence</c></param>
-        /// <param name="seq0Indices">The array of common ordinate indices as in <paramref name="seq0"/></param>
-        /// <param name="seq1Indices">The array of common ordinate indices as in <paramref name="seq1"/></param>
-        private static void GetCommonOrdinateIndices(CoordinateSequence seq0, CoordinateSequence seq1,
-            out int[] seq0Indices, out int[] seq1Indices)
-        {
-            var srcIndexList = new List<int>(16);
-            var destIndexList = new List<int>(16);
-            var commonOrdinates = seq0.Ordinates & seq1.Ordinates;
-            var ordinatesChecked = Ordinates.None;
-
-            // Check all spatial and non-spatial ordinate values
-            for (int i = 0; i < 16; i++)
-            {
-                // if indices of all common ordinates were gathered then exit
-                if (commonOrdinates == ordinatesChecked)
-                    break;
-
-                // investigate spatial ordinate
-                var ordinateFlag = (Ordinates)(1 << i);
-                var ordinate = (Ordinate)i;
-
-                // is ordinate common to both sequences?
-                if ((commonOrdinates & ordinateFlag) == ordinateFlag)
-                {
-                    seq0.TryGetOrdinateIndex(ordinate, out int index);
-                    srcIndexList.Add(index);
-                    seq1.TryGetOrdinateIndex(ordinate, out index);
-                    destIndexList.Add(index);
-                    ordinatesChecked |= ordinateFlag;
-                }
-
-                // investigate non-spatial ordinate
-                ordinateFlag = (Ordinates)(1 << (i+16));
-                ordinate = (Ordinate)(i + 16);
-
-                // is ordinate common to both sequences?
-                if ((commonOrdinates & ordinateFlag) == ordinateFlag)
-                {
-                    seq0.TryGetOrdinateIndex(ordinate, out int index);
-                    srcIndexList.Add(index);
-                    seq1.TryGetOrdinateIndex(ordinate, out index);
-                    destIndexList.Add(index);
-                    ordinatesChecked |= ordinateFlag;
-                }
-            }
-
-            seq0Indices = srcIndexList.ToArray();
-            seq1Indices = destIndexList.ToArray();
+                CopyCoord(src, srcPos + i, dest, destPos + i, minSpatial, minMeasures);
         }
 
         /// <summary>
@@ -191,7 +138,6 @@ namespace NetTopologySuite.Geometries
             return true;
         }
 
-
         /// <summary>
         /// Copies a section of a <see cref="PackedDoubleCoordinateSequence"/> to another <see cref="PackedDoubleCoordinateSequence"/>.
         /// The sequences must have same dimensions.
@@ -229,6 +175,7 @@ namespace NetTopologySuite.Geometries
 
             return true;
         }
+
         /// <summary>
         /// Copies a coordinate of a <see cref="CoordinateSequence"/> to another <see cref="CoordinateSequence"/>.
         /// The sequences may have different dimensions;
@@ -240,22 +187,35 @@ namespace NetTopologySuite.Geometries
         /// <param name="destPos">The index of the coordinate in <see paramref="dest"/></param>
         public static void CopyCoord(CoordinateSequence src, int srcPos, CoordinateSequence dest, int destPos)
         {
-            GetCommonOrdinateIndices(src, dest, out int[] srcIndices, out int[] destIndices);
-            CopyCoord(src, srcPos, srcIndices, dest, destPos, destIndices);
+            int minSpatial = Math.Min(src.Spatial, dest.Spatial);
+            int minMeasures = Math.Min(src.Measures, dest.Measures);
+            CopyCoord(src, srcPos, dest, destPos, minSpatial, minMeasures);
         }
 
-        private static void CopyCoord(CoordinateSequence src, int srcPos, int[] srcIndices,
-                                      CoordinateSequence dest, int destPos, int[] destIndices)
+        /// <summary>
+        /// Copies a coordinate of a <see cref="CoordinateSequence"/> to another <see cref="CoordinateSequence"/>.
+        /// The sequences may have different dimensions;
+        /// in this case only the common dimensions are copied.
+        /// </summary>
+        /// <param name="src">The sequence to copy coordinate from</param>
+        /// <param name="srcPos">The index of the coordinate to copy</param>
+        /// <param name="dest">The sequence to which the coordinate should be copied to</param>
+        /// <param name="destPos">The index of the coordinate in <see paramref="dest"/></param>
+        /// <param name="numSpatial">The number of spatial ordinates to copy</param>
+        /// <param name="numMeasures">The number of measure ordinates to copy</param>
+        private static void CopyCoord(CoordinateSequence src, int srcPos, CoordinateSequence dest, int destPos,
+            int numSpatial, int numMeasures)
         {
-            if (srcIndices.Length != destIndices.Length)
-                throw new ArgumentException(nameof(destIndices));
+            // Copy spatial ordinates
+            for (int dim = 0; dim < numSpatial; dim++)
+                dest.SetOrdinate(destPos, dim, src.GetOrdinate(srcPos, dim));
 
-            for (int dim = 0; dim < srcIndices.Length; dim++)
-            {
-                double value = src.GetOrdinate(srcPos, srcIndices[dim]);
-                dest.SetOrdinate(destPos, destIndices[dim], value);
-            }
+            // Copy measure ordinates
+            for (int measure = 0; measure < numMeasures; measure++)
+                dest.SetOrdinate(destPos, dest.Spatial + measure,
+                    src.GetOrdinate(srcPos, src.Spatial + measure));
         }
+
         /// <summary>
         /// Tests whether a <see cref="CoordinateSequence"/> forms a valid <see cref="LinearRing"/>,
         /// by checking the sequence length and closure
@@ -306,13 +266,13 @@ namespace NetTopologySuite.Geometries
 
         private static CoordinateSequence CreateClosedRing(CoordinateSequenceFactory fact, CoordinateSequence seq, int size)
         {
-            var newseq = fact.Create(size, seq.Dimension, seq.Measures);
+            var newSeq = fact.Create(size, seq.Dimension, seq.Measures);
             int n = seq.Count;
-            Copy(seq, 0, newseq, 0, n);
+            Copy(seq, 0, newSeq, 0, n);
             // fill remaining coordinates with start point
             for (int i = n; i < size; i++)
-                Copy(seq, 0, newseq, i, 1);
-            return newseq;
+                Copy(seq, 0, newSeq, i, 1);
+            return newSeq;
         }
 
         /// <summary>
@@ -330,7 +290,7 @@ namespace NetTopologySuite.Geometries
         /// <returns>The extended sequence</returns>
         public static CoordinateSequence Extend(CoordinateSequenceFactory fact, CoordinateSequence seq, int size)
         {
-            var newSeq = fact.Create(size, seq.Ordinates);
+            var newSeq = fact.Create(size, seq.Dimension, seq.Measures);
             int n = seq.Count;
             Copy(seq, 0, newSeq, 0, n);
             // fill remaining coordinates with end point, if it exists
@@ -350,31 +310,76 @@ namespace NetTopologySuite.Geometries
         /// must be equal.
         /// Two <c>NaN</c> ordinates values are considered to be equal.
         /// </summary>
-        /// <param name="cs1">a CoordinateSequence</param>
-        /// <param name="cs2">a CoordinateSequence</param>
+        /// <param name="seq1">a CoordinateSequence</param>
+        /// <param name="seq2">a CoordinateSequence</param>
         /// <returns><c>true</c> if the sequences are equal in the common dimensions</returns>
-        public static bool IsEqual(CoordinateSequence cs1, CoordinateSequence cs2)
+        public static bool IsEqual(CoordinateSequence seq1, CoordinateSequence seq2)
         {
-            int cs1Size = cs1.Count;
-            int cs2Size = cs2.Count;
+            int cs1Size = seq1.Count;
+            int cs2Size = seq2.Count;
             if (cs1Size != cs2Size)
                 return false;
-            int dim = Math.Min(cs1.Dimension, cs2.Dimension);
+
+            int minSpatial = Math.Min(seq1.Spatial, seq2.Spatial);
+            int minMeasures = Math.Min(seq1.Measures, seq2.Measures);
             for (int i = 0; i < cs1Size; i++)
             {
-                for (int d = 0; d < dim; d++)
-                {
-                    double v1 = cs1.GetOrdinate(i, d);
-                    double v2 = cs2.GetOrdinate(i, d);
-                    if (v1 == v2)
-                        continue;
-                    // special check for NaNs
-                    else if (double.IsNaN(v1) && double.IsNaN(v2))
-                        continue;
-                    else
-                        return false;
-                }
+                if (!IsEqualAt(seq1, i, seq2, i, minSpatial, minMeasures))
+                    return false;
             }
+            return true;
+        }
+
+        /// <summary>
+        /// Tests whether two <c>Coordinate</c>s <see cref="CoordinateSequence"/>s are equal.
+        /// They do not need to be of the same dimension,
+        /// but the ordinate values for the common ordinates of the two
+        /// must be equal.
+        /// Two <c>NaN</c> ordinates values are considered to be equal.
+        /// </summary>
+        /// <param name="seq1">A CoordinateSequence</param>
+        /// <param name="pos1">The index of the <c>Coordinate</c> in <paramref name="seq1"/>.</param>
+        /// <param name="seq2">a CoordinateSequence</param>
+        /// <param name="pos2">The index of the <c>Coordinate</c> in <paramref name="seq2"/>.</param>
+        /// <returns><c>true</c> if the sequences are equal in the common dimensions</returns>
+        public static bool IsEqualAt(CoordinateSequence seq1, int pos1, CoordinateSequence seq2, int pos2)
+        {
+            int minSpatial = Math.Min(seq1.Spatial, seq2.Spatial);
+            int minMeasures = Math.Min(seq1.Measures, seq2.Measures);
+            return IsEqualAt(seq1, pos1, seq2, pos2, minSpatial, minMeasures);
+        }
+
+        /// <summary>
+        /// Tests whether two <c>Coordinate</c>s <see cref="CoordinateSequence"/>s are equal.
+        /// They do not need to be of the same dimension,
+        /// but the ordinate values for the common ordinates of the two
+        /// must be equal.
+        /// Two <c>NaN</c> ordinates values are considered to be equal.
+        /// </summary>
+        /// <param name="seq1">A CoordinateSequence</param>
+        /// <param name="pos1">The index of the <c>Coordinate</c> in <paramref name="seq1"/>.</param>
+        /// <param name="seq2">a CoordinateSequence</param>
+        /// <param name="pos2">The index of the <c>Coordinate</c> in <paramref name="seq2"/>.</param>
+        /// <param name="numSpatial">The number of spatial ordinates to compare</param>
+        /// <param name="numMeasures">The number of measure ordinates to compare</param>
+        /// <returns><c>true</c> if the sequences are equal in the common dimensions</returns>
+        private static bool IsEqualAt(CoordinateSequence seq1, int pos1, CoordinateSequence seq2, int pos2,
+            int numSpatial, int numMeasures)
+        {
+            for (int i = 0; i < numSpatial; i++)
+            {
+                double v1 = seq1.GetOrdinate(pos1, i);
+                double v2 = seq2.GetOrdinate(pos2, i);
+                if (!v1.Equals(v2)) return false;
+            }
+
+            for (int i = 0; i < numMeasures; i++)
+            {
+                double v1 = seq1.GetOrdinate(pos1, seq1.Spatial + i);
+                double v2 = seq2.GetOrdinate(pos2, seq2.Spatial + i);
+                if (!v1.Equals(v2)) return false;
+            }
+
             return true;
         }
 

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateSequencesTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateSequencesTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection.PortableExecutable;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Implementation;
 using NUnit.Framework;
@@ -108,10 +109,10 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         public void TestCopyDifferent3rd()
         {
             TestContext.WriteLine("Testing copy");
-            DoTestCopyDifferent3rd(CoordinateArraySequenceFactory.Instance);
-            DoTestCopyDifferent3rd(PackedCoordinateSequenceFactory.DoubleFactory);
-            DoTestCopyDifferent3rd(PackedCoordinateSequenceFactory.FloatFactory);
-            DoTestCopyDifferent3rd(DotSpatialAffineCoordinateSequenceFactory.Instance);
+            DoTestCopyDifferentDim(CoordinateArraySequenceFactory.Instance);
+            DoTestCopyDifferentDim(PackedCoordinateSequenceFactory.DoubleFactory);
+            DoTestCopyDifferentDim(PackedCoordinateSequenceFactory.FloatFactory);
+            DoTestCopyDifferentDim(DotSpatialAffineCoordinateSequenceFactory.Instance);
         }
 
         [Test]
@@ -188,11 +189,11 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             // ToDo test if dimensions don't match
         }
 
-        private static void DoTestCopyDifferent3rd(CoordinateSequenceFactory factory)
+        private static void DoTestCopyDifferentDim(CoordinateSequenceFactory factory)
         {
 
             // arrange
-            var sequence = CreateSequenceFromOrdinates(factory, 3, 0);
+            var sequence = CreateSequenceFromOrdinates(factory, 4, 1);
             if (sequence.Count <= 7)
             {
                 TestContext.WriteLine("sequence has a size of " + sequence.Count + ". Execution of this test needs a sequence " +
@@ -210,12 +211,12 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             // assert
             for (int i = 0; i < fullCopy.Count; i++)
             {
-                CheckCoordinateAt(sequence, i, fullCopy, i, 2);
+                CheckCoordinateAt(sequence, i, fullCopy, i, Ordinates.XYM);
             }
 
             for (int i = 0; i < partialCopy.Count; i++)
             {
-                CheckCoordinateAt(sequence, 2 + i, partialCopy, i, 2);
+                CheckCoordinateAt(sequence, 2 + i, partialCopy, i, Ordinates.XYM);
             }
 
         }
@@ -346,6 +347,25 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             }
         }
 
+        private static void CheckCoordinateAt(CoordinateSequence seq1, int pos1,
+            CoordinateSequence seq2, int pos2, Ordinates toCheck)
+        {
+            Assert.AreEqual(seq1.GetOrdinate(pos1, Ordinate.X), seq2.GetOrdinate(pos2, Ordinate.X),
+                "unexpected x-ordinate at pos " + pos2);
+            Assert.AreEqual(seq1.GetOrdinate(pos1, Ordinate.Y), seq2.GetOrdinate(pos2, Ordinate.Y),
+                "unexpected y-ordinate at pos " + pos2);
+
+            // check additional ordinates
+            for (var j = Ordinate.Spatial3; j <= Ordinate.Measure16; j++)
+            {
+                var coFlag = (Ordinates)(1 << (int)j);
+                if ((coFlag & toCheck) == coFlag)
+                {
+                    Assert.AreEqual(seq1.GetOrdinate(pos1, j), seq2.GetOrdinate(pos2, j),
+                        "unexpected " + j + "-ordinate at pos " + pos2);
+                }
+            }
+        }
         private static CoordinateSequence CreateAlmostRing(CoordinateSequenceFactory factory, int dimension, int num)
         {
 

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateSequencesTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateSequencesTest.cs
@@ -19,7 +19,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         public void TestCopyToLargerDim()
         {
             var csFactory = new PackedCoordinateSequenceFactory();
-            var cs2D = CreateTestSequence(csFactory, 10, 2);
+            var cs2D = CreateTestSequence(csFactory, 10, 2, 0);
             var cs3D = csFactory.Create(10, 3, 0);
             CoordinateSequences.Copy(cs2D, 0, cs3D, 0, cs3D.Count);
             Assert.IsTrue(CoordinateSequences.IsEqual(cs2D, cs3D));
@@ -29,7 +29,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         public void TestCopyToSmallerDim()
         {
             var csFactory = new PackedCoordinateSequenceFactory();
-            var cs3D = CreateTestSequence(csFactory, 10, 3);
+            var cs3D = CreateTestSequence(csFactory, 10, 3, 0);
             var cs2D = csFactory.Create(10, 2, 0);
             CoordinateSequences.Copy(cs3D, 0, cs2D, 0, cs2D.Count);
             Assert.IsTrue(CoordinateSequences.IsEqual(cs2D, cs3D));
@@ -46,6 +46,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             DoTestScrollRing(PackedCoordinateSequenceFactory.DoubleFactory, 4);
             DoTestScrollRing(PackedCoordinateSequenceFactory.FloatFactory, 2);
             DoTestScrollRing(PackedCoordinateSequenceFactory.FloatFactory, 4);
+            DoTestScrollRing(DotSpatialAffineCoordinateSequenceFactory.Instance, 2);
+            DoTestScrollRing(DotSpatialAffineCoordinateSequenceFactory.Instance, 4);
         }
 
         [Test]
@@ -58,6 +60,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             DoTestScroll(PackedCoordinateSequenceFactory.DoubleFactory, 4);
             DoTestScroll(PackedCoordinateSequenceFactory.FloatFactory, 2);
             DoTestScroll(PackedCoordinateSequenceFactory.FloatFactory, 4);
+            DoTestScroll(DotSpatialAffineCoordinateSequenceFactory.Instance, 2);
+            DoTestScroll(DotSpatialAffineCoordinateSequenceFactory.Instance, 4);
         }
 
         [Test]
@@ -67,6 +71,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             DoTestIndexOf(CoordinateArraySequenceFactory.Instance, 2);
             DoTestIndexOf(PackedCoordinateSequenceFactory.DoubleFactory, 5);
             DoTestIndexOf(PackedCoordinateSequenceFactory.FloatFactory, 7);
+            DoTestIndexOf(DotSpatialAffineCoordinateSequenceFactory.Instance, 4);
         }
 
         [Test]
@@ -76,6 +81,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             DoTestMinCoordinateIndex(CoordinateArraySequenceFactory.Instance, 2);
             DoTestMinCoordinateIndex(PackedCoordinateSequenceFactory.DoubleFactory, 5);
             DoTestMinCoordinateIndex(PackedCoordinateSequenceFactory.FloatFactory, 7);
+            DoTestMinCoordinateIndex(DotSpatialAffineCoordinateSequenceFactory.Instance, 4);
         }
 
         [Test]
@@ -85,6 +91,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             DoTestIsRing(CoordinateArraySequenceFactory.Instance, 2);
             DoTestIsRing(PackedCoordinateSequenceFactory.DoubleFactory, 5);
             DoTestIsRing(PackedCoordinateSequenceFactory.FloatFactory, 7);
+            DoTestIsRing(DotSpatialAffineCoordinateSequenceFactory.Instance, 4);
         }
 
         [Test]
@@ -94,6 +101,17 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             DoTestCopy(CoordinateArraySequenceFactory.Instance, 2);
             DoTestCopy(PackedCoordinateSequenceFactory.DoubleFactory, 5);
             DoTestCopy(PackedCoordinateSequenceFactory.FloatFactory, 7);
+            DoTestCopy(DotSpatialAffineCoordinateSequenceFactory.Instance, 4);
+        }
+
+        [Test]
+        public void TestCopyDifferent3rd()
+        {
+            TestContext.WriteLine("Testing copy");
+            DoTestCopyDifferent3rd(CoordinateArraySequenceFactory.Instance);
+            DoTestCopyDifferent3rd(PackedCoordinateSequenceFactory.DoubleFactory);
+            DoTestCopyDifferent3rd(PackedCoordinateSequenceFactory.FloatFactory);
+            DoTestCopyDifferent3rd(DotSpatialAffineCoordinateSequenceFactory.Instance);
         }
 
         [Test]
@@ -105,9 +123,9 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             DoTestReverse(PackedCoordinateSequenceFactory.FloatFactory, 7);
         }
 
-        private static CoordinateSequence CreateSequenceFromOrdinates(CoordinateSequenceFactory csFactory, int dim)
+        private static CoordinateSequence CreateSequenceFromOrdinates(CoordinateSequenceFactory csFactory, int dim, int measures)
         {
-            var sequence = csFactory.Create(ordinateValues.Length, dim, 0);
+            var sequence = csFactory.Create(ordinateValues.Length, dim, measures);
             for (int i = 0; i < ordinateValues.Length; i++)
             {
                 sequence.SetOrdinate(i, Ordinate.X, ordinateValues[i][0]);
@@ -116,9 +134,9 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             return FillNonPlanarDimensions(sequence);
         }
 
-        private static CoordinateSequence CreateTestSequence(CoordinateSequenceFactory csFactory, int size, int dim)
+        private static CoordinateSequence CreateTestSequence(CoordinateSequenceFactory csFactory, int size, int dim, int measures)
         {
-            var cs = csFactory.Create(size, dim, 0);
+            var cs = csFactory.Create(size, dim, measures);
             // initialize with a data signature where coords look like [1, 10, 100, ...]
             for (int i = 0; i < size; i++)
                 for (int d = 0; d < dim; d++)
@@ -131,7 +149,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         {
 
             // arrange
-            var sequence = CreateSequenceFromOrdinates(factory, dimension);
+            var sequence = CreateSequenceFromOrdinates(factory, dimension, 0);
             var reversed = sequence.Copy();
 
             // act
@@ -146,7 +164,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         {
 
             // arrange
-            var sequence = CreateSequenceFromOrdinates(factory, dimension);
+            var sequence = CreateSequenceFromOrdinates(factory, dimension, 0);
             if (sequence.Count <= 7)
             {
                 TestContext.WriteLine("sequence has a size of " + sequence.Count + ". Execution of this test needs a sequence " +
@@ -168,6 +186,38 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
                 CheckCoordinateAt(sequence, 2 + i, partialCopy, i, dimension);
 
             // ToDo test if dimensions don't match
+        }
+
+        private static void DoTestCopyDifferent3rd(CoordinateSequenceFactory factory)
+        {
+
+            // arrange
+            var sequence = CreateSequenceFromOrdinates(factory, 3, 0);
+            if (sequence.Count <= 7)
+            {
+                TestContext.WriteLine("sequence has a size of " + sequence.Count + ". Execution of this test needs a sequence " +
+                                      "with more than 6 coordinates.");
+                return;
+            }
+
+            var fullCopy = factory.Create(sequence.Count, 3, 1);
+            var partialCopy = factory.Create(sequence.Count - 5, 3, 1);
+
+            // act
+            CoordinateSequences.Copy(sequence, 0, fullCopy, 0, sequence.Count);
+            CoordinateSequences.Copy(sequence, 2, partialCopy, 0, partialCopy.Count);
+
+            // assert
+            for (int i = 0; i < fullCopy.Count; i++)
+            {
+                CheckCoordinateAt(sequence, i, fullCopy, i, 2);
+            }
+
+            for (int i = 0; i < partialCopy.Count; i++)
+            {
+                CheckCoordinateAt(sequence, 2 + i, partialCopy, i, 2);
+            }
+
         }
 
         private static void DoTestIsRing(CoordinateSequenceFactory factory, int dimension)
@@ -208,7 +258,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         private static void DoTestIndexOf(CoordinateSequenceFactory factory, int dimension)
         {
             // arrange
-            var sequence = CreateSequenceFromOrdinates(factory, dimension);
+            var sequence = CreateSequenceFromOrdinates(factory, dimension, 0);
 
             // act & assert
             var coordinates = sequence.ToCoordinateArray();
@@ -220,7 +270,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         private static void DoTestMinCoordinateIndex(CoordinateSequenceFactory factory, int dimension)
         {
 
-            var sequence = CreateSequenceFromOrdinates(factory, dimension);
+            var sequence = CreateSequenceFromOrdinates(factory, dimension, 0);
             if (sequence.Count <= 6)
             {
                 TestContext.WriteLine("sequence has a size of " + sequence.Count + ". Execution of this test needs a sequence " +


### PR DESCRIPTION
Instead of copying sequences on a per Coordinate basis this implementation attempts to copy underlying arrays as a whole.
