### PR TITLE
No boxing in AbstractSTRtree loop

### DIFF
--- a/src/NetTopologySuite/Index/Strtree/AbstractSTRtree.cs
+++ b/src/NetTopologySuite/Index/Strtree/AbstractSTRtree.cs
@@ -314,8 +314,10 @@ namespace NetTopologySuite.Index.Strtree
 
         private void QueryInternal(T searchBounds, AbstractNode<T, TItem> node, IList<TItem> matches)
         {
-            foreach (var childBoundable in node.ChildBoundables)
+            var childBoundables = node.ChildBoundables;
+            for (int i = 0; i < childBoundables.Count; i++)
             {
+                var childBoundable = childBoundables[i];
                 if (!IntersectsOp.Intersects(childBoundable.Bounds, searchBounds))
                     continue;
 


### PR DESCRIPTION
### Prerequisites
In my project there are a lot of unncessary boxing in the `AbstractSTRtree.QueryInternal` method.
![image](https://github.com/NetTopologySuite/NetTopologySuite/assets/3104253/f8a0c901-c2c1-46fd-bf69-17ceae44ca6f)

It is because the `node.ChildBoundables` returns `IList<IBoundable<T, TItem>>`, so the GetEnumerator returns `IEnumerator<IBoundable<T, TItem>`. But in the behind it is `List<IBoundable<T, TItem>>`, so the actual type of the iterator is `List<IBoundable<T, TItem>>` which is a value type, so it is boxed in the foreach loop.
Foreach converted to for loop.

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [ ] I have provided test coverage for my change (where applicable)

### Description
_(A description of the changes proposed in the pull-request_)

_Thanks for contributing to NetTopologySuite!_
