### PR TITLE
Alternative approach to fix #655

### DIFF
--- a/src/NetTopologySuite/Algorithm/LineIntersectorFactory.cs
+++ b/src/NetTopologySuite/Algorithm/LineIntersectorFactory.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace NetTopologySuite.Algorithm
+{
+    /// <summary>
+    /// A factory that is to be used to create <see cref="LineIntersector"/> instances.
+    /// The distinguation is some sort <see cref="Elevation.ElevationModel"/>
+    /// </summary>
+    /// 
+    public static class LineIntersectorFactory
+    {
+        private static Elevation.ElevationModel _defaultEm;
+
+        /// <summary>
+        /// Gets or sets a value indicating the default elevation model to use when none is supplied.
+        /// <para/>
+        /// If this property is not <c>null</c>
+        /// </summary>
+        public static Elevation.ElevationModel DefaultElevationModel
+        {
+            get => _defaultEm;
+            set
+            {
+                if (value is Operation.OverlayNG.ElevationModel)
+                    throw new ArgumentException("Elevation model must not be of type NetTopologySuite.Operation.OverlayNG.ElevationModel");
+
+                _defaultEm = value;
+
+            }
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LineIntersector"/> for the provided elevation model
+        /// </summary>
+        /// <param name="elevationModel">An elevation model</param>
+        /// <returns>A line intersector</returns>
+        public static LineIntersector CreateFor(Elevation.ElevationModel elevationModel)
+        {
+            // See if we have an elevation model that forces us to use the RobustLineIntersectorWithElevationModel
+            if (elevationModel != null && !(elevationModel is Operation.OverlayNG.ElevationModel))
+                return new RobustLineIntersectorWithElevationModel(elevationModel);
+
+            // Is a default ElevationModel defined, which forces us to use the RobustLineIntersectorWithElevationModel
+            var dem = DefaultElevationModel;
+            if (dem != null)
+                return new RobustLineIntersectorWithElevationModel(dem);
+
+            // Return plain old RobustLineIntersector
+            return new RobustLineIntersector();
+        }
+    }
+}

--- a/src/NetTopologySuite/Algorithm/PointLocation.cs
+++ b/src/NetTopologySuite/Algorithm/PointLocation.cs
@@ -21,7 +21,7 @@ namespace NetTopologySuite.Algorithm
         /// </returns>
         public static bool IsOnLine(Coordinate p, Coordinate[] line)
         {
-            var lineIntersector = new RobustLineIntersector();
+            var lineIntersector = LineIntersectorFactory.CreateFor(null);
             for (int i = 1; i < line.Length; i++)
             {
                 var p0 = line[i - 1];
@@ -47,7 +47,7 @@ namespace NetTopologySuite.Algorithm
         /// </returns>
         public static bool IsOnLine(Coordinate p, CoordinateSequence line)
         {
-            var lineIntersector = new RobustLineIntersector();
+            var lineIntersector = LineIntersectorFactory.CreateFor(null);
             var p0 = line.CreateCoordinate();
             var p1 = p0.Copy();
             int n = line.Count;

--- a/src/NetTopologySuite/Algorithm/RectangleLineIntersector.cs
+++ b/src/NetTopologySuite/Algorithm/RectangleLineIntersector.cs
@@ -20,7 +20,7 @@ namespace NetTopologySuite.Algorithm
     public class RectangleLineIntersector
     {
         // for intersection testing, don't need to set precision model
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = LineIntersectorFactory.CreateFor(null);
 
         private readonly Envelope _rectEnv;
 

--- a/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
+++ b/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
@@ -9,6 +9,12 @@ namespace NetTopologySuite.Algorithm
     /// </summary>
     public class RobustLineIntersector : LineIntersector
     {
+#if DEBUG
+        public RobustLineIntersector()
+        {
+            // just to see stack trace when creating this
+        }
+#endif
         /// <summary>
         ///
         /// </summary>
@@ -206,7 +212,7 @@ namespace NetTopologySuite.Algorithm
             return NoIntersection;
         }
 
-        private static Coordinate CopyWithZInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
+        private Coordinate CopyWithZInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
         {
             return CopyWithZ(p, zGetOrInterpolate(p, p1, p2));
         }
@@ -217,7 +223,9 @@ namespace NetTopologySuite.Algorithm
             if (double.IsNaN(z))
                 res = p.Copy();
             else
-                res = new CoordinateZ(p) { Z = z };
+                res = double.IsNaN(p.M)
+                    ? new CoordinateZ(p) { Z = z }
+                    : new CoordinateZM(p) { Z = z };
 
             return res;
         }
@@ -366,15 +374,14 @@ namespace NetTopologySuite.Algorithm
             return nearestPt;
         }
 
-        /*
-         * Gets the Z value of the first argument if present, 
-         * otherwise the value of the second argument.
-         * 
-         * @param p a coordinate, possibly with Z
-         * @param q a coordinate, possibly with Z
-         * @return the Z value if present
-         */
-        private static double zGet(Coordinate p, Coordinate q)
+        /// <summary>
+        /// Gets the Z value of the first argument if present,
+        /// otherwise the value of the second argument.
+        /// </summary>
+        /// <param name="p">A coordinate, possibly with Z</param>
+        /// <param name="q">A coordinate, possibly with Z</param>
+        /// <returns>The Z value if present</returns>
+        protected virtual double zGet(Coordinate p, Coordinate q)
         {
             double z = p.Z;
             if (double.IsNaN(z))
@@ -394,7 +401,7 @@ namespace NetTopologySuite.Algorithm
         /// <param name="p1">A segment endpoint, possibly with Z</param>
         /// <param name="p2">A segment endpoint, possibly with Z</param>
         /// <returns>The extracted or interpolated Z value (may be NaN)</returns>
-        private static double zGetOrInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
+        protected virtual double zGetOrInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
         {
             double z = p.Z;
             if (!double.IsNaN(z))
@@ -413,7 +420,7 @@ namespace NetTopologySuite.Algorithm
         /// <param name="p1">A segment endpoint, possibly with Z</param>
         /// <param name="p2">A segment endpoint, possibly with Z</param>
         /// <returns>The extracted or interpolated Z value (may be NaN)</returns>
-        private static double zInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
+        protected virtual double zInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
         {
             double p1z = p1.Z;
             double p2z = p2.Z;
@@ -465,7 +472,7 @@ namespace NetTopologySuite.Algorithm
         /// <param name="q1">A segment endpoint, possibly with Z</param>
         /// <param name="q2">A segment endpoint, possibly with Z</param>
         /// <returns>The averaged interpolated Z value (may be NaN)</returns>    
-        private static double zInterpolate(Coordinate p, Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2)
+        protected virtual double zInterpolate(Coordinate p, Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2)
         {
             double zp = zInterpolate(p, p1, p2);
             double zq = zInterpolate(p, q1, q2);

--- a/src/NetTopologySuite/Algorithm/RobustLineIntersectorWithElevationModel.cs
+++ b/src/NetTopologySuite/Algorithm/RobustLineIntersectorWithElevationModel.cs
@@ -1,0 +1,46 @@
+﻿using NetTopologySuite.Geometries;
+using NetTopologySuite.Elevation;
+
+namespace NetTopologySuite.Algorithm
+{
+    public sealed class RobustLineIntersectorWithElevationModel : RobustLineIntersector
+    {
+        private readonly ElevationModel _elevationModel;
+
+        public RobustLineIntersectorWithElevationModel(ElevationModel elevationModel)
+        {
+            _elevationModel = elevationModel;
+        }
+
+        protected override double zGet(Coordinate p, Coordinate q)
+        {
+            if (!double.IsNaN(p.Z))
+                return p.Z;
+
+            return _elevationModel.GetZ(p.X, p.Y);
+        }
+
+        protected override double zGetOrInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
+        {
+            if (!double.IsNaN(p.Z))
+                return p.Z;
+
+            return _elevationModel.GetZ(p.X, p.Y);
+        }
+
+        protected override double zInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
+        {
+            if (!double.IsNaN(p.Z))
+                return p.Z;
+
+            return _elevationModel.GetZ(p.X, p.Y);
+        }
+        protected override double zInterpolate(Coordinate p, Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2)
+        {
+            if (!double.IsNaN(p.Z))
+                return p.Z;
+
+            return _elevationModel.GetZ(p.X, p.Y);
+        }
+    }
+}

--- a/src/NetTopologySuite/Coverage/InvalidSegmentDetector.cs
+++ b/src/NetTopologySuite/Coverage/InvalidSegmentDetector.cs
@@ -94,7 +94,7 @@ namespace NetTopologySuite.Coverage
         private bool IsCollinearOrInterior(Coordinate tgt0, Coordinate tgt1,
             Coordinate adj0, Coordinate adj1, CoverageRing adj, int indexAdj)
         {
-            var li = new RobustLineIntersector();
+            var li = LineIntersectorFactory.CreateFor(null);
             li.ComputeIntersection(tgt0, tgt1, adj0, adj1);
 
             //-- segments do not interact

--- a/src/NetTopologySuite/Elevation/ConstElevationModel.cs
+++ b/src/NetTopologySuite/Elevation/ConstElevationModel.cs
@@ -1,0 +1,22 @@
+﻿using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Elevation
+{
+    public class ConstElevationModel : ElevationModel
+    {
+        private readonly double _z;
+
+        public ConstElevationModel() : this(Coordinate.NullOrdinate)
+        { }
+
+        public ConstElevationModel(double z)
+        {
+            _z = z;
+        }
+
+        public override double GetZ(double x, double y)
+        {
+            return _z;
+        }
+    }
+}

--- a/src/NetTopologySuite/Elevation/ElevationModel.cs
+++ b/src/NetTopologySuite/Elevation/ElevationModel.cs
@@ -1,0 +1,70 @@
+﻿using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Elevation
+{
+    public abstract class ElevationModel
+    {
+        public abstract double GetZ(double x, double y);
+
+        public double GetZ(Coordinate p)
+        {
+            return GetZ(p.X, p.Y);
+        }
+
+
+        /// <summary>
+        /// Computes Z values for any missing Z values in a geometry,
+        /// using the computed model.
+        /// If the model has no Z value, or the geometry coordinate dimension
+        /// does not include Z, the geometry is not updated.
+        /// </summary>
+        /// <param name="geom">The geometry to populate Z values for</param>
+        public virtual void PopulateZ(Geometry geom)
+        {
+            var filter = new PopulateZFilter(this);
+            geom.Apply(filter);
+        }
+
+        public static bool HasValidZ(Coordinate p) => IsValidZ(p.Z);
+
+        public static bool IsValidZ(double z) => !double.IsNaN(z);
+
+        private class PopulateZFilter : IEntireCoordinateSequenceFilter
+        {
+            private readonly ElevationModel _em;
+
+            public PopulateZFilter(ElevationModel em)
+            {
+                _em = em;
+            }
+
+            public bool Done { get; private set; }
+
+            public bool GeometryChanged
+            {
+                get => false;
+            }
+
+            public void Filter(CoordinateSequence seq)
+            {
+                if (!seq.HasZ)
+                {
+                    // if no Z then short-circuit evaluation
+                    Done = true;
+                    return;
+                }
+
+                for (int i = 0; i < seq.Count; i++)
+                {
+                    // if Z not populated then assign using model
+                    if (!IsValidZ(seq.GetZ(i)))
+                    {
+                        double z = _em.GetZ(seq.GetX(i), seq.GetY(i));
+                        seq.SetOrdinate(i, Ordinate.Z, z);
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/NetTopologySuite/Elevation/IHasElevationModel.cs
+++ b/src/NetTopologySuite/Elevation/IHasElevationModel.cs
@@ -1,0 +1,20 @@
+﻿namespace NetTopologySuite.Elevation
+{
+    /// <summary>
+    /// An interface for classes that may have access to an <see cref="ElevationModel"/>.
+    /// </summary>
+    internal interface IHasElevationModel
+    {
+        /// <summary>
+        /// Gets the elevation model 
+        /// </summary>
+        ElevationModel ElevationModel { get; }
+
+        /// <summary>
+        /// Method to attempt and set the <see cref="ElevationModel"/>.
+        /// </summary>
+        /// <param name="model">The elevation model to set</param>
+        /// <returns><c>true</c> if setting the elevation model was successful.</returns>
+        bool TrySetElevationModel(ElevationModel model);
+    }
+}

--- a/src/NetTopologySuite/Geometries/LineSegment.cs
+++ b/src/NetTopologySuite/Geometries/LineSegment.cs
@@ -557,7 +557,7 @@ namespace NetTopologySuite.Geometries
         /// <see cref="RobustLineIntersector"/>
         public Coordinate Intersection(LineSegment line)
         {
-            var li = new RobustLineIntersector();
+            var li = LineIntersectorFactory.CreateFor(null);
             li.ComputeIntersection(_p0, _p1, line.P0, line.P1);
             if (li.HasIntersection)
                 return li.GetIntersection(0);

--- a/src/NetTopologySuite/Noding/FastNodingValidator.cs
+++ b/src/NetTopologySuite/Noding/FastNodingValidator.cs
@@ -48,7 +48,7 @@ namespace NetTopologySuite.Noding
             return nv.Intersections;
         }
 
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li;
 
         private readonly List<ISegmentString> _segStrings = new List<ISegmentString>();
         private NodingIntersectionFinder _segInt;
@@ -59,8 +59,17 @@ namespace NetTopologySuite.Noding
         /// </summary>
         /// <param name="segStrings">A collection of <see cref="ISegmentString"/>s</param>
         public FastNodingValidator(IEnumerable<ISegmentString> segStrings)
+            : this(segStrings, null)
+        { }
+
+        /// <summary>
+        /// Creates a new noding validator for a given set of linework.
+        /// </summary>
+        /// <param name="segStrings">A collection of <see cref="ISegmentString"/>s</param>
+        public FastNodingValidator(IEnumerable<ISegmentString> segStrings, Elevation.ElevationModel elevationModel)
         {
             _segStrings.AddRange(segStrings);
+            _li = LineIntersectorFactory.CreateFor(elevationModel);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Noding/NodingValidator.cs
+++ b/src/NetTopologySuite/Noding/NodingValidator.cs
@@ -13,7 +13,7 @@ namespace NetTopologySuite.Noding
     {
         private static readonly GeometryFactory Factory = new GeometryFactory();
 
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li;
         private readonly IList<ISegmentString> _segStrings;
 
         /// <summary>
@@ -22,8 +22,18 @@ namespace NetTopologySuite.Noding
         /// </summary>
         /// <param name="segStrings">The seg strings.</param>
         public NodingValidator(IList<ISegmentString> segStrings)
+            : this(segStrings, null)
+        { }
+
+        /// <summary>
+        /// Creates a new validator for the given collection
+        /// of <see cref="ISegmentString"/>s.
+        /// </summary>
+        /// <param name="segStrings">The seg strings.</param>
+        public NodingValidator(IList<ISegmentString> segStrings, Elevation.ElevationModel em)
         {
             _segStrings = segStrings;
+            _li = LineIntersectorFactory.CreateFor(em);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Noding/SegmentIntersectionDetector.cs
+++ b/src/NetTopologySuite/Noding/SegmentIntersectionDetector.cs
@@ -28,7 +28,7 @@ namespace NetTopologySuite.Noding
         /// Creates an intersection finder using a <see cref="RobustLineIntersector"/>
         /// </summary>
         public SegmentIntersectionDetector()
-            :this(new RobustLineIntersector())
+            :this(LineIntersectorFactory.CreateFor(null))
         {
         }
 

--- a/src/NetTopologySuite/Noding/Snap/SnappingIntersectionAdder.cs
+++ b/src/NetTopologySuite/Noding/Snap/SnappingIntersectionAdder.cs
@@ -11,7 +11,7 @@ namespace NetTopologySuite.Noding.Snap
     /// <version>1.17</version>
     public sealed class SnappingIntersectionAdder : ISegmentIntersector
     {
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = LineIntersectorFactory.CreateFor(null);
         private readonly double _snapTolerance;
         private readonly SnappingPointIndex _snapPointIndex;
 
@@ -21,10 +21,22 @@ namespace NetTopologySuite.Noding.Snap
         /// </summary>
         /// <param name="snapTolerance">The snapping tolerance distance</param>
         /// <param name="snapPointIndex">A snap index to use</param>
-        public SnappingIntersectionAdder(double snapTolerance, SnappingPointIndex snapPointIndex)
+        public SnappingIntersectionAdder(double snapTolerance, SnappingPointIndex snapPointIndex):
+            this(snapTolerance, snapPointIndex, null)
+        { }
+
+        /// <summary>
+        /// Creates an intersector which finds all snapped intersections,
+        /// and adds them as nodes.
+        /// </summary>
+        /// <param name="snapTolerance">The snapping tolerance distance</param>
+        /// <param name="snapPointIndex">A snap index to use</param>
+        /// <param name="elevationModel">An elevation model to use for the line intersector</param>
+        public SnappingIntersectionAdder(double snapTolerance, SnappingPointIndex snapPointIndex, Elevation.ElevationModel elevationModel)
         {
             _snapPointIndex = snapPointIndex;
             _snapTolerance = snapTolerance;
+            _li = LineIntersectorFactory.CreateFor(elevationModel);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Noding/Snapround/GeometryNoder.cs
+++ b/src/NetTopologySuite/Noding/Snapround/GeometryNoder.cs
@@ -23,6 +23,7 @@ namespace NetTopologySuite.Noding.Snapround
     {
         private GeometryFactory _geomFact;
         private readonly PrecisionModel _pm;
+        private readonly Elevation.ElevationModel _em;
         //private bool isValidityChecked = false;
 
         /// <summary>
@@ -30,8 +31,19 @@ namespace NetTopologySuite.Noding.Snapround
         /// </summary>
         /// <param name="pm">The precision model for the grid to snap-round to.</param>
         public GeometryNoder(PrecisionModel pm)
+            : this(pm, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new noder which snap-rounds to a grid specified by the given <see cref="PrecisionModel"/>
+        /// </summary>
+        /// <param name="pm">The precision model for the grid to snap-round to.</param>
+        /// <param name="em">The elevation model to use for evaluating z-ordinate values</param>
+        public GeometryNoder(PrecisionModel pm, Elevation.ElevationModel em)
         {
             _pm = pm;
+            _em = em;
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Noding/Snapround/HotPixel.cs
+++ b/src/NetTopologySuite/Noding/Snapround/HotPixel.cs
@@ -327,7 +327,7 @@ namespace NetTopologySuite.Noding.Snapround
             corner[lowerLeft] = new Coordinate(minx, miny);
             corner[lowerRight] = new Coordinate(maxx, miny);
 
-            LineIntersector li = new RobustLineIntersector();
+            var li = LineIntersectorFactory.CreateFor(null);
             li.ComputeIntersection(p0, p1, corner[0], corner[1]);
             if (li.HasIntersection) return true;
             li.ComputeIntersection(p0, p1, corner[1], corner[2]);

--- a/src/NetTopologySuite/Noding/Snapround/MCIndexSnapRounder.cs
+++ b/src/NetTopologySuite/Noding/Snapround/MCIndexSnapRounder.cs
@@ -39,7 +39,8 @@ namespace NetTopologySuite.Noding.Snapround
         /// <param name="pm">The <see cref="PrecisionModel" /> to use.</param>
         public MCIndexSnapRounder(PrecisionModel pm)
         {
-            _li = new RobustLineIntersector { PrecisionModel = pm };
+            _li = LineIntersectorFactory.CreateFor(null);
+            _li.PrecisionModel = pm;
             _scaleFactor = pm.Scale;
         }
 

--- a/src/NetTopologySuite/Noding/Snapround/SnapRoundingIntersectionAdder.cs
+++ b/src/NetTopologySuite/Noding/Snapround/SnapRoundingIntersectionAdder.cs
@@ -24,7 +24,7 @@ namespace NetTopologySuite.Noding.Snapround
     /// </summary>
     public sealed class SnapRoundingIntersectionAdder : ISegmentIntersector
     {
-
+        private readonly Elevation.ElevationModel _elevationModel;
         private readonly LineIntersector _li;
         private readonly double _nearnessTol;
 
@@ -45,6 +45,16 @@ namespace NetTopologySuite.Noding.Snapround
         /// </summary>
         /// <param name="nearnessTol">the intersection distance tolerance</param>
         public SnapRoundingIntersectionAdder(double nearnessTol)
+            : this(nearnessTol, null)
+        { }
+
+        /// <summary>
+        /// Creates an intersector which finds all snapped interior intersections,
+        /// and adds them as nodes.
+        /// </summary>
+        /// <param name="nearnessTol">the intersection distance tolerance</param>
+        /// <param name="elevationModel">An (optional) elevation model</param>
+        public SnapRoundingIntersectionAdder(double nearnessTol, Elevation.ElevationModel elevationModel)
         {
             _nearnessTol = nearnessTol;
 
@@ -52,7 +62,10 @@ namespace NetTopologySuite.Noding.Snapround
              * Intersections are detected and computed using full precision.
              * They are snapped in a subsequent phase.
              */
-            _li = new RobustLineIntersector();
+            _li = LineIntersectorFactory.CreateFor(elevationModel);
+            if (!(elevationModel is Operation.OverlayNG.ElevationModel))
+                _elevationModel = elevationModel;
+
             Intersections = new Collection<Coordinate>();
         }
 

--- a/src/NetTopologySuite/Noding/Snapround/SnapRoundingNoder.cs
+++ b/src/NetTopologySuite/Noding/Snapround/SnapRoundingNoder.cs
@@ -46,13 +46,19 @@ namespace NetTopologySuite.Noding.Snapround
 
         private readonly PrecisionModel _pm;
         private readonly HotPixelIndex _pixelIndex;
+        private readonly Elevation.ElevationModel _elevationModel;
 
         private List<NodedSegmentString> _snappedResult;
 
         public SnapRoundingNoder(PrecisionModel pm)
+            :this(pm, null)
+        { }
+
+        public SnapRoundingNoder(PrecisionModel pm, Elevation.ElevationModel elevationModel)
         {
             _pm = pm;
             _pixelIndex = new HotPixelIndex(pm);
+            _elevationModel = elevationModel;
         }
 
         /// <summary>
@@ -103,7 +109,7 @@ namespace NetTopologySuite.Noding.Snapround
             double snapGridSize = 1.0 / _pm.Scale;
             double nearnessTol = snapGridSize / NEARNESS_FACTOR;
 
-            var intAdder = new SnapRoundingIntersectionAdder(nearnessTol);
+            var intAdder = new SnapRoundingIntersectionAdder(nearnessTol, _elevationModel);
             var noder = new MCIndexNoder(intAdder, nearnessTol);
             noder.ComputeNodes(segStrings);
             var intPts = intAdder.Intersections;

--- a/src/NetTopologySuite/Noding/ValidatingNoder.cs
+++ b/src/NetTopologySuite/Noding/ValidatingNoder.cs
@@ -18,6 +18,7 @@ namespace NetTopologySuite.Noding
     {
 
         private readonly INoder _noder;
+        private readonly Elevation.ElevationModel _elevationModel;
         private IList<ISegmentString> _nodedSs;
 
         /// <summary>
@@ -25,8 +26,17 @@ namespace NetTopologySuite.Noding
         /// </summary>
         /// <param name="noder">The noder to validate</param>
         public ValidatingNoder(INoder noder)
+            : this(noder, null) { }
+
+        /// <summary>
+        /// Creates a noding validator wrapping the given <paramref name="noder"/>
+        /// </summary>
+        /// <param name="noder">The noder to validate</param>
+        /// <param name="elevationModel">An optional elevation model</param>
+        public ValidatingNoder(INoder noder, Elevation.ElevationModel elevationModel)
         {
-            this._noder = noder;
+            _noder = noder;
+            _elevationModel = elevationModel;
         }
 
         /// <summary>
@@ -43,7 +53,7 @@ namespace NetTopologySuite.Noding
 
         private void Validate()
         {
-            var nv = new FastNodingValidator(_nodedSs);
+            var nv = new FastNodingValidator(_nodedSs, _elevationModel);
             nv.CheckValid();
         }
 

--- a/src/NetTopologySuite/Operation/Buffer/BufferBuilder.cs
+++ b/src/NetTopologySuite/Operation/Buffer/BufferBuilder.cs
@@ -136,7 +136,9 @@ namespace NetTopologySuite.Operation.Buffer
             if (_workingNoder != null) return _workingNoder;
 
             // otherwise use a fast (but non-robust) noder
-            var noder = new MCIndexNoder(new IntersectionAdder(new RobustLineIntersector { PrecisionModel = precisionModel}));
+            var li = LineIntersectorFactory.CreateFor(null);
+            li.PrecisionModel = precisionModel;
+            var noder = new MCIndexNoder(new IntersectionAdder(li));
 
             //var li = new RobustLineIntersector();
             //li.PrecisionModel = precisionModel;

--- a/src/NetTopologySuite/Operation/Buffer/OffsetSegmentGenerator.cs
+++ b/src/NetTopologySuite/Operation/Buffer/OffsetSegmentGenerator.cs
@@ -90,7 +90,7 @@ namespace NetTopologySuite.Operation.Buffer
 
             // compute intersections in full precision, to provide accuracy
             // the points are rounded as they are inserted into the curve line
-            _li = new RobustLineIntersector();
+            _li = LineIntersectorFactory.CreateFor(null);
 
             int quadSegs = bufParams.QuadrantSegments;
             if (quadSegs < 1) quadSegs = 1;

--- a/src/NetTopologySuite/Operation/Buffer/OldOffsetCurveBuilder.cs
+++ b/src/NetTopologySuite/Operation/Buffer/OldOffsetCurveBuilder.cs
@@ -88,7 +88,7 @@ namespace NetTopologySuite.Operation.Buffer
 
             // compute intersections in full precision, to provide accuracy
             // the points are rounded as they are inserted into the curve line
-            _li = new RobustLineIntersector();
+            _li = LineIntersectorFactory.CreateFor(null);
             _filletAngleQuantum = Math.PI / 2.0 / bufParams.QuadrantSegments;
 
             /*

--- a/src/NetTopologySuite/Operation/GeometryGraphOperation.cs
+++ b/src/NetTopologySuite/Operation/GeometryGraphOperation.cs
@@ -10,7 +10,7 @@ namespace NetTopologySuite.Operation
     public class GeometryGraphOperation
     {
 
-        private LineIntersector _li = new RobustLineIntersector();
+        private LineIntersector _li = LineIntersectorFactory.CreateFor(null);
 
         /// <summary>
         ///

--- a/src/NetTopologySuite/Operation/IsSimpleOp.cs
+++ b/src/NetTopologySuite/Operation/IsSimpleOp.cs
@@ -164,7 +164,7 @@ namespace NetTopologySuite.Operation
                 return true;
 
             var graph = new GeometryGraph(0, geom);
-            var li = new RobustLineIntersector();
+            var li = LineIntersectorFactory.CreateFor(null);
             var si = graph.ComputeSelfNodes(li, true);
             // if no self-intersection, must be simple
             if (!si.HasIntersection) return true;

--- a/src/NetTopologySuite/Operation/Predicate/SegmentIntersectionTester.cs
+++ b/src/NetTopologySuite/Operation/Predicate/SegmentIntersectionTester.cs
@@ -12,7 +12,7 @@ namespace NetTopologySuite.Operation.Predicate
     public class SegmentIntersectionTester
     {
         // for purposes of intersection testing, don't need to set precision model
-        private readonly LineIntersector li = new RobustLineIntersector();
+        private readonly LineIntersector li = LineIntersectorFactory.CreateFor(null);
 
         private bool _hasIntersection;
         private readonly Coordinate pt00 = new Coordinate();

--- a/src/NetTopologySuite/Operation/Relate/RelateComputer.cs
+++ b/src/NetTopologySuite/Operation/Relate/RelateComputer.cs
@@ -21,7 +21,7 @@ namespace NetTopologySuite.Operation.Relate
     /// </summary>
     public class RelateComputer
     {
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = LineIntersectorFactory.CreateFor(null);
         private readonly PointLocator _ptLocator = new PointLocator();
         private readonly GeometryGraph[] _arg;     // the arg(s) of the operation
         private readonly NodeMap _nodes = new NodeMap(new RelateNodeFactory());

--- a/src/NetTopologySuite/Operation/Valid/ConsistentAreaTester.cs
+++ b/src/NetTopologySuite/Operation/Valid/ConsistentAreaTester.cs
@@ -19,7 +19,7 @@ namespace NetTopologySuite.Operation.Valid
     [Obsolete]
     public class ConsistentAreaTester
     {
-        private readonly LineIntersector li = new RobustLineIntersector();
+        private readonly LineIntersector li = LineIntersectorFactory.CreateFor(null);
         private readonly GeometryGraph geomGraph;
         private readonly RelateNodeGraph nodeGraph = new RelateNodeGraph();
 

--- a/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
+++ b/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
@@ -323,7 +323,7 @@ namespace NetTopologySuite.Operation.Valid
             private readonly bool _isClosedEndpointsInInterior;
             private readonly bool _isFindAll;
 
-            readonly LineIntersector _li = new RobustLineIntersector();
+            readonly LineIntersector _li = LineIntersectorFactory.CreateFor(null);
             private readonly List<Coordinate> _intersectionPts;
 
             //private bool _hasInteriorInt;

--- a/src/NetTopologySuite/Operation/Valid/PolygonIntersectionAnalyzer.cs
+++ b/src/NetTopologySuite/Operation/Valid/PolygonIntersectionAnalyzer.cs
@@ -19,7 +19,7 @@ namespace NetTopologySuite.Operation.Valid
         //private const int NoInvalidIntersection = -1;
         private readonly bool _isInvertedRingValid;
 
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = LineIntersectorFactory.CreateFor(null);
         private TopologyValidationErrors _invalidCode = TopologyValidationErrors.NoInvalidIntersection;
         private Coordinate _invalidLocation;
 

--- a/src/NetTopologySuite/Operation/Valid/PolygonTopologyAnalyzer.cs
+++ b/src/NetTopologySuite/Operation/Valid/PolygonTopologyAnalyzer.cs
@@ -165,7 +165,7 @@ namespace NetTopologySuite.Operation.Valid
         /// <returns>The intersection segment index, or <c>-1</c> if not intersection is found.</returns>
         private static int IntersectingSegIndex(Coordinate[] ringPts, Coordinate pt)
         {
-            LineIntersector li = new RobustLineIntersector();
+            LineIntersector li = LineIntersectorFactory.CreateFor(null);
             for (int i = 0; i < ringPts.Length - 1; i++)
             {
                 li.ComputeIntersection(pt, ringPts[i], ringPts[i + 1]);

--- a/src/NetTopologySuite/Simplify/TaggedLineStringSimplifier.cs
+++ b/src/NetTopologySuite/Simplify/TaggedLineStringSimplifier.cs
@@ -10,7 +10,7 @@ namespace NetTopologySuite.Simplify
     /// </summary>
     public class TaggedLineStringSimplifier
     {
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = LineIntersectorFactory.CreateFor(null);
         private readonly LineSegmentIndex _inputIndex = new LineSegmentIndex();
         private readonly LineSegmentIndex _outputIndex = new LineSegmentIndex();
         private TaggedLineString _line;

--- a/src/NetTopologySuite/Triangulate/Tri/Tri.cs
+++ b/src/NetTopologySuite/Triangulate/Tri/Tri.cs
@@ -406,7 +406,7 @@ namespace NetTopologySuite.Triangulate.Tri
             Assert.IsTrue(e1.Equals2D(n0), "Edge coord not equal");
 
             //--- check that no edges cross
-            var li = new RobustLineIntersector();
+            var li = LineIntersectorFactory.CreateFor(null);
             for (int i = 0; i < 3; i++)
             {
                 for (int j = 0; j < 3; j++)

--- a/test/NetTopologySuite.Tests.NUnit/Operation/OverlayNG/OverlayNGWithElevModelTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/OverlayNG/OverlayNGWithElevModelTest.cs
@@ -1,0 +1,759 @@
+﻿using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.Overlay;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Operation.OverlayNG
+{
+    public class OverlayNGWithElevModelTest : GeometryTestCase
+    {
+        private readonly static Elevation.ElevationModel _em = new Elevation.ConstElevationModel();
+
+        [Test]
+        public void TestEmptyGCBothIntersection()
+        {
+            var a = Read("GEOMETRYCOLLECTION EMPTY");
+            var b = Read("GEOMETRYCOLLECTION EMPTY");
+            var expected = Read("GEOMETRYCOLLECTION EMPTY");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyAPolygonIntersection()
+        {
+            var a = Read("POLYGON EMPTY");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("POLYGON EMPTY");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyBIntersection()
+        {
+            var a = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var b = Read("POLYGON EMPTY");
+            var expected = Read("POLYGON EMPTY");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyABIntersection()
+        {
+            var a = Read("POLYGON EMPTY");
+            var b = Read("POLYGON EMPTY");
+            var expected = Read("POLYGON EMPTY");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyADifference()
+        {
+            var a = Read("POLYGON EMPTY");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("POLYGON EMPTY");
+            var actual = Difference(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyAUnion()
+        {
+            var a = Read("POLYGON EMPTY");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyASymDifference()
+        {
+            var a = Read("POLYGON EMPTY");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var actual = SymDifference(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyLinePolygonIntersection()
+        {
+            var a = Read("LINESTRING EMPTY");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("LINESTRING EMPTY");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyLinePolygonDifference()
+        {
+            var a = Read("LINESTRING EMPTY");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("LINESTRING EMPTY");
+            var actual = Difference(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestEmptyPointPolygonIntersection()
+        {
+            var a = Read("POINT EMPTY");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("POINT EMPTY");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDisjointIntersection()
+        {
+            var a = Read("POLYGON ((60 90, 90 90, 90 60, 60 60, 60 90))");
+            var b = Read("POLYGON ((200 300, 300 300, 300 200, 200 200, 200 300))");
+            var expected = Read("POLYGON EMPTY");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDisjointIntersectionNoOpt()
+        {
+            var a = Read("POLYGON ((60 90, 90 90, 90 60, 60 60, 60 90))");
+            var b = Read("POLYGON ((200 300, 300 300, 300 200, 200 200, 200 300))");
+            var expected = Read("POLYGON EMPTY");
+            var actual = IntersectionNoOpt(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestAreaLineIntersection()
+        {
+            var a = Read("POLYGON ((360 200, 220 200, 220 180, 300 180, 300 160, 300 140, 360 200))");
+            var b = Read("MULTIPOLYGON (((280 180, 280 160, 300 160, 300 180, 280 180)), ((220 230, 240 230, 240 180, 220 180, 220 230)))");
+            var expected = Read("GEOMETRYCOLLECTION (LINESTRING (280 180, 300 180), LINESTRING (300 160, 300 180), POLYGON ((220 180, 220 200, 240 200, 240 180, 220 180)))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestAreaLinePointIntersection()
+        {
+            var a = Read("POLYGON ((100 100, 200 100, 200 150, 250 100, 300 100, 300 150, 350 100, 350 200, 100 200, 100 100))");
+            var b = Read("POLYGON ((100 140, 170 140, 200 100, 400 100, 400 30, 100 30, 100 140))");
+            var expected = Read("GEOMETRYCOLLECTION (POINT (350 100), LINESTRING (250 100, 300 100), POLYGON ((100 100, 100 140, 170 140, 200 100, 100 100)))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Note this result is different to old overlay, because the top-right diagonal line
+         * gets snapped to the vertex above it.
+         */
+        [Test]
+        public void TestTriangleFillingHoleUnion()
+        {
+            var a = Read("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 1, 1 1), (1 2, 1 3, 2 3, 1 2), (2 3, 3 3, 3 2, 2 3))");
+            var b = Read("POLYGON ((2 1, 3 1, 3 2, 2 1))");
+            var expected = Read("POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0), (1 2, 1 1, 2 1, 1 2), (2 3, 1 3, 1 2, 2 3))");
+            CheckEqual(expected, OverlayNGWithElevModelTest.Union(a, b, 1));
+        }
+
+        [Test]
+        public void TestTriangleFillingHoleUnionPrec10()
+        {
+            var a = Read("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 1, 1 1), (1 2, 1 3, 2 3, 1 2), (2 3, 3 3, 3 2, 2 3))");
+            var b = Read("POLYGON ((2 1, 3 1, 3 2, 2 1))");
+            var expected = Read("POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0), (1 2, 1 1, 2 1, 1 2), (2 3, 1 3, 1 2, 2 3), (3 2, 3 3, 2 3, 3 2))");
+            CheckEqual(expected, OverlayNGWithElevModelTest.Union(a, b, 10));
+        }
+
+
+        [Test]
+        public void TestBoxTriIntersection()
+        {
+            var a = Read("POLYGON ((0 6, 4 6, 4 2, 0 2, 0 6))");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("POLYGON ((3 2, 1 2, 2 5, 3 2))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestBoxTriUnion()
+        {
+            var a = Read("POLYGON ((0 6, 4 6, 4 2, 0 2, 0 6))");
+            var b = Read("POLYGON ((1 0, 2 5, 3 0, 1 0))");
+            var expected = Read("POLYGON ((0 6, 4 6, 4 2, 3 2, 3 0, 1 0, 1 2, 0 2, 0 6))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void Test2spikesIntersection()
+        {
+            var a = Read("POLYGON ((0 100, 40 100, 40 0, 0 0, 0 100))");
+            var b = Read("POLYGON ((70 80, 10 80, 60 50, 11 20, 69 11, 70 80))");
+            var expected = Read("MULTIPOLYGON (((40 80, 40 62, 10 80, 40 80)), ((40 38, 40 16, 11 20, 40 38)))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void Test2spikesUnion()
+        {
+            var a = Read("POLYGON ((0 100, 40 100, 40 0, 0 0, 0 100))");
+            var b = Read("POLYGON ((70 80, 10 80, 60 50, 11 20, 69 11, 70 80))");
+            var expected = Read("POLYGON ((0 100, 40 100, 40 80, 70 80, 69 11, 40 16, 40 0, 0 0, 0 100), (40 62, 40 38, 60 50, 40 62))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestTriBoxIntersection()
+        {
+            var a = Read("POLYGON ((68 35, 35 42, 40 9, 68 35))");
+            var b = Read("POLYGON ((20 60, 50 60, 50 30, 20 30, 20 60))");
+            var expected = Read("POLYGON ((37 30, 35 42, 50 39, 50 30, 37 30))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestNestedShellsIntersection()
+        {
+            var a = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var b = Read("POLYGON ((120 180, 180 180, 180 120, 120 120, 120 180))");
+            var expected = Read("POLYGON ((120 180, 180 180, 180 120, 120 120, 120 180))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestNestedShellsUnion()
+        {
+            var a = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var b = Read("POLYGON ((120 180, 180 180, 180 120, 120 120, 120 180))");
+            var expected = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestATouchingNestedPolyUnion()
+        {
+            var a = Read("MULTIPOLYGON (((0 200, 200 200, 200 0, 0 0, 0 200), (50 50, 190 50, 50 200, 50 50)), ((60 100, 100 60, 50 50, 60 100)))");
+            var b = Read("POLYGON ((135 176, 180 176, 180 130, 135 130, 135 176))");
+            var expected = Read("MULTIPOLYGON (((0 0, 0 200, 50 200, 200 200, 200 0, 0 0), (50 50, 190 50, 50 200, 50 50)), ((50 50, 60 100, 100 60, 50 50)))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestTouchingPolyDifference()
+        {
+            var a = Read("POLYGON ((200 200, 200 0, 0 0, 0 200, 200 200), (100 100, 50 100, 50 200, 100 100))");
+            var b = Read("POLYGON ((150 100, 100 100, 150 200, 150 100))");
+            var expected = Read("MULTIPOLYGON (((0 0, 0 200, 50 200, 50 100, 100 100, 150 100, 150 200, 200 200, 200 0, 0 0)), ((50 200, 150 200, 100 100, 50 200)))");
+            var actual = Difference(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestTouchingHoleUnion()
+        {
+            var a = Read("POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300), (200 200, 150 200, 200 300, 200 200))");
+            var b = Read("POLYGON ((130 160, 260 160, 260 120, 130 120, 130 160))");
+            var expected = Read("POLYGON ((100 100, 100 300, 200 300, 300 300, 300 100, 100 100), (150 200, 200 200, 200 300, 150 200))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestTouchingMultiHoleUnion()
+        {
+            var a = Read("POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300), (200 200, 150 200, 200 300, 200 200), (250 230, 216 236, 250 300, 250 230), (235 198, 300 200, 237 175, 235 198))");
+            var b = Read("POLYGON ((130 160, 260 160, 260 120, 130 120, 130 160))");
+            var expected = Read("POLYGON ((100 300, 200 300, 250 300, 300 300, 300 200, 300 100, 100 100, 100 300), (200 300, 150 200, 200 200, 200 300), (250 300, 216 236, 250 230, 250 300), (300 200, 235 198, 237 175, 300 200))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestBoxLineIntersection()
+        {
+            var a = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var b = Read("LINESTRING (50 150, 150 150)");
+            var expected = Read("LINESTRING (100 150, 150 150)");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestBoxLineUnion()
+        {
+            var a = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var b = Read("LINESTRING (50 150, 150 150)");
+            var expected = Read("GEOMETRYCOLLECTION (POLYGON ((200 200, 200 100, 100 100, 100 150, 100 200, 200 200)), LINESTRING (50 150, 100 150))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestAdjacentBoxesIntersection()
+        {
+            var a = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var b = Read("POLYGON ((300 200, 300 100, 200 100, 200 200, 300 200))");
+            var expected = Read("LINESTRING (200 100, 200 200)");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestAdjacentBoxesUnion()
+        {
+            var a = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var b = Read("POLYGON ((300 200, 300 100, 200 100, 200 200, 300 200))");
+            var expected = Read("POLYGON ((100 100, 100 200, 200 200, 300 200, 300 100, 200 100, 100 100))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestCollapseBoxGoreIntersection()
+        {
+            var a = Read("MULTIPOLYGON (((1 1, 5 1, 5 0, 1 0, 1 1)), ((1 1, 5 2, 5 4, 1 4, 1 1)))");
+            var b = Read("POLYGON ((1 0, 1 2, 2 2, 2 0, 1 0))");
+            var expected = Read("POLYGON ((2 0, 1 0, 1 1, 1 2, 2 2, 2 1, 2 0))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestCollapseBoxGoreUnion()
+        {
+            var a = Read("MULTIPOLYGON (((1 1, 5 1, 5 0, 1 0, 1 1)), ((1 1, 5 2, 5 4, 1 4, 1 1)))");
+            var b = Read("POLYGON ((1 0, 1 2, 2 2, 2 0, 1 0))");
+            var expected = Read("POLYGON ((2 0, 1 0, 1 1, 1 2, 1 4, 5 4, 5 2, 2 1, 5 1, 5 0, 2 0))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+        [Test]
+        public void TestSnapBoxGoreIntersection()
+        {
+            var a = Read("MULTIPOLYGON (((1 1, 5 1, 5 0, 1 0, 1 1)), ((1 1, 5 2, 5 4, 1 4, 1 1)))");
+            var b = Read("POLYGON ((4 3, 5 3, 5 0, 4 0, 4 3))");
+            var expected = Read("MULTIPOLYGON (((4 3, 5 3, 5 2, 4 2, 4 3)), ((4 0, 4 1, 5 1, 5 0, 4 0)))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestSnapBoxGoreUnion()
+        {
+            var a = Read("MULTIPOLYGON (((1 1, 5 1, 5 0, 1 0, 1 1)), ((1 1, 5 2, 5 4, 1 4, 1 1)))");
+            var b = Read("POLYGON ((4 3, 5 3, 5 0, 4 0, 4 3))");
+            var expected = Read("POLYGON ((1 1, 1 4, 5 4, 5 3, 5 2, 5 1, 5 0, 4 0, 1 0, 1 1), (1 1, 4 1, 4 2, 1 1))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestCollapseTriBoxIntersection()
+        {
+            var a = Read("POLYGON ((1 2, 1 1, 9 1, 1 2))");
+            var b = Read("POLYGON ((9 2, 9 1, 8 1, 8 2, 9 2))");
+            var expected = Read("LINESTRING (8 1, 9 1)");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestCollapseTriBoxUnion()
+        {
+            var a = Read("POLYGON ((1 2, 1 1, 9 1, 1 2))");
+            var b = Read("POLYGON ((9 2, 9 1, 8 1, 8 2, 9 2))");
+            var expected = Read("MULTIPOLYGON (((1 1, 1 2, 8 1, 1 1)), ((8 1, 8 2, 9 2, 9 1, 8 1)))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Fails because polygon A collapses totally, but one
+         * L edge is still labelled with location A:iL due to being located
+         * inside original A polygon by PiP test for incomplete edges.
+         * That edge is then marked as in-result-area, but 
+         * it is the only edge marked in-result, so result ring can't
+         * be formed because ring is incomplete
+         */
+        [Test]
+        public void TestCollapseAIncompleteRingUnion()
+        {
+            var a = Read("POLYGON ((0.9 1.7, 1.3 1.4, 2.1 1.4, 2.1 0.9, 1.3 0.9, 0.9 0, 0.9 1.7))");
+            var b = Read("POLYGON ((1 3, 3 3, 3 1, 1.3 0.9, 1 0.4, 1 3))");
+            var expected = Read("GEOMETRYCOLLECTION (LINESTRING (1 0, 1 1), POLYGON ((1 1, 1 2, 1 3, 3 3, 3 1, 2 1, 1 1)))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Fails because edge of B is computed as Interior to A because it
+         * is checked against full precision input, rather than collapsed linework.
+         * 
+         * Probably need to determine location against output rings
+         */
+        [Test]
+        public void TestCollapseResultShouldHavePolygonUnion()
+        {
+            var a = Read("POLYGON ((1 3.3, 1.3 1.4, 3.1 1.4, 3.1 0.9, 1.3 0.9, 1 -0.2, 0.8 1.3, 1 3.3))");
+            var b = Read("POLYGON ((1 2.9, 2.9 2.9, 2.9 1.3, 1.7 1, 1.3 0.9, 1 0.4, 1 2.9))");
+            var expected = Read("GEOMETRYCOLLECTION (LINESTRING (1 0, 1 1), POLYGON ((1 1, 1 3, 3 3, 3 1, 2 1, 1 1)))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Fails because current isResultAreaEdge does not accept L edges as result area boundary
+         */
+        [Test]
+        public void TestCollapseHoleAlongEdgeOfBIntersection()
+        {
+            var a = Read("POLYGON ((0 3, 3 3, 3 0, 0 0, 0 3), (1 1.2, 1 1.1, 2.3 1.1, 1 1.2))");
+            var b = Read("POLYGON ((1 1, 2 1, 2 0, 1 0, 1 1))");
+            var expected = Read("POLYGON ((1 1, 2 1, 2 0, 1 0, 1 1))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Fails because A holes collapse to L edges, and are not computed as in Int of A,
+         * so are not included as result area edges.
+         */
+        [Test]
+        public void TestCollapseHolesAlongAllEdgesOfBIntersection()
+        {
+            var a = Read("POLYGON ((0 3, 3 3, 3 0, 0 0, 0 3), (1 2.2, 1 2.1, 2 2.1, 1 2.2), (2.1 2, 2.2 2, 2.1 1, 2.1 2), (2 0.9, 2 0.8, 1 0.9, 2 0.9), (0.9 1, 0.8 1, 0.9 2, 0.9 1))");
+            var b = Read("POLYGON ((1 2, 2 2, 2 1, 1 1, 1 2))");
+            var expected = Read("POLYGON ((1 2, 2 2, 2 1, 1 1, 1 2))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestVerySmallBIntersection()
+        {
+            var a = Read("POLYGON ((2.526855443750341 48.82324221874807, 2.5258255 48.8235855, 2.5251389 48.8242722, 2.5241089 48.8246155, 2.5254822 48.8246155, 2.5265121 48.8242722, 2.526855443750341 48.82324221874807))");
+            var b = Read("POLYGON ((2.526512100000002 48.824272199999996, 2.5265120999999953 48.8242722, 2.5265121 48.8242722, 2.526512100000002 48.824272199999996))");
+            var expected = Read("POLYGON EMPTY");
+            var actual = Intersection(a, b, 100000000);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Currently noding is incorrect, producing one 2pt edge which is coincident
+         * with a 3-pt edge.  The EdgeMerger doesn't check that merged edges are identical,
+         * so merges the 3pt edge into the 2-pt edge.
+         * FIXED by better noding.
+         */
+        [Test]
+        public void TestEdgeDisappears()
+        {
+            var a = Read("LINESTRING (2.1279144 48.8445282, 2.126884443750796 48.84555818124935, 2.1268845 48.8455582, 2.1268845 48.8462448)");
+            var b = Read("LINESTRING EMPTY");
+            var expected = Read("LINESTRING EMPTY");
+            var actual = Intersection(a, b, 1000000);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Probably due to B collapsing completely and disconnected edges being located incorrectly in B interior.
+         * Have seen other cases of this as well.
+         * Also - a B edge is marked as a Hole, which is incorrect.
+         * 
+         * FIXED - copy-paste error in Edge.mergedRingRole
+         */
+        [Test]
+        public void TestBcollapseLocateIssue()
+        {
+            var a = Read("POLYGON ((2.3442078 48.9331054, 2.3435211 48.9337921, 2.3428345 48.9358521, 2.3428345 48.9372253, 2.3433495 48.9370537, 2.3440361 48.936367, 2.3442078 48.9358521, 2.3442078 48.9331054))");
+            var b = Read("POLYGON ((2.3442078 48.9331054, 2.3435211 48.9337921, 2.3433494499999985 48.934307100000005, 2.3438644 48.9341354, 2.3442078 48.9331055, 2.3442078 48.9331054))");
+            var expected = Read("MULTILINESTRING ((2.343 48.934, 2.344 48.934), (2.344 48.933, 2.344 48.934))");
+            var actual = Intersection(a, b, 1000);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Fails because a component of B collapses completely and labelling is wrong.
+         * Labelling marks a single collapsed edge as B:i.
+         * Edge is only connected to two other edges both marked B:e.
+         * B:i edge is included in area result edges, and faild because it does not form a ring.
+         * 
+         * Perhaps a fix is to ignore connected single Bi edges which do not form a ring?
+         * This may be dangerous since it may hide other labelling problems?
+         * 
+         * FIXED by computing location of both edge endpoints.
+         */
+        [Test]
+        public void TestBcollapseEdgeLabeledInterior()
+        {
+            var a = Read("POLYGON ((2.384376506250038 48.91765596875102, 2.3840332 48.916626, 2.3840332 48.9138794, 2.3833466 48.9118195, 2.3812866 48.9111328, 2.37854 48.9111328, 2.3764801 48.9118195, 2.3723602 48.9159393, 2.3703003 48.916626, 2.3723602 48.9173126, 2.3737335 48.9186859, 2.3757935 48.9193726, 2.3812866 48.9193726, 2.3833466 48.9186859, 2.384376506250038 48.91765596875102))");
+            var b = Read("MULTIPOLYGON (((2.3751067666731345 48.919143677778855, 2.3757935 48.9193726, 2.3812866 48.9193726, 2.3812866 48.9179993, 2.3809433 48.9169693, 2.3799133 48.916626, 2.3771667 48.916626, 2.3761368 48.9169693, 2.3754501 48.9190292, 2.3751067666731345 48.919143677778855)), ((2.3826108673454116 48.91893115612326, 2.3833466 48.9186859, 2.3840331750033394 48.91799930833141, 2.3830032 48.9183426, 2.3826108673454116 48.91893115612326)))");
+            var expected = Read("POLYGON ((2.375 48.91833333333334, 2.375 48.92, 2.381666666666667 48.92, 2.381666666666667 48.91833333333334, 2.381666666666667 48.916666666666664, 2.38 48.916666666666664, 2.3766666666666665 48.916666666666664, 2.375 48.91833333333334))");
+            var actual = Intersection(a, b, 600);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * This failure is due to B inverting due to an snapped intersection being added 
+         * to a segment by a nearby vertex, and the snap vertex "jumped" across another segment.
+         * This is because the nearby snap intersection tolerance in SnapIntersectionAdder was too large (FACTOR = 10).
+         * 
+         * FIXED by reducing the tolerance factor to 100.
+         * 
+         * However, it may be that there is no safe tolerance level?  
+         * Perhaps there can always be situations where a snap intersection will jump across a segment?
+         */
+        [Test]
+        public void TestBNearVertexSnappingCausesInversion()
+        {
+            var a = Read("POLYGON ((2.2494507 48.8864136, 2.2484207 48.8867569, 2.2477341 48.8874435, 2.2470474 48.8874435, 2.2463608 48.8853836, 2.2453308 48.8850403, 2.2439575 48.8850403, 2.2429276 48.8853836, 2.2422409 48.8860703, 2.2360611 48.8970566, 2.2504807 48.8956833, 2.2494507 48.8864136))");
+            var b = Read("POLYGON ((2.247734099999997 48.8874435, 2.2467041 48.8877869, 2.2453308 48.8877869, 2.2443008 48.8881302, 2.243957512499544 48.888473487500455, 2.2443008 48.8888168, 2.2453308 48.8891602, 2.2463608 48.8888168, 2.247734099999997 48.8874435))");
+            var expected = Read("LINESTRING (2.245 48.89, 2.25 48.885)");
+            var actual = Intersection(a, b, 200);
+            CheckEqual(expected, actual);
+        }
+
+        /**
+         * Failure due to B hole collapsing and edges being labeled Exterior.
+         * They are coincident with an A hole edge, but because labeled E are not
+         * included in Intersection result.
+         * This occurred because of a very subtle instance field update sequence bug 
+         * in Edge.mergeEdge.
+         */
+        [Test]
+        public void TestBCollapsedHoleEdgeLabelledExterior()
+        {
+            var a = Read("POLYGON ((309500 3477900, 309900 3477900, 309900 3477600, 309500 3477600, 309500 3477900), (309741.87561330193 3477680.6737848604, 309745.53718649445 3477677.607851833, 309779.0333599192 3477653.585555199, 309796.8051681937 3477642.143583868, 309741.87561330193 3477680.6737848604))");
+            var b = Read("POLYGON ((309500 3477900, 309900 3477900, 309900 3477600, 309500 3477600, 309500 3477900), (309636.40806633036 3477777.2910157656, 309692.56085444096 3477721.966349552, 309745.53718649445 3477677.607851833, 309779.0333599192 3477653.585555199, 309792.0991800499 3477645.1734264474, 309779.03383125085 3477653.5853248164, 309745.53756275156 3477677.6076231804, 309692.5613257677 3477721.966119165, 309636.40806633036 3477777.2910157656))");
+            var expected = Read("POLYGON ((309500 3477600, 309500 3477900, 309900 3477900, 309900 3477600, 309500 3477600), (309741.88 3477680.67, 309745.54 3477677.61, 309779.03 3477653.59, 309792.1 3477645.17, 309796.81 3477642.14, 309741.88 3477680.67))");
+            var actual = Intersection(a, b, 100);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLineUnion()
+        {
+            var a = Read("LINESTRING (0 0, 1 1)");
+            var b = Read("LINESTRING (1 1, 2 2)");
+            var expected = Read("MULTILINESTRING ((0 0, 1 1), (1 1, 2 2))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLine2Union()
+        {
+            var a = Read("LINESTRING (0 0, 1 1, 0 1)");
+            var b = Read("LINESTRING (1 1, 2 2, 3 3)");
+            var expected = Read("MULTILINESTRING ((0 0, 1 1), (0 1, 1 1), (1 1, 2 2, 3 3))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLine3Union()
+        {
+            var a = Read("MULTILINESTRING ((0 1, 1 1), (2 2, 2 0))");
+            var b = Read("LINESTRING (0 0, 1 1, 2 2, 3 3)");
+            var expected = Read("MULTILINESTRING ((0 0, 1 1), (0 1, 1 1), (1 1, 2 2), (2 0, 2 2), (2 2, 3 3))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLine4Union()
+        {
+            var a = Read("LINESTRING (100 300, 200 300, 200 100, 100 100)");
+            var b = Read("LINESTRING (300 300, 200 300, 200 300, 200 100, 300 100)");
+            var expected = Read("MULTILINESTRING ((200 100, 100 100), (300 300, 200 300), (200 300, 200 100), (200 100, 300 100), (100 300, 200 300))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLineFigure8Union()
+        {
+            var a = Read("LINESTRING (5 1, 2 2, 5 3, 2 4, 5 5)");
+            var b = Read("LINESTRING (5 1, 8 2, 5 3, 8 4, 5 5)");
+            var expected = Read("MULTILINESTRING ((5 1, 2 2, 5 3), (5 1, 8 2, 5 3), (5 3, 2 4, 5 5), (5 3, 8 4, 5 5))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLineRingUnion()
+        {
+            var a = Read("LINESTRING (1 1, 5 5, 9 1)");
+            var b = Read("LINESTRING (1 1, 9 1)");
+            var expected = Read("MULTILINESTRING ((1 1, 5 5, 9 1), (1 1, 9 1))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDisjointLinesRoundedIntersection()
+        {
+            var a = Read("LINESTRING (3 2, 3 4)");
+            var b = Read("LINESTRING (1.1 1.6, 3.8 1.9)");
+            var expected = Read("POINT (3 2)");
+            CheckEqual(expected, OverlayNGWithElevModelTest.Intersection(a, b, 1));
+        }
+
+        [Test]
+        public void TestPolygonMultiLineUnion()
+        {
+            var a = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var b = Read("MULTILINESTRING ((150 250, 150 50), (250 250, 250 50))");
+            var expected = Read("GEOMETRYCOLLECTION (LINESTRING (150 50, 150 100), LINESTRING (150 200, 150 250), LINESTRING (250 50, 250 250), POLYGON ((100 100, 100 200, 150 200, 200 200, 200 100, 150 100, 100 100)))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLinePolygonUnion()
+        {
+            var a = Read("LINESTRING (50 150, 150 150)");
+            var b = Read("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))");
+            var expected = Read("GEOMETRYCOLLECTION (LINESTRING (50 150, 100 150), POLYGON ((100 200, 200 200, 200 100, 100 100, 100 150, 100 200)))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLinePolygonUnionAlongPolyBoundary()
+        {
+            var a = Read("LINESTRING (150 300, 250 300)");
+            var b = Read("POLYGON ((100 400, 200 400, 200 300, 100 300, 100 400))");
+            var expected = Read("GEOMETRYCOLLECTION (LINESTRING (200 300, 250 300), POLYGON ((200 300, 150 300, 100 300, 100 400, 200 400, 200 300)))");
+            var actual = Union(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLinePolygonIntersectionAlongPolyBoundary()
+        {
+            var a = Read("LINESTRING (150 300, 250 300)");
+            var b = Read("POLYGON ((100 400, 200 400, 200 300, 100 300, 100 400))");
+            var expected = Read("LINESTRING (200 300, 150 300)");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Tests that overlay can handle polygons with flat topology collapse
+        /// along top, courtesy of improved Orientation.isCCW algorithm.
+        /// </summary>
+        /// <remarks>
+        /// See also <a href="https://trac.osgeo.org/geos/ticket/1038"/>
+        /// </remarks>
+        [Test]
+        public void TestPolygonFlatCollapseIntersection()
+        {
+            var a = Read("POLYGON ((200 100, 150 200, 250 200, 150 200, 100 100, 200 100))");
+            var b = Read("POLYGON ((50 150, 250 150, 250 50, 50 50, 50 150))");
+            var expected = Read("POLYGON ((175 150, 200 100, 100 100, 125 150, 175 150))");
+            var actual = Intersection(a, b, 1);
+            CheckEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestPolygonLineIntersectionOrder()
+        {
+            var a = Read("POLYGON ((1 1, 1 9, 9 9, 9 7, 3 7, 3 3, 9 3, 9 1, 1 1))");
+            var b = Read("MULTILINESTRING ((2 10, 2 0), (4 10, 4 0))");
+            var expected = Read("MULTILINESTRING ((2 9, 2 1), (4 9, 4 7), (4 3, 4 1))");
+            var actual = Intersection(a, b, 1);
+            CheckEqualExact(expected, actual);
+        }
+
+        [Test]
+        public void TestPolygonLineVerticalntersection()
+        {
+            var a = Read("POLYGON ((-200 -200, 200 -200, 200 200, -200 200, -200 -200))");
+            var b = Read("LINESTRING (-100 100, -100 -100)");
+            var expected = Read("LINESTRING (-100 100, -100 -100)");
+            CheckEqual(expected, Intersection(a, b));
+        }
+
+        [Test]
+        public void TestPolygonLineHorizontalIntersection()
+        {
+            var a = Read("POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90))");
+            var b = Read("LINESTRING (20 50, 80 50)");
+            var expected = Read("LINESTRING (20 50, 80 50)");
+            CheckEqual(expected, Intersection(a, b));
+        }
+
+        //============================================================
+
+
+        public static Geometry Difference(Geometry a, Geometry b, double scaleFactor)
+        {
+            var pm = new PrecisionModel(scaleFactor);
+            return NetTopologySuite.Operation.OverlayNG.OverlayNG.Overlay(a, b, SpatialFunction.Difference, pm, _em);
+        }
+
+        public static Geometry SymDifference(Geometry a, Geometry b, double scaleFactor)
+        {
+            var pm = new PrecisionModel(scaleFactor);
+            return NetTopologySuite.Operation.OverlayNG.OverlayNG.Overlay(a, b, SpatialFunction.SymDifference, pm, _em);
+        }
+
+        public static Geometry Intersection(Geometry a, Geometry b, double scaleFactor)
+        {
+            var pm = new PrecisionModel(scaleFactor);
+            return NetTopologySuite.Operation.OverlayNG.OverlayNG.Overlay(a, b, SpatialFunction.Intersection, pm, _em);
+        }
+
+        public static Geometry Union(Geometry a, Geometry b, double scaleFactor)
+        {
+            var pm = new PrecisionModel(scaleFactor);
+            return NetTopologySuite.Operation.OverlayNG.OverlayNG.Overlay(a, b, SpatialFunction.Union, pm, _em);
+        }
+
+        public static Geometry Difference(Geometry a, Geometry b)
+        {
+            var pm = new PrecisionModel();
+            return NetTopologySuite.Operation.OverlayNG.OverlayNG.Overlay(a, b, SpatialFunction.Difference, pm, _em);
+        }
+
+        public static Geometry SymDifference(Geometry a, Geometry b)
+        {
+            var pm = new PrecisionModel();
+            return NetTopologySuite.Operation.OverlayNG.OverlayNG.Overlay(a, b, SpatialFunction.SymDifference, pm, _em);
+        }
+
+        public static Geometry Intersection(Geometry a, Geometry b)
+        {
+            var pm = new PrecisionModel();
+            return NetTopologySuite.Operation.OverlayNG.OverlayNG.Overlay(a, b, SpatialFunction.Intersection, pm, _em);
+        }
+
+        public static Geometry Union(Geometry a, Geometry b)
+        {
+            var pm = new PrecisionModel();
+            return NetTopologySuite.Operation.OverlayNG.OverlayNG.Overlay(a, b, SpatialFunction.Union, pm, _em);
+        }
+
+        public static Geometry IntersectionNoOpt(Geometry a, Geometry b, double scaleFactor)
+        {
+            var pm = new PrecisionModel(scaleFactor);
+            var ov = new NetTopologySuite.Operation.OverlayNG.OverlayNG(a, b, pm, SpatialFunction.Intersection);
+            ov.ElevationModel = _em;
+            ov.Optimized = false;
+            return ov.GetResult();
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
* Add abstract ElevationModel class with `GetZ` and `PopulateZ` methods
* Derive `ConstElevationModel : ElevationModel`
* Make `NetTopologySuite.Operation.OverlayNG.ElevationModel` inherit from `ElevationModel`
* Alter `zGet`, `zGetOrInterpolate`, `zInterpolate`s of `RobustLineIntersector` from `private static` to `protected virtual`
* Derive `RobustLineIntersectorWithElevationModel` from `RobustLineIntersector`, override the above methods to use `ElevationModel.GetZ`
* Add `ElevationModel` to `OverlayNG` class and wire its usage
* Add static `LineIntersectorFactory` class with `LineIntersector CreateFor(ElevationModel)` method and a property for the default `ElevationModel` to use. Wire its usage for OverlayNG

This is a proof of concept for discussion

