### PR TITLE
Fixed Reversing of EdgeSequence in LineSequencer (Redone)

### DIFF
--- a/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
+++ b/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
@@ -431,7 +431,7 @@ namespace NetTopologySuite.Operation.Linemerge
         /// <returns>The reversed sequence.</returns>
         private static List<DirectedEdge> Reverse(IEnumerable<DirectedEdge> seq)
         {
-            var tmp = new Stack<DirectedEdge>(seq);
+            var tmp = new Stack<DirectedEdge>();
 
             foreach (var edge in seq)
             {

--- a/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
+++ b/src/NetTopologySuite/Operation/Linemerge/LineSequencer.cs
@@ -432,6 +432,13 @@ namespace NetTopologySuite.Operation.Linemerge
         private static List<DirectedEdge> Reverse(IEnumerable<DirectedEdge> seq)
         {
             var tmp = new Stack<DirectedEdge>(seq);
+
+            foreach (var edge in seq)
+            {
+                // Add Edge that has the other direction instead of copying it.
+                tmp.Push(edge.Sym);
+            }
+
             return new List<DirectedEdge>(tmp);
             /*
             LinkedList<DirectedEdge> newSeq = new LinkedList<DirectedEdge>();

--- a/test/NetTopologySuite.Samples.Console/Tests/Operation/Linemerge/LineSequencerTest.cs
+++ b/test/NetTopologySuite.Samples.Console/Tests/Operation/Linemerge/LineSequencerTest.cs
@@ -201,6 +201,20 @@ namespace NetTopologySuite.Samples.Tests.Operation.Linemerge
             RunIsSequenced(wkt, false);
         }
 
+        [Test]
+        public void ReverseNodedLineSequenceHasRightDirection()
+        {
+            string[] wkt = new []
+            {
+                "LINESTRING (0 1, 0 0)",
+                "LINESTRING (0 1, 0 2)",
+                "LINESTRING (0 3, 0 2)"
+            };
+
+            string expected = "MULTILINESTRING ((0 3, 0 2), (0 2, 0 1), (0 1, 0 0))";
+            RunLineSequencer(wkt, expected);
+        }
+
         private static void RunLineSequencer(string[] inputWKT, string expectedWKT)
         {
             try


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description
Without this the Added Unit Test Fails.

Input to LineSequencer is 

```
"LINESTRING (0 1, 0 0)",
"LINESTRING (0 1, 0 2)",
"LINESTRING (0 3, 0 2)",
```

expected Result:

```
"MULTILINESTRING ((0 3, 0 2), (0 2, 0 1), (0 1, 0 0))"
```

current Result (without Reverse Fix):

```
"MULTILINESTRING ((0 2, 0 3), (0 1, 0 2), (0 0, 0 1))"
```

The Order of the Lines is correct but they are reversed.

I accidently closed this https://github.com/NetTopologySuite/NetTopologySuite/pull/605 so I'll redo this pull request here.

