### PR TITLE
Fix point's ordinate properties to not throw exceptions

### DIFF
--- a/src/NetTopologySuite/Geometries/Point.cs
+++ b/src/NetTopologySuite/Geometries/Point.cs
@@ -68,7 +68,7 @@ namespace NetTopologySuite.Geometries
             if (coordinates == null)
                 coordinates = factory.CoordinateSequenceFactory.Create(new Coordinate[] { });
             NetTopologySuite.Utilities.Assert.IsTrue(coordinates.Count <= 1);
-            this._coordinates = coordinates;
+            _coordinates = coordinates;
         }
 
         /// <summary>
@@ -113,46 +113,44 @@ namespace NetTopologySuite.Geometries
         public override Dimension BoundaryDimension => Dimension.False;
 
         /// <summary>
-        ///
+        /// Gets a value indicating the x-ordinate of this point
         /// </summary>
+        /// <remarks>
+        /// Deviation from JTS: this implementation <b>does not</b> throw an exception
+        /// when this property is accessed or set
+        /// </remarks>
         public double X
         {
             get
             {
-                if (Coordinate == null)
-                    throw new ArgumentOutOfRangeException("X called on empty Point");
-                return Coordinate.X;
+                return !IsEmpty ? CoordinateSequence.GetX(0) : double.NaN;
             }
             set
             {
-                if (CoordinateSequence.Count == 0)
-                    throw new ArgumentOutOfRangeException("X called on empty Point");
-                CoordinateSequence.SetX(0, value);
+                if (!IsEmpty) CoordinateSequence.SetX(0, value);
             }
         }
 
         /// <summary>
-        ///
+        /// Gets a value indicating the y-ordinate of this point
         /// </summary>
+        /// <remarks>
+        /// Deviation from JTS: this implementation <b>does not</b> throw an exception
+        /// when this property is accessed or set
+        /// </remarks>
         public double Y
         {
             get
             {
-                if (Coordinate == null)
-                    throw new ArgumentOutOfRangeException("Y called on empty Point");
-                return Coordinate.Y;
+                return !IsEmpty ? CoordinateSequence.GetY(0) : double.NaN;
             }
             set
             {
-                if (CoordinateSequence.Count == 0)
-                    throw new ArgumentOutOfRangeException("Y called on empty Point");
-                CoordinateSequence.SetY(0, value);
+                if (!IsEmpty) CoordinateSequence.SetY(0, value);
             }
         }
 
-        /// <summary>
-        ///
-        /// </summary>
+        /// <inheritdoc/>
         public override Coordinate Coordinate => _coordinates.Count != 0 ? _coordinates.GetCoordinate(0) : null;
 
         /// <summary>
@@ -200,10 +198,8 @@ namespace NetTopologySuite.Geometries
             return Factory.CoordinateEqualityComparer.Equals(other.Coordinate, Coordinate, tolerance);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="filter"></param>
+
+        /// <inheritdoc />
         public override void Apply(ICoordinateFilter filter)
         {
             if (IsEmpty)
@@ -211,6 +207,7 @@ namespace NetTopologySuite.Geometries
             filter.Filter(Coordinate);
         }
 
+        /// <inheritdoc />
         public override void Apply(ICoordinateSequenceFilter filter)
         {
             if (IsEmpty)
@@ -241,19 +238,13 @@ namespace NetTopologySuite.Geometries
             }
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="filter"></param>
+        /// <inheritdoc />
         public override void Apply(IGeometryFilter filter)
         {
             filter.Filter(this);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="filter"></param>
+        /// <inheritdoc />
         public override void Apply(IGeometryComponentFilter filter)
         {
             filter.Filter(this);

--- a/src/NetTopologySuite/Geometries/Point.cs
+++ b/src/NetTopologySuite/Geometries/Point.cs
@@ -123,7 +123,7 @@ namespace NetTopologySuite.Geometries
         {
             get
             {
-                return !IsEmpty ? CoordinateSequence.GetX(0) : double.NaN;
+                return !IsEmpty ? CoordinateSequence.GetX(0) : Coordinate.NullOrdinate;
             }
             set
             {
@@ -142,7 +142,7 @@ namespace NetTopologySuite.Geometries
         {
             get
             {
-                return !IsEmpty ? CoordinateSequence.GetY(0) : double.NaN;
+                return !IsEmpty ? CoordinateSequence.GetY(0) : Coordinate.NullOrdinate;
             }
             set
             {

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/MiscellaneousTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/MiscellaneousTest.cs
@@ -158,23 +158,8 @@ namespace NetTopologySuite.Tests.NUnit
             Assert.AreEqual(0, (int) p.Dimension);
             Assert.AreEqual(new Envelope(), p.EnvelopeInternal);
             Assert.IsTrue(p.IsSimple);
-            try
-            {
-                double tmp = p.X;
-                Assert.IsTrue(false);
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-            }
-            try
-            {
-                double tmp = p.Y;
-                Assert.IsTrue(false);
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-            }
-
+            Assert.IsTrue(double.IsNaN(p.X));
+            Assert.IsTrue(double.IsNaN(p.Y));
             Assert.AreEqual("POINT EMPTY", p.ToString());
             Assert.AreEqual("POINT EMPTY", p.AsText());
         }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/PointImplTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/PointImplTest.cs
@@ -89,5 +89,20 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             var p2 = (Point)_reader.Read("POINT EMPTY");
             Assert.IsTrue(p2.IsSimple);
         }
+
+        [Test]
+        public void TestEmptyPointOrdinatePropertyDoesNotThrow()
+        {
+            var pt = NtsGeometryServices.Instance.CreateGeometryFactory().CreatePoint();
+            double? x = null;
+            Assert.That(() => x = pt.X, Throws.Nothing);
+            Assert.That(x.HasValue, Is.True);
+            Assert.That(x.Value, Is.EqualTo(double.NaN));
+
+            double? y = null;
+            Assert.That(() => y = pt.Y, Throws.Nothing);
+            Assert.That(x.HasValue, Is.True);
+            Assert.That(x.Value, Is.EqualTo(double.NaN));
+        }
     }
 }


### PR DESCRIPTION
`Point`'s X and Y properties throw `ArgumentOutOfRangeException` when accessing or setting on an empty point.
This is undesireable hence the semantics are changed to:
* return double.NaN on the getter
* do nothing on the setter