### PR TITLE
Fix QuadEdgeSubdivision.TriangleEdgesListVisitor

### DIFF
--- a/src/NetTopologySuite/Triangulate/QuadEdge/QuadEdgeSubdivision.cs
+++ b/src/NetTopologySuite/Triangulate/QuadEdge/QuadEdgeSubdivision.cs
@@ -716,7 +716,7 @@ namespace NetTopologySuite.Triangulate.QuadEdge
 
             public void Visit(QuadEdge[] triEdges)
             {
-                _triList.Add(triEdges);
+                _triList.Add(new[] { triEdges[0], triEdges[1], triEdges[2] });
             }
 
             public IList<QuadEdge[]> GetTriangleEdges()


### PR DESCRIPTION
Fixed a bug that all values in _triList are rewritten with the last record because _triEdges is a reference type

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
_(A description of the changes proposed in the pull-request_)

_Thanks for contributing to NetTopologySuite!_
