### PR TITLE
LineSequencer.Reverse changes input geometries

### DIFF
--- a/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
+++ b/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
@@ -480,7 +480,11 @@ namespace NetTopologySuite.Operation.Linemerge
 
         private static LineString Reverse(LineString line)
         {
-            var pts = line.Coordinates;
+            var coordinates = line.Coordinates;
+            var pts = new Coordinate[coordinates.Length];
+
+            // copy first the array or else it gets reversed in the original Line
+            Array.Copy(coordinates, pts, coordinates.Length);
             Array.Reverse(pts);
             var rev = line.Factory.CreateLineString(pts);
             rev.UserData = line.UserData; // Maintain UserData in reverse process

--- a/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
+++ b/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
@@ -480,12 +480,9 @@ namespace NetTopologySuite.Operation.Linemerge
 
         private static LineString Reverse(LineString line)
         {
-            var coordinates = line.Coordinates;
-            var pts = new Coordinate[coordinates.Length];
+            // Use a new Coordinate Array to avoiding reversing the Coordinates of the line
+            var pts = line.CoordinateSequence.Reversed().ToCoordinateArray();
 
-            // copy first the array or else it gets reversed in the original Line
-            Array.Copy(coordinates, pts, coordinates.Length);
-            Array.Reverse(pts);
             var rev = line.Factory.CreateLineString(pts);
             rev.UserData = line.UserData; // Maintain UserData in reverse process
             return rev;

--- a/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
+++ b/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
@@ -480,10 +480,8 @@ namespace NetTopologySuite.Operation.Linemerge
 
         private static LineString Reverse(LineString line)
         {
-            // Use a new Coordinate Array to avoiding reversing the Coordinates of the line
-            var pts = line.CoordinateSequence.Reversed().ToCoordinateArray();
-
-            var rev = line.Factory.CreateLineString(pts);
+            // Use a new CoordinateSequence to avoiding reversing the Coordinates of the line
+            var rev = line.Factory.CreateLineString(line.CoordinateSequence.Reversed());
             rev.UserData = line.UserData; // Maintain UserData in reverse process
             return rev;
         }

--- a/test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
+++ b/test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
@@ -28,7 +28,6 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src\NetTopologySuite\NetTopologySuite.csproj" />
     <ProjectReference Include="$(SolutionDir)src\NetTopologySuite.Lab\NetTopologySuite.Lab.csproj" />
-    <ProjectReference Include="..\NetTopologySuite.Tests.NUnit\NetTopologySuite.Tests.NUnit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
+++ b/test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src\NetTopologySuite\NetTopologySuite.csproj" />
     <ProjectReference Include="$(SolutionDir)src\NetTopologySuite.Lab\NetTopologySuite.Lab.csproj" />
+    <ProjectReference Include="..\NetTopologySuite.Tests.NUnit\NetTopologySuite.Tests.NUnit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/NetTopologySuite.Samples.Console/Tests/Operation/Linemerge/LineSequencerTest.cs
+++ b/test/NetTopologySuite.Samples.Console/Tests/Operation/Linemerge/LineSequencerTest.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using NetTopologySuite.Operation.Linemerge;
 using NetTopologySuite.Samples.SimpleTests;
+using NetTopologySuite.Tests.NUnit;
+using NetTopologySuite.Tests.NUnit.Operation.LineMerge;
 using NUnit.Framework;
 
 namespace NetTopologySuite.Samples.Tests.Operation.Linemerge
@@ -198,6 +201,27 @@ namespace NetTopologySuite.Samples.Tests.Operation.Linemerge
         {
             const string wkt = "MULTILINESTRING ((0 0, 0 1), (0 2, 0 3), (0 1, 0 4) )";
             RunIsSequenced(wkt, false);
+        }
+
+        [Test]
+        public void TestSequenceOnReverseInputDoesNotChangeInput()
+        {
+            string[] wkt =
+            {
+                "LINESTRING (0 6, 0 5)",
+                "LINESTRING (0 3, 0 6)",
+                "LINESTRING (0 8, 0 3)",
+            };
+
+            var input = FromWKT(wkt).ToList();
+            var expected = FromWKT(wkt).ToList();
+            var sequencer = new LineSequencer();
+            sequencer.Add(input);
+
+            _ = sequencer.GetSequencedLineStrings();
+
+            // The input should not have been changed
+            LineMergerTest.Compare(expected, input, true);
         }
 
         private static void RunLineSequencer(string[] inputWKT, string expectedWKT)

--- a/test/NetTopologySuite.Samples.Console/Tests/Operation/Linemerge/LineSequencerTest.cs
+++ b/test/NetTopologySuite.Samples.Console/Tests/Operation/Linemerge/LineSequencerTest.cs
@@ -203,27 +203,6 @@ namespace NetTopologySuite.Samples.Tests.Operation.Linemerge
             RunIsSequenced(wkt, false);
         }
 
-        [Test]
-        public void TestSequenceOnReverseInputDoesNotChangeInput()
-        {
-            string[] wkt =
-            {
-                "LINESTRING (0 6, 0 5)",
-                "LINESTRING (0 3, 0 6)",
-                "LINESTRING (0 8, 0 3)",
-            };
-
-            var input = FromWKT(wkt).ToList();
-            var expected = FromWKT(wkt).ToList();
-            var sequencer = new LineSequencer();
-            sequencer.Add(input);
-
-            _ = sequencer.GetSequencedLineStrings();
-
-            // The input should not have been changed
-            LineMergerTest.Compare(expected, input, true);
-        }
-
         private static void RunLineSequencer(string[] inputWKT, string expectedWKT)
         {
             try

--- a/test/NetTopologySuite.Samples.Console/Tests/Operation/Linemerge/LineSequencerTest.cs
+++ b/test/NetTopologySuite.Samples.Console/Tests/Operation/Linemerge/LineSequencerTest.cs
@@ -6,8 +6,6 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using NetTopologySuite.Operation.Linemerge;
 using NetTopologySuite.Samples.SimpleTests;
-using NetTopologySuite.Tests.NUnit;
-using NetTopologySuite.Tests.NUnit.Operation.LineMerge;
 using NUnit.Framework;
 
 namespace NetTopologySuite.Samples.Tests.Operation.Linemerge

--- a/test/NetTopologySuite.Tests.NUnit/Operation/LineMerge/LineMergerTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/LineMerge/LineMergerTest.cs
@@ -57,6 +57,27 @@ namespace NetTopologySuite.Tests.NUnit.Operation.LineMerge
               new string[] { });
         }
 
+        [Test]
+        public void TestSequenceOnReverseInputDoesNotChangeInput()
+        {
+            string[] wkt =
+            {
+                "LINESTRING (0 6, 0 5)",
+                "LINESTRING (0 3, 0 6)",
+                "LINESTRING (0 8, 0 3)",
+            };
+
+            var input = ToGeometries(wkt);
+            var expected = ToGeometries(wkt);
+            var sequencer = new LineSequencer();
+            sequencer.Add(input);
+
+            _ = sequencer.GetSequencedLineStrings();
+
+            // The input should not have been changed
+            LineMergerTest.Compare(expected, input, true);
+        }
+
         [Ignore("This test is currently failing due to the generalization of the line (removal of repeated points) in the AddEdge method of NetTopologySuite.Operation.Linemerge.LineMergeGraph.  Need to see if this test is working in JTS")]
         public void TestSingleUniquePoint()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
- [x] I have provided test coverage for my change (where applicable)

### Description
Running the LineSequencer changes the Input Geometries, because the Reverse LineString Function of LineSequencer makes an  inplace Reverse of the Coordinates instead of copying them.


