### PR TITLE
Fix the errors in the solution. (Use "var" errors)

### DIFF
--- a/src/NetTopologySuite.Lab/Operation/OverlayArea/SimpleOverlayArea.cs
+++ b/src/NetTopologySuite.Lab/Operation/OverlayArea/SimpleOverlayArea.cs
@@ -141,9 +141,9 @@ namespace NetTopologySuite.Operation.OverlayArea
              */
             for (int i = 0; i < ring.Count - 1; i++)
             {
-                Coordinate vPrev = i == 0 ? ring.GetCoordinate(ring.Count - 2) : ring.GetCoordinate(i - 1);
-                Coordinate v = ring.GetCoordinate(i);
-                Coordinate vNext = ring.GetCoordinate(i + 1);
+                var vPrev = i == 0 ? ring.GetCoordinate(ring.Count - 2) : ring.GetCoordinate(i - 1);
+                var v = ring.GetCoordinate(i);
+                var vNext = ring.GetCoordinate(i + 1);
                 var loc = RayCrossingCounter.LocatePointInRing(v, ring2);
                 if (loc == Location.Interior)
                 {

--- a/src/NetTopologySuite/Geometries/Utilities/EnvelopeCombiner.cs
+++ b/src/NetTopologySuite/Geometries/Utilities/EnvelopeCombiner.cs
@@ -132,7 +132,7 @@ namespace NetTopologySuite.Geometries.Utilities
         /// </returns>
         public Geometry CombineAsGeometry()
         {
-            Envelope env = Combine();
+            var env = Combine();
             GeometryFactory factory = null;
             foreach (var geom in _geoms)
             {


### PR DESCRIPTION
### Prerequisites
When I open the solution it shows 10 errors:
![image](https://github.com/NetTopologySuite/NetTopologySuite/assets/3104253/9f6bbcc3-31b5-4a14-bc8e-6b655a7fa0ef)

This PR is fixing them. They are just simple changes to use the var keyword. All other "var" style seems to be OK in the solutions.

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
_(A description of the changes proposed in the pull-request_)

_Thanks for contributing to NetTopologySuite!_
