### PR TITLE
Cache results of Geometry.Area and Geometry.Length computation

### DIFF
--- a/src/NetTopologySuite/Geometries/Geometry.cs
+++ b/src/NetTopologySuite/Geometries/Geometry.cs
@@ -214,6 +214,9 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         private Envelope _envelope;
 
+        private double? _area;
+        private double? _length;
+
         /// <summary>
         /// Sets the ID of the Spatial Reference System used by the <c>Geometry</c>.
         /// </summary>
@@ -476,7 +479,16 @@ namespace NetTopologySuite.Geometries
         /// Others return 0.0
         /// </summary>
         /// <returns>The area of the Geometry.</returns>
-        public virtual double Area => 0.0;
+        public virtual double Area
+        {
+            get => _area ?? 0d;
+            protected set => _area = value;
+        }
+
+        /// <summary>
+        /// Gets a value indicating if the value for <see cref="Area"/> has been set.
+        /// </summary>
+        protected bool IsAreaSet => _area.HasValue;
 
         /// <summary>
         /// Returns the length of this <c>Geometry</c>.
@@ -486,7 +498,16 @@ namespace NetTopologySuite.Geometries
         /// Others return 0.0
         /// </summary>
         /// <returns>The length of the Geometry.</returns>
-        public virtual double Length => 0.0;
+        public virtual double Length
+        {
+            get => _length ?? 0d;
+            protected set => _length = value;
+        }
+
+        /// <summary>
+        /// Gets a value indicating if the value for <see cref="Length"/> has been set.
+        /// </summary>
+        protected bool IsLengthSet => _length.HasValue;
 
         /// <summary>
         /// Computes the centroid of this <c>Geometry</c>.
@@ -650,6 +671,8 @@ namespace NetTopologySuite.Geometries
         public void GeometryChangedAction()
         {
             _envelope = null;
+            _area = null;
+            _length = null;
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/GeometryCollection.cs
+++ b/src/NetTopologySuite/Geometries/GeometryCollection.cs
@@ -241,10 +241,14 @@ namespace NetTopologySuite.Geometries
         {
             get
             {
-                double area = 0.0;
-                for (int i = 0; i < _geometries.Length; i++)
-                    area += _geometries[i].Area;
-                return area;
+                if (!IsAreaSet)
+                {
+                    double area = 0.0;
+                    for (int i = 0; i < _geometries.Length; i++)
+                        area += _geometries[i].Area;
+                    base.Area = area;
+                }
+                return base.Area;
             }
         }
 
@@ -255,10 +259,14 @@ namespace NetTopologySuite.Geometries
         {
             get
             {
-                double sum = 0.0;
-                for (int i = 0; i < _geometries.Length; i++)
-                    sum += (_geometries[i]).Length;
-                return sum;
+                if (!IsLengthSet)
+                {
+                    double sum = 0.0;
+                    for (int i = 0; i < _geometries.Length; i++)
+                        sum += (_geometries[i]).Length;
+                    base.Length = sum;
+                }
+                return base.Length;
             }
         }
 

--- a/src/NetTopologySuite/Geometries/LineString.cs
+++ b/src/NetTopologySuite/Geometries/LineString.cs
@@ -244,7 +244,15 @@ namespace NetTopologySuite.Geometries
         /// Returns the length of this <c>LineString</c>
         /// </summary>
         /// <returns>The length of the polygon.</returns>
-        public override double Length => Algorithm.Length.OfLine(_points);
+        public override double Length
+        {
+            get
+            {
+                if (!IsLengthSet)
+                    base.Length = Algorithm.Length.OfLine(_points);
+                return base.Length;
+            }
+        }
 
         /// <summary>
         /// Returns the boundary, or an empty geometry of appropriate dimension

--- a/src/NetTopologySuite/Geometries/Polygon.cs
+++ b/src/NetTopologySuite/Geometries/Polygon.cs
@@ -291,10 +291,14 @@ namespace NetTopologySuite.Geometries
             get
             {
                 double area = 0.0;
-                area += Algorithm.Area.OfRing(_shell.CoordinateSequence);
-                for (int i = 0; i < _holes.Length; i++)
-                    area -= Algorithm.Area.OfRing(_holes[i].CoordinateSequence);
-                return area;
+                if (!IsAreaSet)
+                {
+                    area += Algorithm.Area.OfRing(_shell.CoordinateSequence);
+                    for (int i = 0; i < _holes.Length; i++)
+                        area -= Algorithm.Area.OfRing(_holes[i].CoordinateSequence);
+                    base.Area = area;
+                }
+                return base.Area;
             }
         }
 
@@ -306,11 +310,15 @@ namespace NetTopologySuite.Geometries
         {
             get
             {
-                double len = 0.0;
-                len += _shell.Length;
-                for (int i = 0; i < _holes.Length; i++)
-                    len += _holes[i].Length;
-                return len;
+                if (!IsLengthSet)
+                {
+                    double len = 0.0;
+                    len += _shell.Length;
+                    for (int i = 0; i < _holes.Length; i++)
+                        len += _holes[i].Length;
+                    base.Length = len;
+                }
+                return base.Length;
             }
         }
 


### PR DESCRIPTION
Upon accessing Geometry.Area and Geometry.Length the values are always computed. This is usually not a problem except for scenarios where these values are compared to between different geometries.

The values are now cached and only computed once, unless the GeometryChangedAction invalidates the cached results.
