### PR TITLE
Fix incorrect line segment orientation

### DIFF
--- a/src/NetTopologySuite/Geometries/LineSegment.cs
+++ b/src/NetTopologySuite/Geometries/LineSegment.cs
@@ -168,7 +168,7 @@ namespace NetTopologySuite.Geometries
                 return Math.Max(orient0, orient1);
             // this handles the case where the points are R or collinear
             if (orient0 <= 0 && orient1 <= 0)
-                return Math.Max(orient0, orient1);
+                return Math.Min(orient0, orient1);
             // points lie on opposite sides ==> indeterminate orientation
             return 0;
         }

--- a/src/NetTopologySuite/Geometries/LineSegment.cs
+++ b/src/NetTopologySuite/Geometries/LineSegment.cs
@@ -163,7 +163,7 @@ namespace NetTopologySuite.Geometries
         {
             int orient0 = (int)Orientation.Index(_p0, _p1, seg._p0);
             int orient1 = (int)Orientation.Index(_p0, _p1, seg._p1);
-            // this handles the case where the points are Curve or collinear
+            // this handles the case where the points are L or collinear
             if (orient0 >= 0 && orient1 >= 0)
                 return Math.Max(orient0, orient1);
             // this handles the case where the points are R or collinear

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/LineSegmentTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/LineSegmentTest.cs
@@ -165,6 +165,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             CheckOrientationIndex(seg, 100, 99, 105, 96, -1);
 
             CheckOrientationIndex(seg, 200, 200, 210, 210, 0);
+            CheckOrientationIndex(seg, 105, 105, 110, 100, -1);
 
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description
Currently, in cases where the input line segment's start/end point is collinear with "this" line segment and its end/start point is to the right, an orientation of 0 (Collinear) is returned by the OrientationIndex(LineSegment) function.  This is inconsistent with the analogous left case, which returns an orientation index of 1 (Left).  Judging by the function's documentation, the function should return  -1 (Right) in the right case, as enforced by this PR.
