### PR TITLE
add .netstandard 2.1

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -28,7 +28,7 @@ jobs:
       shell: bash # defaults disagree on how to quote the filter string
 
     - name: Pack
-      run: dotnet pack -c Release --no-build -o artifacts -p:NoWarn=NU5105
+      run: dotnet pack -c Release --no-build -o artifacts -p:NoWarn=NU5105 NetTopologySuite/NetTopologySuite.csproj
 
     - name: Upload
       uses: actions/upload-artifact@v2

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -28,7 +28,7 @@ jobs:
       shell: bash # defaults disagree on how to quote the filter string
 
     - name: Pack
-      run: dotnet pack -c Release --no-build -o artifacts -p:NoWarn=NU5105 NetTopologySuite/NetTopologySuite.csproj
+      run: dotnet pack -c Release --no-build -o artifacts -p:NoWarn=NU5105 ./src/NetTopologySuite/NetTopologySuite.csproj
 
     - name: Upload
       uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,6 @@ NetTopologySuite.Samples.Shapefiles/tmp*.dbf
 NetTopologySuite.Samples.Shapefiles/test_arcview.shp
 NetTopologySuite.Samples.Shapefiles/test_buffer.shp
 /Sandcastle/Help
+
+# Jetbrains IDE
+.idea/

--- a/src/NetTopologySuite/NetTopologySuite.csproj
+++ b/src/NetTopologySuite/NetTopologySuite.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <NoWarn>659,168,1587</NoWarn>
     <EnableApiCompat>true</EnableApiCompat>
@@ -26,7 +26,7 @@
     <PackageTags>NTS;Topology;OGC;SFS</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description
This adds .Net Standard 2.1 Target so that the System.Memory Dependency can be removed for this target. Because this causes often issues with Xamarin.iOS. (Which supports .Net Standard 2.1)


