### PR TITLE
Make Geometry Tuple and Pattern Matching Friendly

### DIFF
--- a/src/NetTopologySuite/Geometries/LineString.cs
+++ b/src/NetTopologySuite/Geometries/LineString.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NetTopologySuite.Operation;
 using NetTopologySuite.Utilities;
 
@@ -70,6 +71,23 @@ namespace NetTopologySuite.Geometries
             if (points.Count == 1)
                 throw new ArgumentException($"Invalid number of points in LineString (found {points.Count} - must be 0 or >= {MinimumValidSize})");
             _points = points;
+        }
+
+        /// <summary>
+        /// Implicitly cast a tuple to a new <see cref="LineString"/> as a copy of this instance.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator LineString((double x, double y)[] value)
+            => new LineString(value.Select(v=>new Coordinate(v.x, v.y)).ToArray());
+
+        /// <summary>
+        /// Deconstructs this <see cref="LineString"/> into its components.
+        /// </summary>
+        /// <param name="values"></param>
+        public void Deconstruct(out (double x, double y)[] values)
+        {
+            values = _points.ToCoordinateArray().Select(c => (c.X, c.Y)).ToArray();
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/LinearRing.cs
+++ b/src/NetTopologySuite/Geometries/LinearRing.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using NetTopologySuite.Algorithm;
 
 namespace NetTopologySuite.Geometries
@@ -138,5 +139,13 @@ namespace NetTopologySuite.Geometries
             this(DefaultFactory.CoordinateSequenceFactory.Create(points), DefaultFactory) { }
 
         /* END ADDED BY MPAUL42: monoGIS team */
+
+        /// <summary>
+        /// Implicitly cast a tuple to a new <see cref="LinearRing"/> as a copy of this instance.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator LinearRing((double x, double y)[] value)
+            => new LinearRing(value.Select(v => new Coordinate(v.x, v.y)).ToArray());
     }
 }

--- a/src/NetTopologySuite/Geometries/Point.cs
+++ b/src/NetTopologySuite/Geometries/Point.cs
@@ -328,6 +328,46 @@ namespace NetTopologySuite.Geometries
             : this(DefaultFactory.CoordinateSequenceFactory.Create(new Coordinate[] { new Coordinate(x, y) }), DefaultFactory) { }
 
         /// <summary>
+        /// Implicitly cast a tuple to a new <see cref="Point"/> as a copy of this instance.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator Point((double x, double y) value)
+            => new Point(value.x, value.y);
+
+        /// <summary>
+        /// Implicitly cast a tuple to a new <see cref="Point"/> as a copy of this instance.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static implicit operator Point((double x, double y, double z) value)
+            => new Point(value.x, value.y, value.z);
+
+        /// <summary>
+        /// Deconstructs this <see cref="Point"/> into its components.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        public void Deconstruct(out double x, out double y)
+        {
+            x = X;
+            y = Y;
+        }
+
+        /// <summary>
+        /// Deconstructs this <see cref="Point"/> into its components.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
+        public void Deconstruct(out double x, out double y, out double z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+        }
+
+        /// <summary>
         ///
         /// </summary>
         public double Z

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/LineStringImplTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/LineStringImplTest.cs
@@ -194,5 +194,27 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             var ringFromWKT = Read("LINEARRING (0 0, 10 10, 0 0)");
             CheckEqual(ring, ringFromWKT);
         }
+
+        [Test]
+        public void TestLineStringTupleConversions()
+        {
+            LineString line = new[] {(1d, 2d), (3d, 4d)};
+
+            Assert.AreEqual(1, line[0].X);
+            Assert.AreEqual(2, line[0].Y);
+            Assert.AreEqual(3, line[1].X);
+            Assert.AreEqual(4, line[1].Y);
+        }
+
+        [Test]
+        public void TestLinearRingTupleConversions()
+        {
+            LinearRing linearRing = new[] { (1d, 2d), (3d, 4d), (1, 2) };
+
+            Assert.AreEqual(1, linearRing[0].X);
+            Assert.AreEqual(2, linearRing[0].Y);
+            Assert.AreEqual(3, linearRing[1].X);
+            Assert.AreEqual(4, linearRing[1].Y);
+        }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/PointImplTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/PointImplTest.cs
@@ -137,14 +137,39 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         public void TestPointPatternMatching()
         {
             Point p1 = (1, 2);
-            Assert.That(p1 is (1,_), Is.True);
+            Assert.That(p1 is (1, 2), Is.True);
             Assert.That(p1 is (_, 2), Is.True);
 
             Point p2 = (1, 2, 3);
+
+            Assert.That(p2 is (1, 2, 3), Is.True);
+            Assert.That(p2 is (1, 2, _), Is.True);
             Assert.That(p2 is (1, _, 3), Is.True);
             Assert.That(p2 is (_, 2, 3), Is.True);
-            Assert.That(p2 is (1, 2, _), Is.True);
+            Assert.That(p2 is (1, _, _), Is.True);
+            Assert.That(p2 is (_, 2, _), Is.True);
+            Assert.That(p2 is (_, _, 3), Is.True);
 
+            // More complex pattern matching
+            Assert.That(p2 is (1, > 1, >= 3), Is.True);
+            Assert.That(p2 is (_, >= 2, _), Is.True);
+        }
+
+        [Test]
+        public void TestPointSwitchPatternMatching()
+        {
+            Point p = (1, 2, 3);
+
+            Assert.That(p is (_, > 1, _), Is.True);
+
+            bool isValid = p switch
+            {
+                (1, >1, >=3) => true,
+                (_, >=2, _) => true,
+                _ => false
+            };
+
+            Assert.That(isValid, Is.True);
         }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/PointImplTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/PointImplTest.cs
@@ -104,5 +104,47 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             Assert.That(x.HasValue, Is.True);
             Assert.That(x.Value, Is.EqualTo(double.NaN));
         }
+
+        [Test]
+        public void TestTupleConversions()
+        {
+            Point p1 = (1, 2);
+            Assert.That(p1.X, Is.EqualTo(1));
+            Assert.That(p1.Y, Is.EqualTo(2));
+
+            Point p2 = (1, 2, 3);
+            Assert.That(p2.X, Is.EqualTo(1));
+            Assert.That(p2.Y, Is.EqualTo(2));
+            Assert.That(p2.Z, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void TestPointDeconstruct()
+        {
+            Point p1 = (1, 2);
+            var (x1, y1) = p1;
+            Assert.That(x1, Is.EqualTo(1));
+            Assert.That(y1, Is.EqualTo(2));
+
+            Point p2 = (1, 2, 3);
+            var (x2, y2, z2) = p2;
+            Assert.That(x2, Is.EqualTo(1));
+            Assert.That(y2, Is.EqualTo(2));
+            Assert.That(z2, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void TestPointPatternMatching()
+        {
+            Point p1 = (1, 2);
+            Assert.That(p1 is (1,_), Is.True);
+            Assert.That(p1 is (_, 2), Is.True);
+
+            Point p2 = (1, 2, 3);
+            Assert.That(p2 is (1, _, 3), Is.True);
+            Assert.That(p2 is (_, 2, 3), Is.True);
+            Assert.That(p2 is (1, 2, _), Is.True);
+
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description
Leveraging the latest features in C#, we can define `Point`, `LineString`, and `LinearRing`,  variables in a more streamlined manner. I recommend the incorporation of implicit conversion operators and deconstructors to enhance usability and readability.

I've already added these features to the `Coordinate` family classes, and it's been merged by this PR: https://github.com/NetTopologySuite/NetTopologySuite/pull/733

With a well-defined implicit conversion operator, we can instantiate geometry objects as follows:

```csharp
Point p1 = (1, 2);
Point p2 = (1, 2, 3);
LineString line = new[] {(1d, 2d), (3d, 4d)};
LinearRing ring = new[] { (1d, 2d), (3d, 4d), (1, 2) };
```

Similarly, by implementing an effective Deconstructor, we can extract values from our geometry objects like so:
```csharp
var (x, y) = p1;
// or
var (x, _) = p1;
// or
var (x, y, z) = p1;
// or
var (x, y, _) = p1;
```
This approach not only simplifies the code but also enhances its readability and maintainability.

#### Pattern Matching
The interesting part is the pattern-matching capabilities that would be enabled:

```csharp
if ( p is (1, 2, 3) ) { }
if ( p is (1, 2, _) ) { }
if ( p is (1, > 1, >= 3) ) { }
if ( p is (_, >= 2, _) ) { }

// and pattern-matching in switch expressions:

bool isValid = p switch
{
    (1, >1, >=3) => true,
    (_, >=2, _) => true,
    _ => false
};
```