### PR TITLE
Fix LinearRing Type on Polygon Class

### DIFF
--- a/src/NetTopologySuite/Geometries/Polygon.cs
+++ b/src/NetTopologySuite/Geometries/Polygon.cs
@@ -251,7 +251,7 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         ///
         /// </summary>
-        public LineString ExteriorRing => _shell;
+        public LinearRing ExteriorRing => _shell;
 
         /// <summary>
         ///
@@ -261,14 +261,14 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         ///
         /// </summary>
-        public LineString[] InteriorRings => _holes.ToArray<LineString>();
+        public LinearRing[] InteriorRings => _holes.ToArray<LinearRing>();
 
         /// <summary>
         ///
         /// </summary>
         /// <param name="n"></param>
         /// <returns></returns>
-        public LineString GetInteriorRingN(int n)
+        public LinearRing GetInteriorRingN(int n)
         {
             return _holes[n];
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description

It was LinearRing Type not  LineString Type in  [Polygon Class of JTS](https://github.com/locationtech/jts/blob/master/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java)


