### PR TITLE
Make Coordinate Tuple friendly (Conversions and Deconstructions)

### DIFF
--- a/src/NetTopologySuite/Geometries/Coordinate.cs
+++ b/src/NetTopologySuite/Geometries/Coordinate.cs
@@ -204,6 +204,25 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
+        /// Implicitly cast a tuple to a new <see cref="Coordinate"/> as a copy of this instance.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator Coordinate((double x, double y) value)
+            => new Coordinate(value.x, value.y);
+        
+        /// <summary>
+        /// Deconstructs this <see cref="Coordinate"/> into its components.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        public void Deconstruct(out double x, out double y)
+        {
+            x = X;
+            y = Y;
+        }
+
+        /// <summary>
         /// Gets/Sets <c>Coordinate</c>s (x,y,z) values.
         /// </summary>
         public virtual Coordinate CoordinateValue

--- a/src/NetTopologySuite/Geometries/CoordinateM.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateM.cs
@@ -112,6 +112,35 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
+        /// Implicit conversion of a <c>(double x, double y, double m)</c> value to a <c>CoordinateM</c>.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator CoordinateM((double x, double y) value)
+            => new CoordinateM(value.x, value.y);
+        
+        /// <summary>
+        /// Implicit conversion of a <c>(double x, double y, double z, double m)</c> value to a <c>CoordinateM</c>.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator CoordinateM((double x, double y, double z) value)
+            => new CoordinateM(value.x, value.y, value.z);
+
+        /// <summary>
+        /// Deconstructs this <c>CoordinateM</c> into its x, y and m values.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="m"></param>
+        public void Deconstruct(out double x, out double y, out double m)
+        {
+            x = X;
+            y = Y;
+            m = M;
+        }
+
+        /// <summary>
         /// Gets/Sets <c>CoordinateM</c>s (x,y,z) values.
         /// </summary>
         public override Coordinate CoordinateValue

--- a/src/NetTopologySuite/Geometries/CoordinateM.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateM.cs
@@ -112,7 +112,7 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
-        /// Implicit conversion of a <c>(double x, double y, double m)</c> value to a <c>CoordinateM</c>.
+        /// Implicit conversion of a <c>(double x, double y)</c> value to a <c>CoordinateM</c>.
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -120,12 +120,12 @@ namespace NetTopologySuite.Geometries
             => new CoordinateM(value.x, value.y);
         
         /// <summary>
-        /// Implicit conversion of a <c>(double x, double y, double z, double m)</c> value to a <c>CoordinateM</c>.
+        /// Implicit conversion of a <c>(double x, double y, double m)</c> value to a <c>CoordinateM</c>.
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static implicit operator CoordinateM((double x, double y, double z) value)
-            => new CoordinateM(value.x, value.y, value.z);
+        public static implicit operator CoordinateM((double x, double y, double m) value)
+            => new CoordinateM(value.x, value.y, value.m);
 
         /// <summary>
         /// Deconstructs this <c>CoordinateM</c> into its x, y and m values.

--- a/src/NetTopologySuite/Geometries/CoordinateZ.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateZ.cs
@@ -112,7 +112,7 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
-        /// Implicit conversion of a <c>Tuple</c> to a <c>Coordinate</c>.
+        /// Implicit conversion of a <c>Tuple</c> to a <c>CoordinateZ</c>.
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -120,7 +120,7 @@ namespace NetTopologySuite.Geometries
             => new CoordinateZ(value.x, value.y);
 
         /// <summary>
-        /// Implicit conversion of a <c>Tuple</c> to a <c>Coordinate</c>.
+        /// Implicit conversion of a <c>Tuple</c> to a <c>CoordinateZ</c>.
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>

--- a/src/NetTopologySuite/Geometries/CoordinateZ.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateZ.cs
@@ -112,6 +112,35 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
+        /// Implicit conversion of a <c>Tuple</c> to a <c>Coordinate</c>.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator CoordinateZ((double x, double y) value)
+            => new CoordinateZ(value.x, value.y);
+
+        /// <summary>
+        /// Implicit conversion of a <c>Tuple</c> to a <c>Coordinate</c>.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator CoordinateZ((double x, double y, double z) value)
+            => new CoordinateZ(value.x, value.y, value.z);
+        
+        /// <summary>
+        /// Deconstructs this <c>CoordinateZ</c> into its x, y and z values.
+        /// </summary>
+        /// <param name="x">The x-ordinate value</param>
+        /// <param name="y">The y-ordinate value</param>
+        /// <param name="z">The z-ordinate value</param>
+        public void Deconstruct(out double x, out double y, out double z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+        }
+
+        /// <summary>
         /// Gets/Sets <c>CoordinateZ</c>s (x,y,z) values.
         /// </summary>
         public override Coordinate CoordinateValue

--- a/src/NetTopologySuite/Geometries/CoordinateZM.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateZM.cs
@@ -119,6 +119,37 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
+        /// Implicit conversion of a <c>Tuple</c> to a <c>CoordinateZM</c>.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator CoordinateZM((double x, double y) value)
+            => new CoordinateZM(value.x, value.y);
+
+        /// <summary>
+        /// Implicit conversion of a <c>Tuple</c> to a <c>CoordinateZM</c>.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator CoordinateZM((double x, double y, double z, double m) value)
+            => new CoordinateZM(value.x, value.y, value.z, value.m);
+
+        /// <summary>
+        /// Deconstructs this <c>CoordinateZM</c> into its x, y, z and values.
+        /// </summary>
+        /// <param name="x">The x-ordinate value</param>
+        /// <param name="y">The y-ordinate value</param>
+        /// <param name="z">The z-ordinate value</param>
+        /// <param name="m"></param>
+        public void Deconstruct(out double x, out double y, out double z, out double m)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            m = M;
+        }
+
+        /// <summary>
         /// Gets/Sets <c>CoordinateZM</c>s (x,y,z) values.
         /// </summary>
         public override Coordinate CoordinateValue

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateTest.cs
@@ -313,6 +313,18 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             Assert.That(testM.X, Is.EqualTo(1d));
             Assert.That(testM.Y, Is.EqualTo(2d));
             Assert.That(testM.M, Is.EqualTo(3d));
+
+            CoordinateZM testZM = (1, 2);
+            Assert.That(testZM.X, Is.EqualTo(1d));
+            Assert.That(testZM.Y, Is.EqualTo(2d));
+            Assert.That(testZM.Z, Is.EqualTo(Coordinate.NullOrdinate));
+            Assert.That(testZM.M, Is.EqualTo(Coordinate.NullOrdinate));
+
+            testZM = (1, 2, 3, 4);
+            Assert.That(testZM.X, Is.EqualTo(1d));
+            Assert.That(testZM.Y, Is.EqualTo(2d));
+            Assert.That(testZM.Z, Is.EqualTo(3d));
+            Assert.That(testZM.M, Is.EqualTo(4d));
         }
 
         [Test]
@@ -350,6 +362,22 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             Assert.That(x, Is.EqualTo(1d));
             Assert.That(y, Is.EqualTo(2d));
             Assert.That(m, Is.EqualTo(3d));
+
+            CoordinateZM testZM = (1, 2);
+            (x, y, z, m) = testZM;
+
+            Assert.That(x, Is.EqualTo(1d));
+            Assert.That(y, Is.EqualTo(2d));
+            Assert.That(z, Is.EqualTo(Coordinate.NullOrdinate));
+            Assert.That(m, Is.EqualTo(Coordinate.NullOrdinate));
+
+            testZM = (1, 2, 3, 4);
+            (x, y, z, m) = testZM;
+
+            Assert.That(x, Is.EqualTo(1d));
+            Assert.That(y, Is.EqualTo(2d));
+            Assert.That(z, Is.EqualTo(3d));
+            Assert.That(m, Is.EqualTo(4d));
         }
 
         [Test]

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/CoordinateTest.cs
@@ -288,6 +288,71 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         }
 
         [Test]
+        public void TestCastFromTuple()
+        {
+            Coordinate test = (1, 2);
+            Assert.That(test.X, Is.EqualTo(1d));
+            Assert.That(test.Y, Is.EqualTo(2d));
+
+            CoordinateZ testZ = (1, 2);
+            Assert.That(testZ.X, Is.EqualTo(1d));
+            Assert.That(testZ.Y, Is.EqualTo(2d));
+            Assert.That(testZ.Z, Is.EqualTo(Coordinate.NullOrdinate));
+
+            testZ = (1, 2, 3);
+            Assert.That(testZ.X, Is.EqualTo(1d));
+            Assert.That(testZ.Y, Is.EqualTo(2d));
+            Assert.That(testZ.Z, Is.EqualTo(3d));
+
+            CoordinateM testM = (1, 2);
+            Assert.That(testM.X, Is.EqualTo(1d));
+            Assert.That(testM.Y, Is.EqualTo(2d));
+            Assert.That(testM.M, Is.EqualTo(Coordinate.NullOrdinate));
+
+            testM = (1, 2, 3);
+            Assert.That(testM.X, Is.EqualTo(1d));
+            Assert.That(testM.Y, Is.EqualTo(2d));
+            Assert.That(testM.M, Is.EqualTo(3d));
+        }
+
+        [Test]
+        public void TestDeconstruct()
+        {
+            Coordinate test = (1, 2);
+            var (x, y) = test;
+            Assert.That(x, Is.EqualTo(1d));
+            Assert.That(y, Is.EqualTo(2d));
+
+            CoordinateZ testZ = (1, 2);
+            (x, y, double z) = testZ;
+
+            Assert.That(x, Is.EqualTo(1d));
+            Assert.That(y, Is.EqualTo(2d));
+            Assert.That(z, Is.EqualTo(Coordinate.NullOrdinate));
+
+            testZ = (1, 2, 3);
+            (x, y, z) = testZ;
+
+            Assert.That(x, Is.EqualTo(1d));
+            Assert.That(y, Is.EqualTo(2d));
+            Assert.That(z, Is.EqualTo(3d));
+
+            CoordinateM testM = (1, 2);
+            (x, y, double m) = testM;
+
+            Assert.That(x, Is.EqualTo(1d));
+            Assert.That(y, Is.EqualTo(2d));
+            Assert.That(m, Is.EqualTo(Coordinate.NullOrdinate));
+
+            testM = (1, 2, 3);
+            (x, y, m) = testM;
+
+            Assert.That(x, Is.EqualTo(1d));
+            Assert.That(y, Is.EqualTo(2d));
+            Assert.That(m, Is.EqualTo(3d));
+        }
+
+        [Test]
         public void TestCoordinateHash()
         {
             DoTestCoordinateHash(true, new Coordinate(1, 2), new Coordinate(1, 2));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description
Leveraging the latest features in C#, we can define `Coordinate` variables in a more streamlined manner. I recommend the incorporation of **implicit conversion operators** and **deconstructors** to enhance usability and readability.

With a well-defined **implicit conversion operator**, we can instantiate `Coordinate` objects as follows:

```csharp
Coordinate p1 = (1, 2);
CoordinateZ p2 = (1, 2, 3);
```

Similarly, by implementing an effective **Deconstructor**, we can extract values from our `Coordinate` objects like so:

```csharp
var (x, y) = p1;
// or
var (x, _) = p1;
// or
var (x, y, z) = p1;
// or
var (x, y, _) = p1;
```
This approach not only simplifies the code but also enhances its readability and maintainability.
