### PR TITLE
Fix KMLReader to read coordinates with whitespace

### DIFF
--- a/src/NetTopologySuite/IO/KML/KMLReader.cs
+++ b/src/NetTopologySuite/IO/KML/KMLReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Xml;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Utilities;
@@ -17,6 +18,7 @@ namespace NetTopologySuite.IO.KML
         //private final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
         private readonly GeometryFactory geometryFactory;
         private readonly ISet<string> attributeNames;
+        private readonly Regex whitespaceRegex = new Regex(@"\s+");
 
         private const string POINT = "Point";
         private const string LINESTRING = "LineString";
@@ -113,6 +115,8 @@ namespace NetTopologySuite.IO.KML
             string coordinates = xmlStreamReader.ReadElementString();
             if (string.IsNullOrWhiteSpace(coordinates))
                 RaiseParseError("Empty coordinates");
+            
+            coordinates = whitespaceRegex.Replace(coordinates.Trim(), " ");
 
             double[] parsedOrdinates = {double.NaN, double.NaN, double.NaN};
             var coordinateList = new List<Coordinate>();

--- a/test/NetTopologySuite.Tests.NUnit/IO/KML/KMLReaderTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/IO/KML/KMLReaderTest.cs
@@ -248,6 +248,19 @@ namespace NetTopologySuite.Tests.NUnit.IO.KML
            new IDictionary<string, string>[] { null }
            );
         }
+       
+        [Test]
+        public void TestCoordinatesWithWhitespace()
+        {
+            CheckParsingResult(new KMLReader(),
+                "<LineString>" +
+                "   <coordinates> 1.0,2.0" +
+                "   -1.0,-2.0 </coordinates>" +
+                "</LineString>",
+                "LINESTRING (1 2, -1 -2)",
+                new IDictionary<string, string>[]{ null, null }
+            );
+        }
 
         private void CheckExceptionThrown(string kmlString, string expectedError)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description

`coordinates = whitespaceRegex.Replace(coordinates.Trim(), " ");`

Without this line, KMLReader will raise "Invalid coordinate format" error for coordinates with extra whitespace.
Example file: https://developers.google.com/kml/documentation/KML_Samples.kml 

Added line to trim and replace whitespace in coordinates string before processing.