### PR TITLE
Line segment hashcode collision reduction

### DIFF
--- a/src/NetTopologySuite/Geometries/LineSegment.cs
+++ b/src/NetTopologySuite/Geometries/LineSegment.cs
@@ -709,19 +709,6 @@ namespace NetTopologySuite.Geometries
                 hash = hash * 29 + _p1.Y.GetHashCode( );
                 return hash;
             }
-
-            long bits0 = BitConverter.DoubleToInt64Bits(_p0.X);
-            bits0 ^= BitConverter.DoubleToInt64Bits(_p0.Y) * 31;
-            int hash0 = (((int)bits0) ^ ((int)(bits0 >> 32)));
-
-            long bits1 = BitConverter.DoubleToInt64Bits(_p1.X);
-            bits1 ^= BitConverter.DoubleToInt64Bits(_p1.Y) * 31;
-            int hash1 = (((int)bits1) ^ ((int)(bits1 >> 32)));
-
-            // XOR is supposed to be a good way to combine hashcodes
-            return hash0 ^ hash1;
-
-            // return base.GetHashCode();
         }
     }
 }

--- a/src/NetTopologySuite/Geometries/LineSegment.cs
+++ b/src/NetTopologySuite/Geometries/LineSegment.cs
@@ -700,6 +700,16 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         public override int GetHashCode()
         {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 29 + _p0.X.GetHashCode( );
+                hash = hash * 29 + _p0.Y.GetHashCode( );
+                hash = hash * 29 + _p1.X.GetHashCode( );
+                hash = hash * 29 + _p1.Y.GetHashCode( );
+                return hash;
+            }
+
             long bits0 = BitConverter.DoubleToInt64Bits(_p0.X);
             bits0 ^= BitConverter.DoubleToInt64Bits(_p0.Y) * 31;
             int hash0 = (((int)bits0) ^ ((int)(bits0 >> 32)));

--- a/test/NetTopologySuite.Tests.NUnit.Performance/Performance/LineSegmentAccessPerformanceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit.Performance/Performance/LineSegmentAccessPerformanceTest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Prepared;
+using NUnit.Framework;
+
+
+namespace NetTopologySuite.Tests.NUnit.Performance
+{
+    public class LineSegmentAccessPerformanceTest
+    {
+        private const int MaxIter = 1;
+
+        private readonly GeometryFactory _fact;
+
+        public LineSegmentAccessPerformanceTest()
+        {
+            _fact = new GeometryFactory(new PrecisionModel(), 0);
+        }
+
+        [Test]
+        public void Test()
+        {
+            Test(50);
+            Test(100);
+            Test(200);
+            Test(500);
+            Test(1000);
+        }
+
+        public void Test(int gridLength)
+        {
+            var gsf = new NetTopologySuite.Utilities.GeometricShapeFactory();
+
+            var geo = new List<LineSegment>();
+
+            Console.WriteLine("Creating grid of " + gridLength);
+
+            for (int gx = 0; gx < gridLength * 10; gx += 10)
+            {
+                for (int gy = 0; gy < gridLength * 10; gy += 10)
+                {
+                    geo.Add(new LineSegment(gx, gy, gx + 10, gy));
+                    geo.Add(new LineSegment(gx, gy, gx, gy + 10));
+                }
+            }
+
+            Test(geo, gridLength);
+        }
+
+        public void Test(IList<LineSegment> gridSquares, int gridLength)
+        {
+            Console.WriteLine("Length of grid: " + gridLength
+                              + "      # squares: " + gridSquares.Count);
+
+            var sw = new Stopwatch();
+            sw.Start();
+            double count = 0;
+            for (int i = 0; i < MaxIter; i++)
+            {
+                count += testOriginal(gridSquares);
+            }
+            sw.Stop();
+
+            Console.WriteLine("Sum of weights = " + count);
+            Console.WriteLine("Finished in " + sw.ElapsedMilliseconds + " ms");
+        }
+
+        public static double testOriginal(IEnumerable<LineSegment> lines)
+        {
+            Console.WriteLine("Using given lines");
+
+            var random = new Random(0);
+            var weights = new Dictionary<LineSegment, double>();
+
+            double count = 0;
+            // build a collection that stores data against edges
+            foreach (var line in lines)
+            {
+                weights.Add(line, random.NextDouble());
+            }
+
+            // pull data from the collection for a given edge
+            foreach (var line in lines)
+            {
+                count += weights[line];
+            }
+
+            return count;
+        }
+
+    }
+
+
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/LineSegmentTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/LineSegmentTest.cs
@@ -16,6 +16,16 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         private static double ROOT2 = Math.Sqrt(2);
 
         [Test]
+        public void HashCollision()
+        {
+            var seg1 = new LineSegment(0, 0, 10, 0);
+            var seg2 = new LineSegment(0, 10, 10, 10);
+
+            Assert.AreNotEqual(seg1.GetHashCode(), seg2.GetHashCode());
+        }
+
+
+        [Test]
         public void TestProjectionFactor()
         {
             // zero-length line


### PR DESCRIPTION
### Description
Line Segment GetHashCode creates collisions.
Seems to be straight lines of same length that are 10 units away in 1 axis.

Added a very simple unit test.
Added a performance test which should identify if things go bad.

Could probably increase robustness by testing lines of varying length/offset/direction.