### PR TITLE
Remove reference to non-existent ReSharper settings file

### DIFF
--- a/NetTopologySuite.sln.DotSettings
+++ b/NetTopologySuite.sln.DotSettings
@@ -1,8 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LCID/@EntryIndexedValue">LCID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SRID/@EntryIndexedValue">SRID</s:String>
-	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=9276D8049595A4428BC3DDA8846F1765/@KeyIndexDefined">True</s:Boolean>
-	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=9276D8049595A4428BC3DDA8846F1765/AbsolutePath/@EntryValue">C:\Progetti\GitHub\NetTopologySuite\NetTopologySuite.sln.DotSettings</s:String>
-	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=9276D8049595A4428BC3DDA8846F1765/RelativePath/@EntryValue"></s:String>
-	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File9276D8049595A4428BC3DDA8846F1765/@KeyIndexDefined">True</s:Boolean>
-	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File9276D8049595A4428BC3DDA8846F1765/RelativePriority/@EntryValue">1</s:Double></wpf:ResourceDictionary>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
The removed lines cause ReSharper to create an empty `NetTopologySuite.sln.DotSettings` file under the `C:\Progetti\GitHub\NetTopologySuite\NetTopologySuite.sln.DotSettings` directory (creating the directory if it does not exist).