### PR TITLE
Fix Length of Position at the End Of a LineString in a MultiLineString

### DIFF
--- a/src/NetTopologySuite/LinearReferencing/LengthLocationMap.cs
+++ b/src/NetTopologySuite/LinearReferencing/LengthLocationMap.cs
@@ -202,13 +202,15 @@ namespace NetTopologySuite.LinearReferencing
                         return totalLength + segLen * loc.SegmentFraction;
                     }
 
-                    // I'm past the segment
-                    if (loc.ComponentIndex < it.ComponentIndex)
+                    totalLength += segLen;
+                }
+                else
+                {
+                    // I'm at the end of the segment
+                    if (loc.ComponentIndex == it.ComponentIndex)
                     {
                         return totalLength;
                     }
-
-                    totalLength += segLen;
                 }
                 it.Next();
             }

--- a/src/NetTopologySuite/LinearReferencing/LengthLocationMap.cs
+++ b/src/NetTopologySuite/LinearReferencing/LengthLocationMap.cs
@@ -201,6 +201,13 @@ namespace NetTopologySuite.LinearReferencing
                     {
                         return totalLength + segLen * loc.SegmentFraction;
                     }
+
+                    // I'm past the segment
+                    if (loc.ComponentIndex < it.ComponentIndex)
+                    {
+                        return totalLength;
+                    }
+
                     totalLength += segLen;
                 }
                 it.Next();

--- a/src/NetTopologySuite/LinearReferencing/LengthLocationMap.cs
+++ b/src/NetTopologySuite/LinearReferencing/LengthLocationMap.cs
@@ -201,7 +201,6 @@ namespace NetTopologySuite.LinearReferencing
                     {
                         return totalLength + segLen * loc.SegmentFraction;
                     }
-
                     totalLength += segLen;
                 }
                 else

--- a/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
+++ b/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NetTopologySuite.LinearReferencing;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.LinearReferencing
+{
+    [TestFixture]
+    public class LengthLocationMapTests
+    {
+        [Test]
+        public void TestLengthAtPosition50()
+        {
+            var line = Read("LINESTRING (0 0, 0 100)");
+            var point = Read("POINT (0 50)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(50, length);
+        }
+
+        [Test]
+        public void TestLengthAtPosition100()
+        {
+            var line = Read("LINESTRING (0 0, 0 100)");
+            var point = Read("POINT (0 100)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(100, length);
+        }
+
+        [Test]
+        public void TestLengthAtPosition0()
+        {
+            var line = Read("LINESTRING (0 0, 0 100)");
+            var point = Read("POINT (0 0)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(0, length);
+        }
+
+        [Test]
+        public void TestMultiLineLengthPosition50()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
+            var point = Read("POINT (0 50)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(50, length);
+        }
+
+        [Test]
+        public void TestMultiLineLengthAtPosition100()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
+            var point = Read("POINT (0 100)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(100, length);
+        }
+
+        [Test]
+        public void TestMultiLineLengthAtPosition0()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
+            var point = Read("POINT (0 0)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(0, length);
+        }
+
+        [Test]
+        public void TestMultiLineHoleLengthPosition50()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
+            var point = Read("POINT (0 50)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(50, length);
+        }
+
+        [Test]
+        public void TestMultiLineHoleLengthAtPosition100()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
+            var point = Read("POINT (0 100)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(99, length);
+        }
+
+        [Test]
+        public void TestMultiLineHoleLengthAtPosition0()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
+            var point = Read("POINT (0 0)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(0, length);
+        }
+
+        private WKTReader _reader = new WKTReader();
+
+        protected Geometry Read(string wkt)
+        {
+            try
+            {
+                return _reader.Read(wkt);
+            }
+            catch (ParseException ex)
+            {
+                throw new ApplicationException("An exception occurred while reading the wkt", ex);
+            }
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
+++ b/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
@@ -10,6 +10,17 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
     public class LengthLocationMapTests
     {
         [Test]
+        public void TestLengthAtPosition30()
+        {
+            var line = Read("LINESTRING (0 0, 0 100)");
+            var point = Read("POINT (0 30)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(30, length);
+        }
+
+        [Test]
         public void TestLengthAtPosition50()
         {
             var line = Read("LINESTRING (0 0, 0 100)");
@@ -18,6 +29,17 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
             var length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(50, length);
+        }
+
+        [Test]
+        public void TestLengthAtPosition60()
+        {
+            var line = Read("LINESTRING (0 0, 0 100)");
+            var point = Read("POINT (0 60)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(60, length);
         }
 
         [Test]
@@ -43,6 +65,17 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
         }
 
         [Test]
+        public void TestMultiLineLengthPosition30()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
+            var point = Read("POINT (0 30)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(30, length);
+        }
+
+        [Test]
         public void TestMultiLineLengthPosition50()
         {
             var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
@@ -51,6 +84,17 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
             var length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(50, length);
+        }
+
+        [Test]
+        public void TestMultiLineLengthPosition60()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
+            var point = Read("POINT (0 60)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(60, length);
         }
 
         [Test]
@@ -76,6 +120,17 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
         }
 
         [Test]
+        public void TestMultiLineHoleLengthPosition30()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
+            var point = Read("POINT (0 30)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(30, length);
+        }
+
+        [Test]
         public void TestMultiLineHoleLengthPosition50()
         {
             var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
@@ -84,6 +139,17 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
             var length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(50, length);
+        }
+
+        [Test]
+        public void TestMultiLineHoleLengthPosition60()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
+            var point = Read("POINT (0 60)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(59, length);
         }
 
         [Test]

--- a/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
+++ b/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
@@ -16,7 +16,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 30)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(30, length);
         }
 
@@ -27,7 +27,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 50)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(50, length);
         }
 
@@ -38,7 +38,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 60)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(60, length);
         }
 
@@ -49,7 +49,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 100)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(100, length);
         }
 
@@ -60,7 +60,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 100)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(100, length);
         }
 
@@ -71,7 +71,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 0)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(0, length);
         }
 
@@ -83,7 +83,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 -1)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(0, length);
         }
 
@@ -94,7 +94,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 30)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(30, length);
         }
 
@@ -105,7 +105,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 50)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(50, length);
         }
 
@@ -116,7 +116,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 60)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(60, length);
         }
 
@@ -127,7 +127,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 100)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(100, length);
         }
 
@@ -138,7 +138,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 101)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(100, length);
         }
 
@@ -149,7 +149,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 0)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(0, length);
         }
 
@@ -160,7 +160,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 -1)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(0, length);
         }
 
@@ -171,7 +171,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 30)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(30, length);
         }
 
@@ -182,7 +182,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 50)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(50, length);
         }
 
@@ -193,7 +193,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 60)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(59, length);
         }
 
@@ -204,7 +204,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 100)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(99, length);
         }
 
@@ -215,7 +215,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 101)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(99, length);
         }
 
@@ -226,7 +226,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 0)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(0, length);
         }
 
@@ -238,7 +238,7 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
             var point = Read("POINT (0 -1)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            var length = LengthLocationMap.GetLength(line, loc);
+            double length = LengthLocationMap.GetLength(line, loc);
             Assert.AreEqual(0, length);
         }
 

--- a/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
+++ b/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
@@ -1,259 +1,224 @@
 ﻿using System;
 using NetTopologySuite.Geometries;
-using NetTopologySuite.IO;
 using NetTopologySuite.LinearReferencing;
 using NUnit.Framework;
 
 namespace NetTopologySuite.Tests.NUnit.LinearReferencing
 {
     [TestFixture]
-    public class LengthLocationMapTests
+    public class LengthLocationMapTests : GeometryTestCase
     {
         [Test]
         public void TestLengthAtPosition30()
         {
-            var line = Read("LINESTRING (0 0, 0 100)");
-            var point = Read("POINT (0 30)");
+            string line = "LINESTRING (0 0, 0 100)";
+            string point = "POINT (0 30)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(30, length);
+            CheckLlm(line, point, 30);
         }
 
         [Test]
         public void TestLengthAtPosition50()
         {
-            var line = Read("LINESTRING (0 0, 0 100)");
-            var point = Read("POINT (0 50)");
+            string line = "LINESTRING (0 0, 0 100)";
+            string point = "POINT (0 50)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(50, length);
+            CheckLlm(line, point, 50);
         }
 
         [Test]
         public void TestLengthAtPosition60()
         {
-            var line = Read("LINESTRING (0 0, 0 100)");
-            var point = Read("POINT (0 60)");
+            string line = "LINESTRING (0 0, 0 100)";
+            string point = "POINT (0 60)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(60, length);
+            CheckLlm(line, point, 60);
         }
 
         [Test]
         public void TestLengthAtPosition100()
         {
-            var line = Read("LINESTRING (0 0, 0 100)");
-            var point = Read("POINT (0 100)");
+            string line = "LINESTRING (0 0, 0 100)";
+            string point = "POINT (0 100)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(100, length);
+            CheckLlm(line, point, 100);
         }
 
         [Test]
         public void TestLengthAtPosition101()
         {
-            var line = Read("LINESTRING (0 0, 0 100)");
-            var point = Read("POINT (0 100)");
+            string line = "LINESTRING (0 0, 0 100)";
+            string point = "POINT (0 100)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(100, length);
+            CheckLlm(line, point, 100);
         }
 
         [Test]
         public void TestLengthAtPosition0()
         {
-            var line = Read("LINESTRING (0 0, 0 100)");
-            var point = Read("POINT (0 0)");
+            string line = "LINESTRING (0 0, 0 100)";
+            string point = "POINT (0 0)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(0, length);
+            CheckLlm(line, point, 0);
         }
 
-        
+
         [Test]
         public void TestLengthAtPositionMinus1()
         {
-            var line = Read("LINESTRING (0 0, 0 100)");
-            var point = Read("POINT (0 -1)");
+            string line = "LINESTRING (0 0, 0 100)";
+            string point = "POINT (0 -1)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(0, length);
+            CheckLlm(line, point, 0);
         }
 
         [Test]
         public void TestMultiLineLengthPosition30()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
-            var point = Read("POINT (0 30)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 50, 0 100))";
+            string point = "POINT (0 30)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(30, length);
+            CheckLlm(line, point, 30);
         }
 
         [Test]
         public void TestMultiLineLengthPosition50()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
-            var point = Read("POINT (0 50)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 50, 0 100))";
+            string point = "POINT (0 50)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(50, length);
+            CheckLlm(line, point, 50);
         }
 
         [Test]
         public void TestMultiLineLengthPosition60()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
-            var point = Read("POINT (0 60)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 50, 0 100))";
+            string point = "POINT (0 60)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(60, length);
+            CheckLlm(line, point, 60);
         }
 
         [Test]
         public void TestMultiLineLengthAtPosition100()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
-            var point = Read("POINT (0 100)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 50, 0 100))";
+            string point = "POINT (0 100)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(100, length);
+            CheckLlm(line, point, 100);
         }
 
         [Test]
         public void TestMultiLineLengthAtPosition101()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
-            var point = Read("POINT (0 101)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 50, 0 100))";
+            string point = "POINT (0 101)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(100, length);
+            CheckLlm(line, point, 100);
         }
 
         [Test]
         public void TestMultiLineLengthAtPosition0()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
-            var point = Read("POINT (0 0)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 50, 0 100))";
+            string point = "POINT (0 0)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(0, length);
+            CheckLlm(line, point, 0);
         }
 
         [Test]
         public void TestMultiLineLengthAtPositionMinus1()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
-            var point = Read("POINT (0 -1)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 50, 0 100))";
+            string point = "POINT (0 -1)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(0, length);
+            CheckLlm(line, point, 0);
         }
 
         [Test]
         public void TestMultiLineHoleLengthPosition30()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
-            var point = Read("POINT (0 30)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 51, 0 100))";
+            string point = "POINT (0 30)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(30, length);
+            CheckLlm(line, point, 30);
         }
 
         [Test]
         public void TestMultiLineHoleLengthPosition50()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
-            var point = Read("POINT (0 50)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 51, 0 100))";
+            string point = "POINT (0 50)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(50, length);
+            CheckLlm(line, point, 50);
         }
 
         [Test]
         public void TestMultiLineHoleLengthPosition60()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
-            var point = Read("POINT (0 60)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 51, 0 100))";
+            string point = "POINT (0 60)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(59, length);
+            CheckLlm(line, point, 59);
         }
 
         [Test]
         public void TestMultiLineHoleLengthAtPosition100()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
-            var point = Read("POINT (0 100)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 51, 0 100))";
+            string point = "POINT (0 100)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(99, length);
+            CheckLlm(line, point, 99);
         }
 
         [Test]
         public void TestMultiLineHoleLengthAtPosition101()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
-            var point = Read("POINT (0 101)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 51, 0 100))";
+            string point = "POINT (0 101)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(99, length);
+            CheckLlm(line, point, 99);
         }
 
         [Test]
         public void TestMultiLineHoleLengthAtPosition0()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
-            var point = Read("POINT (0 0)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 51, 0 100))";
+            string point = "POINT (0 0)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(0, length);
+            CheckLlm(line, point, 0);
         }
 
-        
+
         [Test]
         public void TestMultiLineHoleLengthAtPositionMinus1()
         {
-            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
-            var point = Read("POINT (0 -1)");
+            string line = "MULTILINESTRING((0 0, 0 50), (0 51, 0 100))";
+            string point = "POINT (0 -1)";
 
-            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
-            double length = LengthLocationMap.GetLength(line, loc);
-            Assert.AreEqual(0, length);
+            CheckLlm(line, point, 0);
         }
 
-        private WKTReader _reader = new WKTReader();
-
-        protected Geometry Read(string wkt)
+        private void CheckLlm(string wkt0, string wkt1, double expectedDistance)
         {
-            try
-            {
-                return _reader.Read(wkt);
-            }
-            catch (ParseException ex)
-            {
-                throw new ApplicationException("An exception occurred while reading the wkt", ex);
-            }
+            var lineal = (ILineal)Read(wkt0);
+            var point = (Point)Read(wkt1);
+            if (lineal is LineString line)
+                CheckLlm(line, point, expectedDistance);
+            else
+                CheckLlm((MultiLineString)lineal, point, expectedDistance);
+        }
+
+        private void CheckLlm(LineString geom0, Point geom1, double expectedDistance)
+        {
+            var loc = LocationIndexOfPoint.IndexOf(geom0, geom1.Coordinate);
+            Assert.That(LengthLocationMap.GetLength(geom0, loc), Is.EqualTo(expectedDistance));
+        }
+
+        private void CheckLlm(MultiLineString geom0, Point geom1, double expectedDistance)
+        {
+            var loc = LocationIndexOfPoint.IndexOf(geom0, geom1.Coordinate);
+            Assert.That(LengthLocationMap.GetLength(geom0, loc), Is.EqualTo(expectedDistance));
         }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
+++ b/test/NetTopologySuite.Tests.NUnit/LinearReferencing/LengthLocationMapTests.cs
@@ -54,10 +54,33 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
         }
 
         [Test]
+        public void TestLengthAtPosition101()
+        {
+            var line = Read("LINESTRING (0 0, 0 100)");
+            var point = Read("POINT (0 100)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(100, length);
+        }
+
+        [Test]
         public void TestLengthAtPosition0()
         {
             var line = Read("LINESTRING (0 0, 0 100)");
             var point = Read("POINT (0 0)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(0, length);
+        }
+
+        
+        [Test]
+        public void TestLengthAtPositionMinus1()
+        {
+            var line = Read("LINESTRING (0 0, 0 100)");
+            var point = Read("POINT (0 -1)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
             var length = LengthLocationMap.GetLength(line, loc);
@@ -109,10 +132,32 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
         }
 
         [Test]
+        public void TestMultiLineLengthAtPosition101()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
+            var point = Read("POINT (0 101)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(100, length);
+        }
+
+        [Test]
         public void TestMultiLineLengthAtPosition0()
         {
             var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
             var point = Read("POINT (0 0)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(0, length);
+        }
+
+        [Test]
+        public void TestMultiLineLengthAtPositionMinus1()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
+            var point = Read("POINT (0 -1)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
             var length = LengthLocationMap.GetLength(line, loc);
@@ -164,10 +209,33 @@ namespace NetTopologySuite.Tests.NUnit.LinearReferencing
         }
 
         [Test]
+        public void TestMultiLineHoleLengthAtPosition101()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
+            var point = Read("POINT (0 101)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(99, length);
+        }
+
+        [Test]
         public void TestMultiLineHoleLengthAtPosition0()
         {
             var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
             var point = Read("POINT (0 0)");
+
+            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
+            var length = LengthLocationMap.GetLength(line, loc);
+            Assert.AreEqual(0, length);
+        }
+
+        
+        [Test]
+        public void TestMultiLineHoleLengthAtPositionMinus1()
+        {
+            var line = Read("MULTILINESTRING((0 0, 0 50), (0 51, 0 100))");
+            var point = Read("POINT (0 -1)");
 
             var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
             var length = LengthLocationMap.GetLength(line, loc);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description

 ```
            var line = Read("MULTILINESTRING((0 0, 0 50), (0 50, 0 100))");
            var point = Read("POINT (0 50)");

            var loc = LocationIndexOfPoint.IndexOf(line, point.Coordinate);
            var length = LengthLocationMap.GetLength(line, loc);
            Assert.AreEqual(50, length);
```

Without this Patch this Code returns a length of 100 (end of MultLineString) instead of 50.
So the Code in GetLength does not stop evaluation the length when the point is exactly on the end of a linestring in a multilinestring.
