### PR TITLE
add srsName to GML3 (optional) and all GML2

### DIFF
--- a/src/NetTopologySuite/IO/GML2/GMLWriter.cs
+++ b/src/NetTopologySuite/IO/GML2/GMLWriter.cs
@@ -18,11 +18,12 @@ namespace NetTopologySuite.IO.GML2
     /// </summary>
     public class GMLWriter
     {
+        private const string GmlSrsName = "srsName";
+
         private const int InitValue = 150;
         private const int CoordSize = 200;
         private readonly GMLVersion _gmlVersion;
         private readonly string _gmlNs;
-        private readonly string _gmlSrsName = "srsName";
         private readonly bool _writeSrsNameAttribute;
 
         /// <summary>
@@ -494,27 +495,32 @@ namespace NetTopologySuite.IO.GML2
             return InitValue + CoordSize;
         }
 
+        /// <summary>
+        /// Writes the spatial reference name into the <c>srsName</c> attribute
+        /// </summary>
+        /// <param name="srid">The spatial reference id</param>
+        /// <param name="xmlWriter">The xml writer</param>
         protected virtual void WriteAttributeSrsName(int srid, XmlWriter xmlWriter)
         {
             if(_writeSrsNameAttribute)
-                xmlWriter.WriteAttributeString(_gmlSrsName, GetSrsName(srid));
+                xmlWriter.WriteAttributeString(GmlSrsName, GetSrsName(srid));
         }
 
         /// <summary>
-        /// Provides the srsName exposing the SRID of the geometry
+        /// Provides the srsName expressed by a <see cref="Geometries.Geometry.SRID"/> value.
         /// </summary>
-        /// <param name="srid">The SRID of the geometry</param>
-        /// <returns></returns>
+        /// <param name="srid">An SRID value</param>
+        /// <returns>The <see cref="GetEpsgCode(int)"/></returns>
         protected virtual string GetSrsName(int srid)
         {
             return GetEpsgCode(srid);
         }
 
         /// <summary>
-        /// Provides the EPSG code exposing the SRID of the geometry
+        /// Provides the EPSG code for a  <see cref="Geometries.Geometry.SRID"/> value.
         /// </summary>
-        /// <param name="srid">The SRID of the geometry</param>
-        /// <returns></returns>
+        /// <param name="srid">An SRID value</param>
+        /// <returns>The EPSG code</returns>
         protected virtual string GetEpsgCode(int srid)
         {
             return $"EPSG:{srid}";

--- a/src/NetTopologySuite/IO/GML3/GML3Writer.cs
+++ b/src/NetTopologySuite/IO/GML3/GML3Writer.cs
@@ -10,8 +10,23 @@ namespace NetTopologySuite.IO.GML3
         /// Initializes a new instance of the <see cref="GML3Writer"/> class.
         /// </summary>
         public GML3Writer()
-            : base(GML2.GMLVersion.Three)
+            : this(false)
         {
+        }
+
+        public GML3Writer(bool writeSrsNameAttribute)
+            : base(GML2.GMLVersion.Three, writeSrsNameAttribute)
+        {
+        }
+
+        /// <summary>
+        /// Provides the srsName exposing the SRID of the geometry
+        /// </summary>
+        /// <param name="srid">The SRID of the geometry</param>
+        /// <returns></returns>
+        protected override string GetSrsName(int srid)
+        {
+            return $"https://www.opengis.net/def/crs/EPSG/0/{srid}";
         }
     }
 }

--- a/src/NetTopologySuite/IO/GML3/GML3Writer.cs
+++ b/src/NetTopologySuite/IO/GML3/GML3Writer.cs
@@ -14,16 +14,23 @@ namespace NetTopologySuite.IO.GML3
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GML3Writer"/> class with
+        /// the flag <paramref name="writeSrsNameAttribute"/> indicating if information
+        /// about the spatial reference system should be written to a geometry's
+        /// <c>srsName</c> attribute-
+        /// </summary>
+        /// <param name="writeSrsNameAttribute">Flag indicating to write <c>srsName</c></param>
         public GML3Writer(bool writeSrsNameAttribute)
             : base(GML2.GMLVersion.Three, writeSrsNameAttribute)
         {
         }
 
         /// <summary>
-        /// Provides the srsName exposing the SRID of the geometry
+        /// Provides the srsName expressed by a <see cref="Geometries.Geometry.SRID"/> value.
         /// </summary>
-        /// <param name="srid">The SRID of the geometry</param>
-        /// <returns></returns>
+        /// <param name="srid">An SRID value</param>
+        /// <returns>An URL to the definition of the spatial reference system defined by <paramref name="srid"/></returns>
         protected override string GetSrsName(int srid)
         {
             return $"https://www.opengis.net/def/crs/EPSG/0/{srid}";

--- a/test/NetTopologySuite.Samples.Console/Tests/Github/Issue47Tests.cs
+++ b/test/NetTopologySuite.Samples.Console/Tests/Github/Issue47Tests.cs
@@ -18,7 +18,7 @@ namespace NetTopologySuite.Samples.Tests.Github
 
             string content = doc.OuterXml;
             Assert.That(content, Is.Not.Null);
-            Assert.That(content.StartsWith("<gml:Point xmlns:gml=\"http://www.opengis.net/gml\""), Is.True);
+            Assert.That(content.StartsWith("<gml:Point srsName=\"EPSG:0\" xmlns:gml=\"http://www.opengis.net/gml\""), Is.True);
 
             var reader = new GMLReader();
             var actual = reader.Read(content);

--- a/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
@@ -31,10 +31,13 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             IsOldNtsMultiPointSyntaxAllowed = false,
         };
 
+        private static int _geometrySRID = 4326;
+
         [Test]
         public void TestGML3Point()
         {
-            var document = ToGML3(CreatePoint());
+            var geometry = CreatePoint();
+            var document = ToGML3(geometry);
             AssertPoint(document);
         }
 
@@ -103,7 +106,7 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             using var ms = new MemoryStream();
             using (var writer = XmlWriter.Create(ms, XmlWriterSettings))
             {
-                new GML3Writer().Write(geom, writer);
+                new GML3Writer(true).Write(geom, writer);
             }
 
             ms.Position = 0;
@@ -112,7 +115,9 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
 
         private static Geometry CreatePoint()
         {
-            return WKTReader.Read("POINT (0 0)");
+            var geometry = WKTReader.Read("POINT (0 0)");
+            geometry.SRID = _geometrySRID;
+            return geometry;
         }
 
         private static void AssertPoint(XContainer container)
@@ -120,6 +125,7 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             var pointElement = NotNull(container.Element(GML3Name("Point")));
             var posElement = NotNull(pointElement.Element(GML3Name("pos")));
             Assert.That(posElement.Value, Is.EqualTo("0 0"));
+            Assert.That(pointElement.Attribute(XName.Get("srsName")).Value, Is.EqualTo($"https://www.opengis.net/def/crs/EPSG/0/{_geometrySRID}"));
             AssertRoundTrip(pointElement, CreatePoint());
         }
 

--- a/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/GML3/GML3WriterTest.cs
@@ -10,12 +10,12 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using NetTopologySuite.IO.GML2;
 using NetTopologySuite.IO.GML3;
-
 using NUnit.Framework;
 
 namespace NetTopologySuite.Tests.NUnit.IO.GML3
 {
-    [TestFixture]
+    [TestFixture(true)]
+    [TestFixture(false)]
     public class GML3WriterTest
     {
         private static readonly XmlWriterSettings XmlWriterSettings = new XmlWriterSettings
@@ -25,69 +25,74 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             Encoding = Encoding.UTF8,
         };
 
-        private static readonly WKTReader WKTReader = new WKTReader
+        private static readonly WKTReader WKTReader = new WKTReader()
         {
             IsOldNtsCoordinateSyntaxAllowed = false,
             IsOldNtsMultiPointSyntaxAllowed = false,
         };
 
+        private readonly bool _writeSrsNameAttribute;
         private static int _geometrySRID = 4326;
+
+        public GML3WriterTest(bool writeSrsNameAttribute) {
+            _writeSrsNameAttribute = writeSrsNameAttribute;
+        }
 
         [Test]
         public void TestGML3Point()
         {
             var geometry = CreatePoint();
             var document = ToGML3(geometry);
-            AssertPoint(document);
+            AssertPoint(document, _writeSrsNameAttribute);
         }
 
         [Test]
         public void TestGML3LineString()
         {
             var document = ToGML3(CreateLineString());
-            AssertLineString(document);
+            AssertLineString(document, _writeSrsNameAttribute);
         }
 
         [Test]
         public void TestGML3PolygonWithoutHoles()
         {
             var document = ToGML3(CreatePolygonWithoutHoles());
-            AssertPolygonWithoutHoles(document);
+            AssertPolygonWithoutHoles(document, _writeSrsNameAttribute);
         }
 
         [Test]
         public void TestGML3PolygonWithHoles()
         {
             var document = ToGML3(CreatePolygonWithHoles());
-            AssertPolygonWithHoles(document);
+            AssertPolygonWithHoles(document, _writeSrsNameAttribute);
         }
 
         [Test]
         public void TestGML3MultiPoint()
         {
             var document = ToGML3(CreateMultiPoint());
-            AssertMultiPoint(document);
+            AssertMultiPoint(document, _writeSrsNameAttribute);
         }
 
         [Test]
         public void TestGML3MultiLineString()
         {
             var document = ToGML3(CreateMultiLineString());
-            AssertMultiLineString(document);
+            AssertMultiLineString(document, _writeSrsNameAttribute);
         }
 
         [Test]
         public void TestGML3MultiPolygon()
         {
             var document = ToGML3(CreateMultiPolygon());
-            AssertMultiPolygon(document);
+            AssertMultiPolygon(document, _writeSrsNameAttribute);
         }
 
         [Test]
         public void TestGML3GeometryCollection()
         {
             var document = ToGML3(CreateGeometryCollection());
-            AssertGeometryCollection(document);
+            AssertGeometryCollection(document, _writeSrsNameAttribute);
         }
 
         private static T NotNull<T>(T val)
@@ -101,12 +106,12 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             return XName.Get(localName, "http://www.opengis.net/gml/3.2");
         }
 
-        private static XDocument ToGML3(Geometry geom)
+        private XDocument ToGML3(Geometry geom)
         {
             using var ms = new MemoryStream();
             using (var writer = XmlWriter.Create(ms, XmlWriterSettings))
             {
-                new GML3Writer(true).Write(geom, writer);
+                new GML3Writer(_writeSrsNameAttribute).Write(geom, writer);
             }
 
             ms.Position = 0;
@@ -115,39 +120,42 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
 
         private static Geometry CreatePoint()
         {
-            var geometry = WKTReader.Read("POINT (0 0)");
-            geometry.SRID = _geometrySRID;
+            var geometry = WKTReader.Read($"SRID={_geometrySRID};POINT (0 0)");
+            //geometry.SRID = _geometrySRID;
             return geometry;
         }
 
-        private static void AssertPoint(XContainer container)
+        private static void AssertPoint(XContainer container, bool hasSrsNameAttribute)
         {
             var pointElement = NotNull(container.Element(GML3Name("Point")));
             var posElement = NotNull(pointElement.Element(GML3Name("pos")));
             Assert.That(posElement.Value, Is.EqualTo("0 0"));
-            Assert.That(pointElement.Attribute(XName.Get("srsName")).Value, Is.EqualTo($"https://www.opengis.net/def/crs/EPSG/0/{_geometrySRID}"));
+            AssertSrsName(pointElement.Attribute(XName.Get("srsName")), hasSrsNameAttribute);
+
             AssertRoundTrip(pointElement, CreatePoint());
         }
 
         private static Geometry CreateLineString()
         {
-            return WKTReader.Read("LINESTRING (1 1, 2 2, 3 3, 4 4, 5 5)");
+            return WKTReader.Read($"SRID={_geometrySRID};LINESTRING (1 1, 2 2, 3 3, 4 4, 5 5)");
         }
 
-        private static void AssertLineString(XContainer container)
+        private static void AssertLineString(XContainer container, bool hasSrsNameAttribute)
         {
             var lineStringElement = NotNull(container.Element(GML3Name("LineString")));
             var posListElement = NotNull(lineStringElement.Element(GML3Name("posList")));
             Assert.That(posListElement.Value, Is.EqualTo("1 1 2 2 3 3 4 4 5 5"));
+            AssertSrsName(lineStringElement.Attribute(XName.Get("srsName")), hasSrsNameAttribute);
+
             AssertRoundTrip(lineStringElement, CreateLineString());
         }
 
         private static Geometry CreatePolygonWithoutHoles()
         {
-            return WKTReader.Read("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
+            return WKTReader.Read($"SRID={_geometrySRID};POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
         }
 
-        private static void AssertPolygonWithoutHoles(XContainer container)
+        private static void AssertPolygonWithoutHoles(XContainer container, bool hasSrsNameAttribute)
         {
             var polygonElement = NotNull(container.Element(GML3Name("Polygon")));
             var exteriorElement = NotNull(polygonElement.Element(GML3Name("exterior")));
@@ -155,15 +163,16 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             var exteriorPosListElement = NotNull(exteriorLinearRingElement.Element(GML3Name("posList")));
             Assert.That(exteriorPosListElement.Value, Is.EqualTo("0 0 0 1 1 1 1 0 0 0"));
             Assert.That(polygonElement.Elements(GML3Name("interior")), Is.Empty);
+            AssertSrsName(polygonElement.Attribute(XName.Get("srsName")), hasSrsNameAttribute);
             AssertRoundTrip(polygonElement, CreatePolygonWithoutHoles());
         }
 
         private static Geometry CreatePolygonWithHoles()
         {
-            return WKTReader.Read("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0), (0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2 0.1, 0.1 0.1), (0.4 0.4, 0.4 0.6, 0.6 0.6, 0.6 0.4, 0.4 0.4))");
+            return WKTReader.Read($"SRID={_geometrySRID};POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0), (0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2 0.1, 0.1 0.1), (0.4 0.4, 0.4 0.6, 0.6 0.6, 0.6 0.4, 0.4 0.4))");
         }
 
-        private static void AssertPolygonWithHoles(XContainer container)
+        private static void AssertPolygonWithHoles(XContainer container, bool hasSrsNameAttribute)
         {
             var polygonElement = NotNull(container.Element(GML3Name("Polygon")));
             var exteriorElement = NotNull(polygonElement.Element(GML3Name("exterior")));
@@ -180,15 +189,16 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
                 "0.1 0.1 0.1 0.2 0.2 0.2 0.2 0.1 0.1 0.1",
                 "0.4 0.4 0.4 0.6 0.6 0.6 0.6 0.4 0.4 0.4",
             }));
+            AssertSrsName(polygonElement.Attribute(XName.Get("srsName")), hasSrsNameAttribute);
             AssertRoundTrip(polygonElement, CreatePolygonWithHoles());
         }
 
         private static Geometry CreateMultiPoint()
         {
-            return WKTReader.Read("MULTIPOINT ((1 1), (2 2), (3 3))");
+            return WKTReader.Read($"SRID={_geometrySRID};MULTIPOINT ((1 1), (2 2), (3 3))");
         }
 
-        private static void AssertMultiPoint(XContainer container)
+        private static void AssertMultiPoint(XContainer container, bool hasSrsNameAttribute)
         {
             var multiPointElement = NotNull(container.Element(GML3Name("MultiPoint")));
             var posValues =
@@ -202,15 +212,16 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
                 "2 2",
                 "3 3",
             }));
+            AssertSrsName(multiPointElement.Attribute(XName.Get("srsName")), hasSrsNameAttribute);
             AssertRoundTrip(multiPointElement, CreateMultiPoint());
         }
 
         private static Geometry CreateMultiLineString()
         {
-            return WKTReader.Read("MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
+            return WKTReader.Read($"SRID={_geometrySRID};MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
         }
 
-        private static void AssertMultiLineString(XContainer container)
+        private static void AssertMultiLineString(XContainer container, bool hasSrsNameAttribute)
         {
             var multiCurveElement = NotNull(container.Element(GML3Name("MultiCurve")));
             var posListValues =
@@ -223,15 +234,16 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
                 "10 10 20 20 10 40",
                 "40 40 30 30 40 20 30 10",
             }));
+            AssertSrsName(multiCurveElement.Attribute(XName.Get("srsName")), hasSrsNameAttribute);
             AssertRoundTrip(multiCurveElement, CreateMultiLineString());
         }
 
         private static Geometry CreateMultiPolygon()
         {
-            return WKTReader.Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
+            return WKTReader.Read($"SRID={_geometrySRID};MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
         }
 
-        private static void AssertMultiPolygon(XContainer container)
+        private static void AssertMultiPolygon(XContainer container, bool hasSrsNameAttribute)
         {
             var multiSurfaceElement = NotNull(container.Element(GML3Name("MultiSurface")));
             var posListValues =
@@ -251,6 +263,8 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
                 ("40 40 20 45 45 30 40 40", Array.Empty<string>()),
                 ("20 35 10 30 10 10 30 5 45 20 20 35", new[] { "30 20 20 15 20 25 30 20" }),
             }));
+            AssertSrsName(multiSurfaceElement.Attribute(XName.Get("srsName")), hasSrsNameAttribute);
+
             AssertRoundTrip(multiSurfaceElement, CreateMultiPolygon());
 
             static XElement DummyInteriorElement()
@@ -281,7 +295,7 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             return geoms[0].Factory.CreateGeometryCollection(geoms);
         }
 
-        private static void AssertGeometryCollection(XContainer container)
+        private static void AssertGeometryCollection(XContainer container, bool hasSrsNameAttribute)
         {
             var multiGeometryElement = NotNull(container.Element(GML3Name("MultiGeometry")));
             var elements = new Queue<XElement>(multiGeometryElement.Elements(GML3Name("geometryMember")));
@@ -289,13 +303,13 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             Assert.Multiple(
                 () =>
                 {
-                    AssertPoint(elements.Dequeue());
-                    AssertLineString(elements.Dequeue());
-                    AssertPolygonWithoutHoles(elements.Dequeue());
-                    AssertPolygonWithHoles(elements.Dequeue());
-                    AssertMultiPoint(elements.Dequeue());
-                    AssertMultiLineString(elements.Dequeue());
-                    AssertMultiPolygon(elements.Dequeue());
+                    AssertPoint(elements.Dequeue(), hasSrsNameAttribute);
+                    AssertLineString(elements.Dequeue(), hasSrsNameAttribute);
+                    AssertPolygonWithoutHoles(elements.Dequeue(), hasSrsNameAttribute);
+                    AssertPolygonWithHoles(elements.Dequeue(), hasSrsNameAttribute);
+                    AssertMultiPoint(elements.Dequeue(), hasSrsNameAttribute);
+                    AssertMultiLineString(elements.Dequeue(), hasSrsNameAttribute);
+                    AssertMultiPolygon(elements.Dequeue(), hasSrsNameAttribute);
                 });
             AssertRoundTrip(multiGeometryElement, CreateGeometryCollection());
         }
@@ -305,6 +319,15 @@ namespace NetTopologySuite.Tests.NUnit.IO.GML3
             var document = new XDocument(element);
             var actual = new GMLReader().Read(document);
             Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        private static void AssertSrsName(XAttribute srsNameAttribute, bool hasSrsNameAttribute)
+        {
+            if (hasSrsNameAttribute)
+                Assert.That(srsNameAttribute.Value, Is.EqualTo($"https://www.opengis.net/def/crs/EPSG/0/{_geometrySRID}"));
+            else
+                Assert.That(srsNameAttribute, Is.Null);
+
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
Before I continue with the rest of the tests I would like your input to see if this could be approved.

This PR contains 2 changes to the GML writers.

1. In our use case we would like to have the GML3 writer output the `srsName` attribute.
2. Based on a previous [PR](https://github.com/NetTopologySuite/NetTopologySuite/issues/469) I saw that `Point`, `LinearString`, `LinearRing`, `Polygon` didn't output the `srsName` while it looks required to me: http://schemas.opengis.net/gml/2.1.2/geometry.xsd .
XSD isn't my strong suit, so might be mistaken. It looks like only members of the `MultiPolygon` for example are optional.

Possible improvements:
Add new `ctor` for `GML3Writer` that would take a pattern as input for example `https://www.opengis.net/def/crs/EPSG/0/{0}`.
This would be vulnerable to injection so would have to check if it's a `urn` or `URI`.
Though this could be easily done by creating your own GML writer and inheriting from `GML3Writer` and overriding `GetSrsName`.



