### PR TITLE
Elevation model for RobustLineIntersector

### DIFF
--- a/src/NetTopologySuite/Algorithm/ElevationModel.cs
+++ b/src/NetTopologySuite/Algorithm/ElevationModel.cs
@@ -8,7 +8,7 @@ namespace NetTopologySuite.Algorithm
     /// </summary>
     public class ElevationModel
     {
-        private static ElevationModel _default = new ElevationModel();
+        private static readonly ElevationModel _noZ = new ElevationModel();
 
         private readonly double _z;
         private readonly Envelope _extent;
@@ -43,15 +43,9 @@ namespace NetTopologySuite.Algorithm
         /// Gets or sets a value indicating the default <see cref="ElevationModel"/>
         /// </summary>
         /// <remarks>The value <c>null</c> cannot be assigned to this property, it will be converted to a no-op elevation model.</remarks>
-        public static ElevationModel Default
+        public static ElevationModel NoZ
         {
-            get => _default;
-            set
-            {
-                if (value == null)
-                    value = new ElevationModel();
-                _default = value;
-            }
+            get => _noZ;
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Algorithm/ElevationModel.cs
+++ b/src/NetTopologySuite/Algorithm/ElevationModel.cs
@@ -1,0 +1,132 @@
+﻿using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Algorithm
+{
+    /// <summary>
+    /// A base elevation model class.
+    /// </summary>
+    public class ElevationModel
+    {
+        private static ElevationModel _default = new ElevationModel();
+
+        private readonly double _z;
+        private readonly Envelope _extent;
+        private readonly int _srid;
+
+        /// <summary>
+        /// Creates an elevation model that always returns <see cref="Coordinate.NullOrdinate"/> as result.
+        /// </summary>
+        public ElevationModel() : this(Coordinate.NullOrdinate)
+        { }
+
+        /// <summary>
+        /// Creates an elevation model that always returns <paramref name="z"/> as result.
+        /// </summary>
+        /// <param name="z">The result value for <see cref="GetZ(Coordinate)"/> or its overloads.</param>
+        internal ElevationModel(double z)
+        {
+            _z = z;
+        }
+
+        /// <summary>
+        /// Creates an elevation model that always returns <paramref name="z"/> as result.
+        /// </summary>
+        /// <param name="z">The result value for <see cref="GetZ(Coordinate)"/> or its overloads.</param>
+        /// <param name="extent">The extent where this elevation model is valid</param>
+        /// <param name="srid">The spatial reference id</param>
+        public ElevationModel(double z, Envelope extent, int srid)
+        {
+            _z = z;
+            _extent = extent;
+            _srid = srid;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating the default <see cref="ElevationModel"/>
+        /// </summary>
+        /// <remarks>The value <c>null</c> cannot be assigned to this property, it will be converted to a no-op elevation model.</remarks>
+        public static ElevationModel Default
+        {
+            get => _default;
+            set
+            {
+                if (value == null)
+                    value = new ElevationModel();
+                _default = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating the extent where this elevation model is valid.
+        /// </summary>
+        /// <remarks>
+        /// If this value is <c>null</c>, no check for the validity of the
+        /// input arguments for <see cref="GetZ(Coordinate)"/> and its overload is made.
+        /// </remarks>
+        public Envelope Extent { get => _extent; }
+
+        /// <summary>
+        /// Gets a value indicating the spatial reference system this elevation model belongs to.
+        /// </summary>
+        public int SRID { get => _srid; }
+
+        /// <summary>
+        /// Gets the z-ordinate value for a given <paramref name="coordinate"/>.
+        /// </summary>
+        /// <param name="coordinate">A coordinate to get the z-ordinate value.</param>
+        /// <returns>The z-ordinate value</returns>
+        public virtual double GetZ(Coordinate coordinate)
+        {
+            if (_extent != null && !_extent.Contains(coordinate))
+                return Coordinate.NullOrdinate;
+
+            return _z;
+        }
+
+        /// <summary>
+        /// Gets the z-ordinate value for a given pair of <paramref name="x"/> and <paramref name="y"/> ordinates.
+        /// </summary>
+        /// <param name="x">A x-ordinate value.</param>
+        /// <param name="y">A y-ordinate value.</param>
+        /// <returns>The z-ordinate value</returns>
+        public double GetZ(double x, double y) => GetZ(new Coordinate(x, y));
+
+
+        /// <summary>
+        /// Creates a copy of <paramref name="c"/> that has the z-ordinate value at <paramref name="c"/>.
+        /// If the elevation model can't retrieve a 
+        /// </summary>
+        /// <param name="c">A coordinate</param>
+        /// <returns>A copy of <paramref name="c"/> with the z-ordinate value.</returns>
+        public Coordinate CopyWithZ(Coordinate c)
+        {
+            // If it already has a z-ordinate value, return a copy
+            if (!double.IsNaN(c.Z)) return c.Copy();
+
+            // Get the z-ordinate value for c. If no z-ordinate value was supplied, return a copy of c
+            double z = GetZ(c);
+            if (double.IsNaN(z)) return c.Copy();
+
+            // Depending on the type return specific coordinate classes.
+            if (c.GetType() == typeof(CoordinateM))
+                return new CoordinateZM(c.X, c.Y, z, c.M);
+
+            if (c is ExtraDimensionalCoordinate edc)
+            {
+                ExtraDimensionalCoordinate edcRes = null;
+                if (edc.Dimension - edc.Measures > 2)
+                    edcRes = (ExtraDimensionalCoordinate)edc.Copy();
+                else 
+                    edcRes = new ExtraDimensionalCoordinate(edc.Dimension + 1, edc.Measures) {
+                        CoordinateValue = edc
+                    };
+                edcRes.Z = z;
+                return edcRes;
+            }
+
+            // Last resort
+            return new CoordinateZ(c.X, c.Y, z);
+        }
+    }
+
+}

--- a/src/NetTopologySuite/Algorithm/ElevationModel.cs
+++ b/src/NetTopologySuite/Algorithm/ElevationModel.cs
@@ -107,25 +107,14 @@ namespace NetTopologySuite.Algorithm
             double z = GetZ(c);
             if (double.IsNaN(z)) return c.Copy();
 
-            // Depending on the type return specific coordinate classes.
-            if (c.GetType() == typeof(CoordinateM))
-                return new CoordinateZM(c.X, c.Y, z, c.M);
-
-            if (c is ExtraDimensionalCoordinate edc)
-            {
-                ExtraDimensionalCoordinate edcRes = null;
-                if (edc.Dimension - edc.Measures > 2)
-                    edcRes = (ExtraDimensionalCoordinate)edc.Copy();
-                else 
-                    edcRes = new ExtraDimensionalCoordinate(edc.Dimension + 1, edc.Measures) {
-                        CoordinateValue = edc
-                    };
-                edcRes.Z = z;
-                return edcRes;
-            }
-
-            // Last resort
-            return new CoordinateZ(c.X, c.Y, z);
+            int dim = Coordinates.Dimension(c);
+            int measures = Coordinates.Measures(c);
+            int spatial = Math.Max(3, dim - measures);
+            dim = spatial + measures;
+            var copy = Coordinates.Create(dim, measures);
+            copy.CoordinateValue = c;
+            copy.Z = z;
+            return copy;
         }
     }
 

--- a/src/NetTopologySuite/Algorithm/ElevationModels.cs
+++ b/src/NetTopologySuite/Algorithm/ElevationModels.cs
@@ -110,27 +110,25 @@ namespace NetTopologySuite.Algorithm
                 if (!seq.HasZ)
                     return;
 
-                // Get buffers for ordinate values
-                double[] xy = ArrayPool<double>.Shared.Rent(2 * seq.Count);
-                var xys = new Span<double>(xy, 0, 2 * seq.Count);
-                double[] z = ArrayPool<double>.Shared.Rent(seq.Count);
-                var zs = new Span<double>(z, 0, seq.Count);
-
-                // Perform conversion to arrays
-                _seqToXYAndZ(seq, xys, zs);
-
-                // Get z-ordinate values
-                _elevationModel.GetZ(xys, zs);
-
-                // Return first buffer
-                ArrayPool<double>.Shared.Return(xy);
-
-                // Assign z-ordinate values
-                for (int i = 0; i < seq.Count; i++)
-                    seq.SetZ(i, zs[i]);
-
-                // Return 2nd buffer
-                ArrayPool<double>.Shared.Return(z);
+                // Get buffer for ordinate values
+                double[] xyz = ArrayPool<double>.Shared.Rent(3 * seq.Count);
+                try
+                {
+                    var xys = new Span<double>(xyz, 0, 2 * seq.Count);
+                    var zs = new Span<double>(xyz, 2 * seq.Count, seq.Count);
+                    // Perform conversion to arrays
+                    _seqToXYAndZ(seq, xys, zs);
+                    // Get z-ordinate values
+                    _elevationModel.GetZ(xys, zs);
+                    // Assign z-ordinate values
+                    for (int i = 0; i < zs.Length; i++)
+                        seq.SetZ(i, zs[i]);
+                }
+                finally
+                {
+                    // Return buffer
+                    ArrayPool<double>.Shared.Return(xyz);
+                }
             }
         }
 

--- a/src/NetTopologySuite/Algorithm/ElevationModels.cs
+++ b/src/NetTopologySuite/Algorithm/ElevationModels.cs
@@ -28,7 +28,7 @@ namespace NetTopologySuite.Algorithm
 
             int dim = Coordinates.Dimension(c);
             int measures = Coordinates.Measures(c);
-            int spatial = System.Math.Max(3, dim - measures);
+            int spatial = Math.Max(3, dim - measures);
             dim = spatial + measures;
             var copy = Coordinates.Create(dim, measures);
             copy.CoordinateValue = c;

--- a/src/NetTopologySuite/Algorithm/ElevationModels.cs
+++ b/src/NetTopologySuite/Algorithm/ElevationModels.cs
@@ -1,0 +1,160 @@
+﻿using NetTopologySuite.Geometries;
+using System;
+using System.Buffers;
+
+namespace NetTopologySuite.Algorithm
+{
+    /// <summary>
+    /// Extension methods to work with <see cref="ElevationModel"/>s.
+    /// </summary>
+    public static class ElevationModels
+    {
+        /// <summary>
+        /// Creates a copy of <paramref name="c"/> that has the z-ordinate value at <paramref name="c"/>.
+        /// If the elevation model can't retrieve a z-ordinate value, a copy of <paramref name="c"/> is
+        /// returned.
+        /// </summary>
+        /// <param name="self">The elevation model to use</param>
+        /// <param name="c">A coordinate</param>
+        /// <returns>A copy of <paramref name="c"/> with the z-ordinate value.</returns>
+        public static Coordinate CopyWithZ(this ElevationModel self, Coordinate c)
+        {
+            // If it already has a z-ordinate value, return a copy
+            if (!double.IsNaN(c.Z)) return c.Copy();
+
+            // Get the z-ordinate value for c. If no z-ordinate value was supplied, return a copy of c
+            double z = self.GetZ(c);
+            if (double.IsNaN(z)) return c.Copy();
+
+            int dim = Coordinates.Dimension(c);
+            int measures = Coordinates.Measures(c);
+            int spatial = System.Math.Max(3, dim - measures);
+            dim = spatial + measures;
+            var copy = Coordinates.Create(dim, measures);
+            copy.CoordinateValue = c;
+            copy.Z = z;
+
+            return copy;
+        }
+
+        /// <summary>
+        /// Function to get z-ordinate values for an array of xy-ordinate values
+        /// </summary>
+        /// <param name="self">The elevation model to use</param>
+        /// <param name="xy">An array of xy-ordinate values</param>
+        /// <param name="z">The array of z-ordinate values</param>
+        public static void GetZ(this ElevationModel self, double[] xy, double[] z)
+        {
+            self.GetZ(new ReadOnlySpan<double>(xy), new Span<double>(z));
+        }
+
+        /// <summary>
+        /// Method signature to extract xy- and z-ordinate values from a coordinate sequence
+        /// </summary>
+        /// <param name="sequence">The sequence to extract xy- and z ordinates from</param>
+        /// <param name="xy">The xy-ordinate values</param>
+        /// <param name="z">The z-ordinate values</param>
+        public delegate void CoordinateSequenceToXYAndZ(CoordinateSequence sequence, Span<double> xy, Span<double> z);
+
+        /// <summary>
+        /// Method to add missing z-ordinate values to a geometry. The geometry must be
+        /// built of <see cref="CoordinateSequence"/>s that are able to carry z-ordinate values.
+        /// </summary>
+        /// <param name="self">The elevation model providing missing z-ordinate values</param>
+        /// <param name="g">The geometry to add the missing z-ordinate values to</param>
+        public static void AddMissingZ(this ElevationModel self, Geometry g)
+            => AddMissingZ(self, g, CsToXYAndZ);
+
+
+        /// <summary>
+        /// Method to add missing z-ordinate values to a geometry. The geometry must be
+        /// built of <see cref="CoordinateSequence"/>s that are able to carry z-ordinate values.
+        /// </summary>
+        /// <param name="self">The elevation model providing missing z-ordinate values</param>
+        /// <param name="g">The geometry to add the missing z-ordinate values to</param>
+        /// <param name="seqToXYAndZ">A method to convert a coordinate sequence into arrays of xy- and z-ordinate values.</param>
+        public static void AddMissingZ(this ElevationModel self, Geometry g, CoordinateSequenceToXYAndZ seqToXYAndZ)
+        {
+            if (seqToXYAndZ == null)
+                throw new ArgumentNullException(nameof(seqToXYAndZ));
+
+            var flt = new AddMissingZFilter(self, seqToXYAndZ);
+            g.Apply(flt);
+        }
+
+        /// <summary>
+        /// A filter class to add z-ordinate values where they are missing
+        /// </summary>
+        private class AddMissingZFilter : IEntireCoordinateSequenceFilter
+        {
+            private readonly ElevationModel _elevationModel;
+            private readonly CoordinateSequenceToXYAndZ _seqToXYAndZ;
+
+            public AddMissingZFilter(ElevationModel elevationModel, CoordinateSequenceToXYAndZ seqToXYAndZ)
+            {
+                _elevationModel = elevationModel;
+                _seqToXYAndZ = seqToXYAndZ;
+            }
+
+            // We need to handle all sequences
+            public bool Done => false;
+
+            // Only the z-ordiante values are changed so nothing to update
+            // in the geometry itself
+            public bool GeometryChanged => false;
+
+            public void Filter(CoordinateSequence seq)
+            {
+                // If the sequence can't deal with z-ordinate values
+                // don't even attempt to use the elevation model
+                if (!seq.HasZ)
+                    return;
+
+                // Get buffers for ordinate values
+                double[] xy = ArrayPool<double>.Shared.Rent(2 * seq.Count);
+                var xys = new Span<double>(xy, 0, 2 * seq.Count);
+                double[] z = ArrayPool<double>.Shared.Rent(seq.Count);
+                var zs = new Span<double>(z, 0, seq.Count);
+
+                // Perform conversion to arrays
+                _seqToXYAndZ(seq, xys, zs);
+
+                // Get z-ordinate values
+                _elevationModel.GetZ(xys, zs);
+
+                // Return first buffer
+                ArrayPool<double>.Shared.Return(xy);
+
+                // Assign z-ordinate values
+                for (int i = 0; i < seq.Count; i++)
+                    seq.SetZ(i, zs[i]);
+
+                // Return 2nd buffer
+                ArrayPool<double>.Shared.Return(z);
+            }
+        }
+
+        /// <summary>
+        /// Default -naive- implementation to convert sequence to arrays of xy- and z-ordinate values
+        /// </summary>
+        /// <param name="seq">A coordinate sequence</param>
+        /// <param name="xy">An array with the xy-ordinates of <paramref name="seq"/>. It has to provide space for 2x <see cref="CoordinateSequence.Count"/> elements</param>
+        /// <param name="z">An array with the z-ordinate values of <paramref name="seq"/>. It has to provide space for <see cref="CoordinateSequence.Count"/> elements</param>
+        private static void CsToXYAndZ(CoordinateSequence seq, Span<double> xy, Span<double> z)
+        {
+            if (seq.Count == 0) return;
+
+            if (xy == null || xy.Length < 2 * seq.Count)
+                throw new ArgumentException("Null or not sized properly", nameof(xy));
+            if (z == null || z.Length < seq.Count)
+                throw new ArgumentException("Null or not sized properly", nameof(z));
+
+            for (int i = 0, j = 0; i < seq.Count; i++)
+            {
+                xy[j++] = seq.GetX(i);
+                xy[j++] = seq.GetY(i);
+                z[i] = seq.GetZ(i);
+            }
+        }
+    }
+}

--- a/src/NetTopologySuite/Algorithm/PointLocation.cs
+++ b/src/NetTopologySuite/Algorithm/PointLocation.cs
@@ -65,7 +65,7 @@ namespace NetTopologySuite.Algorithm
         /// </returns>
         public static bool IsOnLine(Coordinate p, CoordinateSequence line)
         {
-            var lineIntersector = new RobustLineIntersector();
+            var lineIntersector = new RobustLineIntersector(ElevationModel.NoZ);
             var p0 = line.CreateCoordinate();
             var p1 = p0.Copy();
             int n = line.Count;

--- a/src/NetTopologySuite/Algorithm/RectangleLineIntersector.cs
+++ b/src/NetTopologySuite/Algorithm/RectangleLineIntersector.cs
@@ -20,7 +20,7 @@ namespace NetTopologySuite.Algorithm
     public class RectangleLineIntersector
     {
         // for intersection testing, don't need to set precision model
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = new RobustLineIntersector(ElevationModel.NoZ);
 
         private readonly Envelope _rectEnv;
 

--- a/src/NetTopologySuite/Algorithm/RobustLineIntersector.LocalElevationModel.cs
+++ b/src/NetTopologySuite/Algorithm/RobustLineIntersector.LocalElevationModel.cs
@@ -1,0 +1,209 @@
+﻿using NetTopologySuite.Geometries;
+using NetTopologySuite.Utilities;
+using System;
+
+namespace NetTopologySuite.Algorithm
+{
+    public partial class RobustLineIntersector
+    {
+        /// <summary>
+        /// A local elevation model.
+        /// This mimics the functionality that was previously hard coded into <see cref="RobustLineIntersector"/>.
+        /// </summary>
+        private class LocalElevationModel : ElevationModel
+        {
+            private readonly Coordinate _p1, _p2, _q1, _q2;
+            private readonly OrientationIndex _Pq1, _Pq2, _Qp1, _Qp2;
+            private readonly bool _collinear;
+
+            public LocalElevationModel(Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2,
+                OrientationIndex Pq1, OrientationIndex Pq2, OrientationIndex Qp1, OrientationIndex Qp2,
+                bool collinear)
+            {
+                _p1 = p1; _p2 = p2;
+                _q1 = q1; _q2 = q2;
+                _Pq1 = Pq1; _Pq2 = Pq2;
+                _Qp1 = Qp1; _Qp2 = Qp2;
+                _collinear = collinear;
+            }
+
+            /* 
+             * For the computation of collinear z-ordinates then values of
+             * _Pq1, _Pq2, _Qp1 and _Qp2 are used to store the boolean values 
+             * for _q1InP, q2inP, _p1inQ and _p2inQ
+             */
+            private bool _q1inP => _Pq1 == OrientationIndex.Clockwise;
+
+            private bool _q2inP => _Pq2 == OrientationIndex.Clockwise;
+
+            private bool _p1inQ => _Qp1 == OrientationIndex.Clockwise;
+
+            private bool _p2inQ => _Qp2 == OrientationIndex.Clockwise;
+
+            /// <inheritdoc/>
+            public override double GetZ(Coordinate c)
+            {
+                if (_collinear)
+                {
+                    if (_q1inP && _q2inP)
+                        return GetZOrInterpolate(c, _p1, _p2);
+                    if (_p1inQ && _p2inQ)
+                        return GetZOrInterpolate(c, _q1, _q2);
+                    if ((_q1inP && _p1inQ) || (_q1inP && _p2inQ))
+                        return c.Equals2D(_q1)
+                            ? GetZOrInterpolate(c, _p1, _p2)
+                            : GetZOrInterpolate(c, _q1, _q2);
+                    if ((_q2inP && _p1inQ) || (_q2inP && _p2inQ))
+                        return c.Equals2D(_q2)
+                            ? GetZOrInterpolate(c, _p1, _p2)
+                            : GetZOrInterpolate(c, _q1, _q2);
+                }
+                else
+                {
+                    if (_Pq1 == 0 || _Pq2 == 0 || _Qp1 == 0 || _Qp2 == 0)
+                    {
+                        if (_p1.Equals2D(_q1))
+                            return GetZFromEitherOr(_p1, _q1);
+                        if (_p1.Equals2D(_q2))
+                            return GetZFromEitherOr(_p1, _q2);
+                        if (_p2.Equals2D(_q1))
+                            return GetZFromEitherOr(_p2, _q1);
+                        if (_p2.Equals2D(_q2))
+                            return GetZFromEitherOr(_p2, _q2);
+                        if (_Pq1 == 0)
+                            return GetZOrInterpolate(_q1, _p1, _p2);
+                        if (_Pq2 == 0)
+                            return GetZOrInterpolate(_q2, _p1, _p2);
+                        if (_Qp1 == 0)
+                            return GetZOrInterpolate(_p1, _q1, _q2);
+                        if (_Qp2 == 0)
+                            return GetZOrInterpolate(_p2, _q1, _q2);
+                    }
+                    else
+                    {
+                        return InterpolateZ(c, _p1, _p2, _q1, _q2);
+                    }
+                }
+
+                // This should not happen whatsoever
+                Assert.ShouldNeverReachHere();
+
+                return Coordinate.NullOrdinate;
+            }
+
+            /// <summary>
+            /// Gets the Z value of the first argument if present,
+            /// otherwise the value of the second argument.
+            /// </summary>
+            /// <param name="p">A coordinate, possibly with Z</param>
+            /// <param name="q">A coordinate, possibly with Z</param>
+            /// <returns>The Z value if present</returns>
+            private static double GetZFromEitherOr(Coordinate p, Coordinate q)
+            {
+                double z = p.Z;
+                if (double.IsNaN(z))
+                {
+                    z = q.Z; // may be NaN
+                }
+                return z;
+            }
+
+            /// <summary>
+            /// Gets the Z value of a coordinate if present, or
+            /// interpolates it from the segment it lies on.
+            /// If the segment Z values are not fully populate
+            /// NaN is returned.
+            /// </summary>
+            /// <param name="p">A coordinate, possibly with Z</param>
+            /// <param name="p1">A segment endpoint, possibly with Z</param>
+            /// <param name="p2">A segment endpoint, possibly with Z</param>
+            /// <returns>The extracted or interpolated Z value (may be NaN)</returns>
+            private static double GetZOrInterpolate(Coordinate p, Coordinate p1, Coordinate p2)
+            {
+                double z = p.Z;
+                if (!double.IsNaN(z))
+                    return z;
+                return InterpolateZ(p, p1, p2); // may be NaN
+            }
+
+            /// <summary>
+            /// Interpolates a Z value for a point along
+            /// a line segment between two points.
+            /// The Z value of the interpolation point (if any) is ignored.
+            /// If either segment point is missing Z,
+            /// returns NaN.
+            /// </summary>
+            /// <param name="p">A coordinate, possibly with Z</param>
+            /// <param name="p1">A segment endpoint, possibly with Z</param>
+            /// <param name="p2">A segment endpoint, possibly with Z</param>
+            /// <returns>The extracted or interpolated Z value (may be NaN)</returns>
+            private static double InterpolateZ(Coordinate p, Coordinate p1, Coordinate p2)
+            {
+                double p1z = p1.Z;
+                double p2z = p2.Z;
+                if (double.IsNaN(p1z))
+                {
+                    return p2z; // may be NaN
+                }
+                if (double.IsNaN(p2z))
+                {
+                    return p1z; // may be NaN
+                }
+                if (p.Equals2D(p1))
+                {
+                    return p1z; // not NaN
+                }
+                if (p.Equals2D(p2))
+                {
+                    return p2z; // not NaN
+                }
+                double dz = p2z - p1z;
+                if (dz == 0.0)
+                {
+                    return p1z;
+                }
+                // interpolate Z from distance of p along p1-p2
+                double dx = (p2.X - p1.X);
+                double dy = (p2.Y - p1.Y);
+                // seg has non-zero length since p1 < p < p2 
+                double seglen = (dx * dx + dy * dy);
+                double xoff = (p.X - p1.X);
+                double yoff = (p.Y - p1.Y);
+                double plen = (xoff * xoff + yoff * yoff);
+                double frac = Math.Sqrt(plen / seglen);
+                double zoff = dz * frac;
+                double zInterpolated = p1z + zoff;
+                return zInterpolated;
+            }
+
+            /// <summary>
+            /// Interpolates a Z value for a point along
+            /// two line segments and computes their average.
+            /// The Z value of the interpolation point (if any) is ignored.
+            /// If one segment point is missing Z that segment is ignored
+            /// if both segments are missing Z, returns NaN.
+            /// </summary>
+            /// <param name="p">A coordinate</param>
+            /// <param name="p1">A segment endpoint, possibly with Z</param>
+            /// <param name="p2">A segment endpoint, possibly with Z</param>
+            /// <param name="q1">A segment endpoint, possibly with Z</param>
+            /// <param name="q2">A segment endpoint, possibly with Z</param>
+            /// <returns>The averaged interpolated Z value (may be NaN)</returns>    
+            private static double InterpolateZ(Coordinate p, Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2)
+            {
+                double zp = InterpolateZ(p, p1, p2);
+                double zq = InterpolateZ(p, q1, q2);
+                if (double.IsNaN(zp))
+                {
+                    return zq; // may be NaN
+                }
+                if (double.IsNaN(zq))
+                {
+                    return zp; // may be NaN
+                }
+                // both Zs have values, so average them
+                return (zp + zq) / 2.0;
+            }
+        }
+    }
+}

--- a/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
+++ b/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
@@ -110,19 +110,19 @@ namespace NetTopologySuite.Algorithm
                  */
                 if (p1.Equals2D(q1))
                 {
-                    p = p1;
+                    p = WithZ(p1, q1);
                 }
                 else if (p1.Equals2D(q2))
                 {
-                    p = p1;
+                    p = WithZ(p1, q2);
                 }
                 else if (p2.Equals2D(q1))
                 {
-                    p = p2;
+                    p = WithZ(p2, q1);
                 }
                 else if (p2.Equals2D(q2))
                 {
-                    p = p2;
+                    p = WithZ(p2, q2);
                 }
                 /*
                  * Now check to see if any endpoint lies on the interior of the other segment.
@@ -344,6 +344,20 @@ namespace NetTopologySuite.Algorithm
             return nearestPt;
         }
 
+        /// <summary>
+        /// Returns either <paramref name="p"/> or <paramref name="q"/>, depending on which one has a valid z-ordinate value
+        /// </summary>
+        /// <param name="p">A coordinate, possibly with z-ordinate</param>
+        /// <param name="q">A coordinate, possibly with z-ordinate</param>
+        /// <returns>Returns eihter p or q.</returns>
+        private static Coordinate WithZ(Coordinate p, Coordinate q)
+        {
+            return double.IsNaN(p.Z) ? q : p;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating the elevation model to use when z-ordinate is not known
+        /// </summary>
         public ElevationModel ElevationModel { get; set; }
 
         /// <summary>
@@ -353,6 +367,19 @@ namespace NetTopologySuite.Algorithm
         /// </summary>
         public static bool UseLocalElevationModel { get; set; } = true;
 
+        /// <summary>
+        /// Factory method to create an elevation model for retrieving missing z-ordinate values
+        /// </summary>
+        /// <param name="p1">Start point of the first line segment (P)</param>
+        /// <param name="p2">End point of the first line segment (P)</param>
+        /// <param name="q1">Start point of the second line segment (Q)</param>
+        /// <param name="q2">End point of the second line segment (Q)</param>
+        /// <param name="Pq1">Orientation of q1 in regartd to P</param>
+        /// <param name="Pq2">Orientation of q2 in regartd to P</param>
+        /// <param name="Qp1">Orientation of p1 in regartd to Q</param>
+        /// <param name="Qp2">Orientation of p2 in regartd to Q</param>
+        /// <param name="collinear">Flag indicating that the two line segments are collinear</param>
+        /// <returns>An elevation model</returns>
         private ElevationModel CreateElevationModel(Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2,
             OrientationIndex Pq1, OrientationIndex Pq2, OrientationIndex Qp1, OrientationIndex Qp2,
             bool collinear)

--- a/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
+++ b/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
@@ -284,7 +284,7 @@ namespace NetTopologySuite.Algorithm
                 intPt = NearestEndpoint(p1, p2, q1, q2);
                 //Console.WriteLine($"Snapped to {intPt}");
             }
-
+            
             return intPt;
         }
 

--- a/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
+++ b/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
@@ -8,6 +8,22 @@ namespace NetTopologySuite.Algorithm
     public partial class RobustLineIntersector : LineIntersector
     {
         /// <summary>
+        /// Creates an instance of this class. No <see cref="Algorithm.ElevationModel"/> is assigned
+        /// </summary>
+        public RobustLineIntersector()
+            :this(null)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of this class assigning the provided <see cref="Algorithm.ElevationModel"/>.
+        /// </summary>
+        public RobustLineIntersector(ElevationModel elevationModel)
+        {
+            ElevationModel = elevationModel;
+        }
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="p"></param>
@@ -358,14 +374,7 @@ namespace NetTopologySuite.Algorithm
         /// <summary>
         /// Gets or sets a value indicating the elevation model to use when z-ordinate is not known
         /// </summary>
-        public ElevationModel ElevationModel { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating if a local <see cref="Algorithm.ElevationModel"/> should be computed from
-        /// the coordinates involved in the robust line intersection test, if other means to
-        /// get one fail. 
-        /// </summary>
-        public static bool UseLocalElevationModel { get; set; } = true;
+        public ElevationModel ElevationModel { get; }
 
         /// <summary>
         /// Factory method to create an elevation model for retrieving missing z-ordinate values
@@ -384,14 +393,7 @@ namespace NetTopologySuite.Algorithm
             OrientationIndex Pq1, OrientationIndex Pq2, OrientationIndex Qp1, OrientationIndex Qp2,
             bool collinear)
         {
-            var res = ElevationModel;
-            if (res != null)
-                return ElevationModel;
-
-            if (UseLocalElevationModel)
-                return new LocalElevationModel(p1, p2, q1, q2, Pq1, Pq2, Qp1, Qp2, collinear);
-
-            return ElevationModel.Default;
+            return ElevationModel ?? new LocalElevationModel(p1, p2, q1, q2, Pq1, Pq2, Qp1, Qp2, collinear);
         }
     }
 }

--- a/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
+++ b/src/NetTopologySuite/Algorithm/RobustLineIntersector.cs
@@ -227,7 +227,8 @@ namespace NetTopologySuite.Algorithm
             return NoIntersection;
         }
 
-
+        // JTS deviation: we use our ElevationModel invention instead of this CopyWithZ.
+#if false
         private static Coordinate CopyWithZ(Coordinate p, double z)
         {
             // If there is not z-ordinate to apply just return the copy
@@ -236,25 +237,14 @@ namespace NetTopologySuite.Algorithm
 
             // If there is a z-ordinate value we need to make sure it
             // can be assigned.
-            Coordinate res;
-            var ptype = p.GetType();
-            if (ptype == typeof(CoordinateZ)) // this includes CoordinateZM
-                res = p.Copy();
-            else if (ptype == typeof(CoordinateM))
-                res = new CoordinateZM { CoordinateValue = p };
-            else if (ptype == typeof(ExtraDimensionalCoordinate))
-            {
-                var edc = (ExtraDimensionalCoordinate)p;
-                res = (edc.Dimension - edc.Measures > 2)
-                    ? edc.Copy()
-                    : new ExtraDimensionalCoordinate(edc.Dimension + 1, edc.Measures) { CoordinateValue = p };
-            }
-            else
-                res = new CoordinateZ(p);
-
+            int spatial = Math.Max(3, Coordinates.SpatialDimension(p));
+            int measures = Coordinates.Measures(p);
+            var res = Coordinates.Create(spatial + measures, measures);
+            res.CoordinateValue = p;
             res.Z = z;
             return res;
         }
+#endif
 
         /// <summary>
         /// This method computes the actual value of the intersection point.
@@ -294,7 +284,7 @@ namespace NetTopologySuite.Algorithm
                 intPt = NearestEndpoint(p1, p2, q1, q2);
                 //Console.WriteLine($"Snapped to {intPt}");
             }
-            
+
             return intPt;
         }
 

--- a/src/NetTopologySuite/Coverage/InvalidSegmentDetector.cs
+++ b/src/NetTopologySuite/Coverage/InvalidSegmentDetector.cs
@@ -112,7 +112,7 @@ namespace NetTopologySuite.Coverage
         private bool IsCollinearOrInterior(Coordinate tgt0, Coordinate tgt1,
             Coordinate adj0, Coordinate adj1, CoverageRing adj, int indexAdj)
         {
-            var li = new RobustLineIntersector();
+            var li =  new RobustLineIntersector(ElevationModel.NoZ);
             li.ComputeIntersection(tgt0, tgt1, adj0, adj1);
 
             //-- segments do not interact

--- a/src/NetTopologySuite/Geometries/ExtraDimensionalCoordinate.cs
+++ b/src/NetTopologySuite/Geometries/ExtraDimensionalCoordinate.cs
@@ -233,24 +233,41 @@ namespace NetTopologySuite.Geometries
                 X = value.X;
                 Y = value.Y;
 
-                int maxInputDim = Coordinates.Dimension(value);
-                int maxOutputDim = Dimension;
-                if (maxInputDim > maxOutputDim)
-                {
-                    maxInputDim = maxOutputDim;
-                }
+                // Reset extra values array
+                ResetExtraValues();
 
-                int dim;
-                for (dim = 2; dim < maxInputDim; dim++)
-                {
-                    _extraValues[dim - 2] = value[dim];
-                }
+                // Get number of dimensions and measures for value
+                int valDimension = Coordinates.Dimension(value);
+                int valMeasures = Coordinates.Measures(value);
 
-                for (; dim < maxOutputDim; dim++)
-                {
-                    _extraValues[dim - 2] = NullOrdinate;
-                }
+                // Get number of values to transfer
+                int numSpatialToCopy = -2 + Math.Min(Dimension - Measures, valDimension - valMeasures);
+                int numMeasuresToCopy = Math.Min(Measures, valMeasures);
+
+                // Transfer remaining spatial values
+                for (int i = 0; i < numSpatialToCopy; i++)
+                    _extraValues[i] = value[2 + i];
+
+                // Transfer measure values
+                int j1 = Dimension - Measures - 2;
+                int j2 = valDimension - valMeasures;
+                for (int i = 0; i < numMeasuresToCopy; i++)
+                    _extraValues[j1++] = value[j2++];
             }
+        }
+
+        /// <summary>
+        /// Resets the <see cref="_extraValues"/> array to default values.
+        /// </summary>
+        private void ResetExtraValues()
+        {
+            // Get number of spatial dimensions stored in _extraValues
+            int numSpatial = Dimension - Measures;
+
+            // Fill extra spatial values with NULL_ORDINATE, measure values 
+            int i = 0;
+            for (; i < numSpatial - 2; i++) _extraValues[i] = NullOrdinate;
+            for (; i < Dimension - 2; i++) _extraValues[i] = 0;
         }
 
         public override Coordinate Copy() => new ExtraDimensionalCoordinate(X, Y, (double[])_extraValues.Clone(), Measures);

--- a/src/NetTopologySuite/Geometries/ExtraDimensionalCoordinate.cs
+++ b/src/NetTopologySuite/Geometries/ExtraDimensionalCoordinate.cs
@@ -233,41 +233,36 @@ namespace NetTopologySuite.Geometries
                 X = value.X;
                 Y = value.Y;
 
-                // Reset extra values array
-                ResetExtraValues();
-
                 // Get number of dimensions and measures for value
                 int valDimension = Coordinates.Dimension(value);
-                int valMeasures = Coordinates.Measures(value);
+                int valSpatial = Coordinates.SpatialDimension(value);
 
-                // Get number of values to transfer
-                int numSpatialToCopy = -2 + Math.Min(Dimension - Measures, valDimension - valMeasures);
-                int numMeasuresToCopy = Math.Min(Measures, valMeasures);
+                // Get number of spatial dimensions
+                int thisSpatial = Dimension - Measures;
 
-                // Transfer remaining spatial values
-                for (int i = 0; i < numSpatialToCopy; i++)
-                    _extraValues[i] = value[2 + i];
-
-                // Transfer measure values
-                int j1 = Dimension - Measures - 2;
-                int j2 = valDimension - valMeasures;
-                for (int i = 0; i < numMeasuresToCopy; i++)
-                    _extraValues[j1++] = value[j2++];
+                // fill in values for spatial dimensions until we reach the end of either one.
+                int thisI = 2, valI = 2;
+                while (thisI < thisSpatial & valI < valSpatial)
+                {
+                    this[thisI++] = value[valI++];
+                }
+                // fill in remaining spatial dimensions that weren't present in the source.
+                while (thisI < thisSpatial)
+                {
+                    this[thisI++] = Coordinate.NullOrdinate;
+                }
+                // fill in values for measures until we reach the end of either one.
+                valI = valSpatial;
+                while (thisI < Dimension && valI < valDimension)
+                {
+                    this[thisI++] = value[valI++];
+                }
+                // fill in remaining measures that weren't present in the source.
+                while (thisI < Dimension)
+                {
+                    this[thisI++] = 0;
+                }
             }
-        }
-
-        /// <summary>
-        /// Resets the <see cref="_extraValues"/> array to default values.
-        /// </summary>
-        private void ResetExtraValues()
-        {
-            // Get number of spatial dimensions stored in _extraValues
-            int numSpatial = Dimension - Measures;
-
-            // Fill extra spatial values with NULL_ORDINATE, measure values 
-            int i = 0;
-            for (; i < numSpatial - 2; i++) _extraValues[i] = NullOrdinate;
-            for (; i < Dimension - 2; i++) _extraValues[i] = 0;
         }
 
         public override Coordinate Copy() => new ExtraDimensionalCoordinate(X, Y, (double[])_extraValues.Clone(), Measures);

--- a/src/NetTopologySuite/Geometries/ExtraDimensionalCoordinate.cs
+++ b/src/NetTopologySuite/Geometries/ExtraDimensionalCoordinate.cs
@@ -2,6 +2,11 @@
 
 namespace NetTopologySuite.Geometries
 {
+    // Please treat this internal class, ExtraDimensionalCoordinate, as an **implementation detail**
+    // of the various methods on the Coordinates static class. The use cases for this type are hard
+    // to quantify. It was originally created to let Coordinates.Create return a Coordinate that
+    // behaves as requested instead of either silently deciding to give the user something that they
+    // didn't ask for (JTS behavior) or throwing an exception (a perhaps-reasonable alternative).
     [Serializable]
     internal sealed class ExtraDimensionalCoordinate : Coordinate
     {

--- a/src/NetTopologySuite/Geometries/GeometryFactory.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries.Utilities;
 using NetTopologySuite.Utilities;
 
@@ -57,7 +58,7 @@ namespace NetTopologySuite.Geometries
         private readonly CoordinateSequenceFactory _coordinateSequenceFactory;
 
         /// <summary>
-        ///
+        /// Gets a value indicating the factory to use for creating <see cref="CoordinateSequence"/>s
         /// </summary>
         public CoordinateSequenceFactory CoordinateSequenceFactory => _coordinateSequenceFactory;
 
@@ -85,6 +86,16 @@ namespace NetTopologySuite.Geometries
         {
             get { return GeometryServices.GeometryRelate; }
         }
+
+
+        [NonSerialized]
+        private ElevationModel _elevationModel;
+
+        /// <summary>
+        /// Gets a value indicating the elevation model that is attached to this geometry factory
+        /// </summary>
+        public ElevationModel ElevationModel => _elevationModel;
+
 
         /// <summary>
         /// Gets a value indicating the geometry overlay function set to use
@@ -130,11 +141,28 @@ namespace NetTopologySuite.Geometries
         /// <param name="services"><c>NtsGeometryServices</c> object creating this factory</param>
         public GeometryFactory(PrecisionModel precisionModel, int srid, CoordinateSequenceFactory coordinateSequenceFactory,
             NtsGeometryServices services)
+            :this(precisionModel, null, srid, coordinateSequenceFactory, services)
+        { }
+
+        /// <summary>
+        /// Constructs a <c>GeometryFactory</c> that generates Geometries having the given
+        /// <paramref name="precisionModel">precision model</paramref>, <paramref name="elevationModel"/>,
+        /// <paramref name="srid">spatial-reference ID</paramref>, <paramref name="coordinateSequenceFactory">CoordinateSequence</paramref> and
+        /// <paramref name="services"><c>NtsGeometryServices</c></paramref>.
+        /// </summary>
+        /// <param name="precisionModel">A precision model</param>
+        /// <param name="elevationModel">An elevation model. May be <c>null</c></param>
+        /// <param name="srid">A spatial reference id</param>
+        /// <param name="coordinateSequenceFactory">A coordinate sequence factory</param>
+        /// <param name="services"><c>NtsGeometryServices</c> object creating this factory</param>
+        public GeometryFactory(PrecisionModel precisionModel, ElevationModel elevationModel, int srid, CoordinateSequenceFactory coordinateSequenceFactory,
+            NtsGeometryServices services)
         {
             _precisionModel = precisionModel;
+            _elevationModel = elevationModel;
             _coordinateSequenceFactory = coordinateSequenceFactory;
             _srid = srid;
-            _services = services;
+            _services = services ?? NtsGeometryServices.Instance;
         }
 
         /// <summary>
@@ -740,6 +768,7 @@ namespace NetTopologySuite.Geometries
         protected void OnDeserialized(StreamingContext context)
         {
             _services = NtsGeometryServices.Instance;
+            _elevationModel = NtsGeometryServices.Instance.DefaultElevationModel;
         }
     }
 }

--- a/src/NetTopologySuite/Geometries/GeometryRelate.cs
+++ b/src/NetTopologySuite/Geometries/GeometryRelate.cs
@@ -5,24 +5,10 @@ using RelatePredicate = NetTopologySuite.Operation.RelateNG.RelatePredicate;
 
 namespace NetTopologySuite.Geometries
 {
-    /**
-     * Internal class which encapsulates the runtime switch to use RelateNG.
-     * <p>
-     * This class allows the {@link Geometry} predicate methods to be 
-     * switched between the original {@link RelateOp} algorithm 
-     * and the modern {@link RelateNG} codebase
-     * via a system property <code>jts.relate</code>.
-     * <ul>
-     * <li><code>jts.relate=old</code> - (default) use original RelateOp algorithm
-     * <li><code>jts.relate=ng</code> - use RelateNG
-     * </ul>
-     * 
-     * @author mdavis
-     *
-     */
     /// <summary>
+    /// Class which provides the available Relate operations for <see cref="NtsGeometryServices"/>.
     /// </summary>
-    /// <author>Martin Davis</author>
+    /// <author>Felix Obermaier</author>
     public abstract class GeometryRelate
     {
         /// <summary>

--- a/src/NetTopologySuite/Geometries/LineSegment.cs
+++ b/src/NetTopologySuite/Geometries/LineSegment.cs
@@ -510,9 +510,20 @@ namespace NetTopologySuite.Geometries
         /// A pair of Coordinates which are the closest points on the line segments.
         /// </returns>
         public Coordinate[] ClosestPoints(LineSegment line)
+            => ClosestPoints(line, null);
+
+        /// <summary>
+        /// Computes the closest points on a line segment.
+        /// </summary>
+        /// <param name="line"></param>
+        /// <returns>
+        /// A pair of Coordinates which are the closest points on the line segments.
+        /// </returns>
+        public Coordinate[] ClosestPoints(LineSegment line, ElevationModel em)
+
         {
             // test for intersection
-            var intPt = Intersection(line);
+            var intPt = Intersection(line, em);
             if (intPt != null)
                 return new[] { intPt, intPt };
 
@@ -598,8 +609,23 @@ namespace NetTopologySuite.Geometries
         /// <returns> An intersection point, or <c>null</c> if there is none.</returns>
         /// <see cref="RobustLineIntersector"/>
         public Coordinate Intersection(LineSegment line)
+            => Intersection(line, null);
+
+        /// <summary>
+        /// Computes an intersection point between two segments, if there is one.
+        /// There may be 0, 1 or many intersection points between two segments.
+        /// If there are 0, null is returned. If there is 1 or more, a single one
+        /// is returned (chosen at the discretion of the algorithm).  If
+        /// more information is required about the details of the intersection,
+        /// the <see cref="RobustLineIntersector"/> class should be used.
+        /// </summary>
+        /// <param name="line">A line segment</param>
+        /// <param name="em">An elevation model. May be <c>null</c></param>
+        /// <returns> An intersection point, or <c>null</c> if there is none.</returns>
+        /// <see cref="RobustLineIntersector"/>
+        public Coordinate Intersection(LineSegment line, ElevationModel em)
         {
-            var li = new RobustLineIntersector();
+            var li = new RobustLineIntersector(em);
             li.ComputeIntersection(_p0, _p1, line.P0, line.P1);
             if (li.HasIntersection)
                 return li.GetIntersection(0);

--- a/src/NetTopologySuite/Geometries/Prepared/AbstractPreparedPolygonContains.cs
+++ b/src/NetTopologySuite/Geometries/Prepared/AbstractPreparedPolygonContains.cs
@@ -210,7 +210,7 @@ namespace NetTopologySuite.Geometries.Prepared
         {
             var lineSegStr = SegmentStringUtil.ExtractSegmentStrings(geom);
 
-            var intDetector = new SegmentIntersectionDetector();
+            var intDetector = new SegmentIntersectionDetector(geom.Factory.ElevationModel);
             intDetector.FindAllIntersectionTypes = true;
             prepPoly.IntersectionFinder.Intersects(lineSegStr, intDetector);
 

--- a/src/NetTopologySuite/Noding/FastNodingValidator.cs
+++ b/src/NetTopologySuite/Noding/FastNodingValidator.cs
@@ -48,7 +48,7 @@ namespace NetTopologySuite.Noding
             return nv.Intersections;
         }
 
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = new RobustLineIntersector(ElevationModel.NoZ);
 
         private readonly List<ISegmentString> _segStrings = new List<ISegmentString>();
         private NodingIntersectionFinder _segInt;

--- a/src/NetTopologySuite/Noding/FastSegmentSetIntersectionFinder.cs
+++ b/src/NetTopologySuite/Noding/FastSegmentSetIntersectionFinder.cs
@@ -1,4 +1,6 @@
+using NetTopologySuite.Algorithm;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NetTopologySuite.Noding
 {
@@ -15,6 +17,7 @@ namespace NetTopologySuite.Noding
     public class FastSegmentSetIntersectionFinder
     {
         private readonly ISegmentSetMutualIntersector _segSetMutInt;
+        private readonly ElevationModel _em;
 
         //for testing purposes
         //private SimpleSegmentSetMutualIntersector mci;
@@ -24,8 +27,18 @@ namespace NetTopologySuite.Noding
         /// </summary>
         /// <param name="baseSegStrings">The segment strings to search for intersections</param>
         public FastSegmentSetIntersectionFinder(IEnumerable<ISegmentString> baseSegStrings)
+            :this(baseSegStrings, null)
+        { }
+
+        /// <summary>
+        /// Creates an intersection finder against a given set of segment strings.
+        /// </summary>
+        /// <param name="baseSegStrings">The segment strings to search for intersections</param>
+        /// <param name="em">An elevation model, may be <c>null</c></param>
+        public FastSegmentSetIntersectionFinder(IEnumerable<ISegmentString> baseSegStrings, ElevationModel em)
         {
             _segSetMutInt = new MCIndexSegmentSetMutualIntersector(baseSegStrings);
+            _em = em;
         }
 
         /// <summary>Gets the segment set intersector used by this class.</summary>
@@ -39,7 +52,7 @@ namespace NetTopologySuite.Noding
         /// <returns><c>true</c> if an intersection was found</returns>
         public bool Intersects(IList<ISegmentString> segStrings)
         {
-            var intFinder = new SegmentIntersectionDetector();
+            var intFinder = new SegmentIntersectionDetector(_em);
             return Intersects(segStrings, intFinder);
         }
 

--- a/src/NetTopologySuite/Noding/NodingValidator.cs
+++ b/src/NetTopologySuite/Noding/NodingValidator.cs
@@ -13,7 +13,7 @@ namespace NetTopologySuite.Noding
     {
         private static readonly GeometryFactory Factory = new GeometryFactory();
 
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = new RobustLineIntersector(ElevationModel.NoZ);
         private readonly IList<ISegmentString> _segStrings;
 
         /// <summary>

--- a/src/NetTopologySuite/Noding/SegmentIntersectionDetector.cs
+++ b/src/NetTopologySuite/Noding/SegmentIntersectionDetector.cs
@@ -33,6 +33,16 @@ namespace NetTopologySuite.Noding
         }
 
         /// <summary>
+        /// Creates an intersection finder using a <see cref="RobustLineIntersector"/>
+        /// with an <see cref="ElevationModel"/>
+        /// </summary>
+        /// <param name="em">An elevation model. May be <c>null</c></param>
+        public SegmentIntersectionDetector(ElevationModel em)
+            : this(new RobustLineIntersector(em))
+        {
+        }
+
+        /// <summary>
         /// Creates an intersection finder using a given <see cref="LineIntersector"/>
         /// </summary>
         /// <param name="li">The LineIntersector to use</param>

--- a/src/NetTopologySuite/Noding/Snap/SnappingIntersectionAdder.cs
+++ b/src/NetTopologySuite/Noding/Snap/SnappingIntersectionAdder.cs
@@ -11,7 +11,7 @@ namespace NetTopologySuite.Noding.Snap
     /// <version>1.17</version>
     public sealed class SnappingIntersectionAdder : ISegmentIntersector
     {
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li;
         private readonly double _snapTolerance;
         private readonly SnappingPointIndex _snapPointIndex;
 
@@ -22,9 +22,22 @@ namespace NetTopologySuite.Noding.Snap
         /// <param name="snapTolerance">The snapping tolerance distance</param>
         /// <param name="snapPointIndex">A snap index to use</param>
         public SnappingIntersectionAdder(double snapTolerance, SnappingPointIndex snapPointIndex)
+            : this(snapTolerance, snapPointIndex, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates an intersector which finds all snapped intersections,
+        /// and adds them as nodes.
+        /// </summary>
+        /// <param name="snapTolerance">The snapping tolerance distance</param>
+        /// <param name="snapPointIndex">A snap index to use</param>
+        /// <param name="em">An elevation model. May be <c>null</c></param>
+        public SnappingIntersectionAdder(double snapTolerance, SnappingPointIndex snapPointIndex, ElevationModel em)
         {
             _snapPointIndex = snapPointIndex;
             _snapTolerance = snapTolerance;
+            _li = new RobustLineIntersector(em);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Noding/Snap/SnappingNoder.cs
+++ b/src/NetTopologySuite/Noding/Snap/SnappingNoder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Mathematics;
 
@@ -31,6 +32,7 @@ namespace NetTopologySuite.Noding.Snap
     {
         private readonly SnappingPointIndex snapIndex;
         private readonly double _snapTolerance;
+        private readonly ElevationModel _em;
         private IList<ISegmentString> _nodedResult;
 
         /// <summary>
@@ -38,8 +40,18 @@ namespace NetTopologySuite.Noding.Snap
         /// </summary>
         /// <param name="snapTolerance">Points are snapped if within this distance</param>
         public SnappingNoder(double snapTolerance)
+            : this(snapTolerance, null)
+        { }
+
+        /// <summary>
+        /// Creates a snapping noder using the given snap distance tolerance.
+        /// </summary>
+        /// <param name="snapTolerance">Points are snapped if within this distance</param>
+        /// <param name="em">An elevation model. May be <c>null</c></param>
+        public SnappingNoder(double snapTolerance, ElevationModel em)
         {
             _snapTolerance = snapTolerance;
+            _em = em;
             snapIndex = new SnappingPointIndex(snapTolerance);
         }
 
@@ -123,7 +135,7 @@ namespace NetTopologySuite.Noding.Snap
         /// <returns>A list of noded substrings</returns>
         private IList<ISegmentString> ComputeIntersections(IList<ISegmentString> inputSS)
         {
-            var intAdder = new SnappingIntersectionAdder(_snapTolerance, snapIndex);
+            var intAdder = new SnappingIntersectionAdder(_snapTolerance, snapIndex, _em);
             /*
              * Use an overlap tolerance to ensure all 
              * possible snapped intersections are found

--- a/src/NetTopologySuite/Noding/Snapround/GeometryNoder.cs
+++ b/src/NetTopologySuite/Noding/Snapround/GeometryNoder.cs
@@ -65,7 +65,7 @@ namespace NetTopologySuite.Noding.Snapround
             }
 
             var segStrings = ToSegmentStrings(lines);
-            var sr = new SnapRoundingNoder(_pm);
+            var sr = new SnapRoundingNoder(_pm, _geomFact.ElevationModel);
             sr.ComputeNodes(segStrings);
             var nodedLines = sr.GetNodedSubstrings();
 

--- a/src/NetTopologySuite/Noding/Snapround/HotPixel.cs
+++ b/src/NetTopologySuite/Noding/Snapround/HotPixel.cs
@@ -327,7 +327,7 @@ namespace NetTopologySuite.Noding.Snapround
             corner[lowerLeft] = new Coordinate(minx, miny);
             corner[lowerRight] = new Coordinate(maxx, miny);
 
-            LineIntersector li = new RobustLineIntersector();
+            LineIntersector li = new RobustLineIntersector(ElevationModel.NoZ);
             li.ComputeIntersection(p0, p1, corner[0], corner[1]);
             if (li.HasIntersection) return true;
             li.ComputeIntersection(p0, p1, corner[1], corner[2]);

--- a/src/NetTopologySuite/Noding/Snapround/SimpleSnapRounder.cs
+++ b/src/NetTopologySuite/Noding/Snapround/SimpleSnapRounder.cs
@@ -175,7 +175,7 @@ namespace NetTopologySuite.Noding.Snapround
              */
             double snapGridSize = 1.0 / _pm.Scale;
             double nearnessTol = snapGridSize / NEARNESS_FACTOR;
-            var intAdder = new SnapRoundingIntersectionAdder(nearnessTol);
+            var intAdder = new SnapRoundingIntersectionAdder(nearnessTol, null);
             var noder = new MCIndexNoder(intAdder, nearnessTol);
             noder.ComputeNodes(segStrings);
             return intAdder.Intersections;

--- a/src/NetTopologySuite/Noding/Snapround/SnapRoundingIntersectionAdder.cs
+++ b/src/NetTopologySuite/Noding/Snapround/SnapRoundingIntersectionAdder.cs
@@ -35,7 +35,7 @@ namespace NetTopologySuite.Noding.Snapround
         /// <param name="pm">The precision model to use</param>
         [Obsolete]
         public SnapRoundingIntersectionAdder(PrecisionModel pm)
-            :this(CalculateNearnessTol(pm))
+            : this(CalculateNearnessTol(pm), null)
         {
         }
 
@@ -45,6 +45,16 @@ namespace NetTopologySuite.Noding.Snapround
         /// </summary>
         /// <param name="nearnessTol">the intersection distance tolerance</param>
         public SnapRoundingIntersectionAdder(double nearnessTol)
+            : this(nearnessTol, null)
+        { }
+
+        /// <summary>
+        /// Creates an intersector which finds all snapped interior intersections,
+        /// and adds them as nodes.
+        /// </summary>
+        /// <param name="nearnessTol">the intersection distance tolerance</param>
+        /// <param name="em">An elevation model. May be <c>null</c></param>
+        public SnapRoundingIntersectionAdder(double nearnessTol, ElevationModel em)
         {
             _nearnessTol = nearnessTol;
 
@@ -52,7 +62,7 @@ namespace NetTopologySuite.Noding.Snapround
              * Intersections are detected and computed using full precision.
              * They are snapped in a subsequent phase.
              */
-            _li = new RobustLineIntersector();
+            _li = new RobustLineIntersector(em);
             Intersections = new Collection<Coordinate>();
         }
 

--- a/src/NetTopologySuite/Noding/Snapround/SnapRoundingNoder.cs
+++ b/src/NetTopologySuite/Noding/Snapround/SnapRoundingNoder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Index.KdTree;
 using NetTopologySuite.Noding.Snap;
@@ -45,13 +46,19 @@ namespace NetTopologySuite.Noding.Snapround
 
 
         private readonly PrecisionModel _pm;
+        private readonly ElevationModel _em;
         private readonly HotPixelIndex _pixelIndex;
 
         private List<NodedSegmentString> _snappedResult;
 
         public SnapRoundingNoder(PrecisionModel pm)
+            : this(pm, null)
+        { }
+
+        public SnapRoundingNoder(PrecisionModel pm, ElevationModel em)
         {
             _pm = pm;
+            _em = em;
             _pixelIndex = new HotPixelIndex(pm);
         }
 
@@ -103,7 +110,7 @@ namespace NetTopologySuite.Noding.Snapround
             double snapGridSize = 1.0 / _pm.Scale;
             double nearnessTol = snapGridSize / NEARNESS_FACTOR;
 
-            var intAdder = new SnapRoundingIntersectionAdder(nearnessTol);
+            var intAdder = new SnapRoundingIntersectionAdder(nearnessTol, _em);
             var noder = new MCIndexNoder(intAdder, nearnessTol);
             noder.ComputeNodes(segStrings);
             var intPts = intAdder.Intersections;

--- a/src/NetTopologySuite/NtsGeometryServices.cs
+++ b/src/NetTopologySuite/NtsGeometryServices.cs
@@ -196,13 +196,13 @@ namespace NetTopologySuite
         }
 
         /// <summary>
-        /// Gets a value indicating the operations to use for geometry overlay.  
+        /// Gets a value indicating the operations to use for geometry overlay.
         /// </summary>
         /// <returns>A set of geometry overlay functions.</returns>
         public GeometryOverlay GeometryOverlay { get; }
 
         /// <summary>
-        /// Gets a value indicating the operations to use for geometry relation determination.  
+        /// Gets a value indicating the operations to use for geometry relation determination.
         /// </summary>
         /// <returns>A set of geometry relation functions.</returns>
         public GeometryRelate GeometryRelate { get; }
@@ -424,26 +424,16 @@ namespace NetTopologySuite
 
             public int SRID { get; }
 
-            public override int GetHashCode()
-            {
-                int res = (PrecisionModel, CoordinateSequenceFactory, SRID).GetHashCode();
-                if (ElevationModel != null) res ^= ElevationModel.GetHashCode();
-
-                return res;
-            }
+            public override int GetHashCode() => (PrecisionModel, CoordinateSequenceFactory, SRID, ElevationModel).GetHashCode();
 
             public override bool Equals(object obj) => obj is GeometryFactoryKey other && Equals(other);
 
             public bool Equals(GeometryFactoryKey other)
             {
-                if (SRID != other.SRID) return false;
-                if (!Equals(CoordinateSequenceFactory, other.CoordinateSequenceFactory)) return false;
-                if (!Equals(PrecisionModel, other.PrecisionModel)) return false;
-
-                if ((ElevationModel != null || other.ElevationModel != null) &&
-                    Equals(ElevationModel, other.ElevationModel)) return false;
-
-                return true;
+                return SRID == other.SRID &&
+                       Equals(CoordinateSequenceFactory, other.CoordinateSequenceFactory) &&
+                       Equals(PrecisionModel, other.PrecisionModel) &&
+                       Equals(ElevationModel, other.ElevationModel);
             }
         }
     }

--- a/src/NetTopologySuite/NtsGeometryServices.cs
+++ b/src/NetTopologySuite/NtsGeometryServices.cs
@@ -196,13 +196,13 @@ namespace NetTopologySuite
         }
 
         /// <summary>
-        /// Gets a value indicating the operations to use for geometry overlay.
+        /// Gets a value indicating the operations to use for geometry overlay.  
         /// </summary>
         /// <returns>A set of geometry overlay functions.</returns>
         public GeometryOverlay GeometryOverlay { get; }
 
         /// <summary>
-        /// Gets a value indicating the operations to use for geometry relation determination.
+        /// Gets a value indicating the operations to use for geometry relation determination.  
         /// </summary>
         /// <returns>A set of geometry relation functions.</returns>
         public GeometryRelate GeometryRelate { get; }

--- a/src/NetTopologySuite/Operation/Buffer/BufferCurveSetBuilder.cs
+++ b/src/NetTopologySuite/Operation/Buffer/BufferCurveSetBuilder.cs
@@ -30,9 +30,22 @@ namespace NetTopologySuite.Operation.Buffer
         public BufferCurveSetBuilder(Geometry inputGeom, double distance,
             PrecisionModel precisionModel, BufferParameters parameters)
         {
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="inputGeom">The input geometry</param>
+        /// <param name="distance">The offset distance</param>
+        /// <param name="precisionModel">A precision model</param>
+        /// <param name="em">An elevation model model. May be <c>null</c></param>
+        /// <param name="parameters">The buffer parameters</param>
+        public BufferCurveSetBuilder(Geometry inputGeom, double distance,
+            PrecisionModel precisionModel, ElevationModel em, BufferParameters parameters)
+        {
             _inputGeom = inputGeom;
             _distance = distance;
-            _curveBuilder = new OffsetCurveBuilder(precisionModel, parameters);
+            _curveBuilder = new OffsetCurveBuilder(precisionModel, em, parameters);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Operation/Buffer/BufferOp.cs
+++ b/src/NetTopologySuite/Operation/Buffer/BufferOp.cs
@@ -375,7 +375,7 @@ namespace NetTopologySuite.Operation.Buffer
              * (Note this only works for buffering, because
              * ScaledNoder may invalidate topology.)
              */
-            var snapNoder = new SnapRoundingNoder(new PrecisionModel(1.0));
+            var snapNoder = new SnapRoundingNoder(new PrecisionModel(1.0), _argGeom.Factory.ElevationModel);
             var noder = new ScaledNoder(snapNoder, fixedPM.Scale);
 
             var bufBuilder = CreateBufferBuilder();

--- a/src/NetTopologySuite/Operation/Buffer/OffsetCurveBuilder.cs
+++ b/src/NetTopologySuite/Operation/Buffer/OffsetCurveBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.GeometriesGraph;
 using Position = NetTopologySuite.Geometries.Position;
@@ -24,14 +25,24 @@ namespace NetTopologySuite.Operation.Buffer
     {
         private double _distance;
         private readonly PrecisionModel _precisionModel;
+        private readonly ElevationModel _em;
         private readonly BufferParameters _bufParams;
 
         public OffsetCurveBuilder(
             PrecisionModel precisionModel,
             BufferParameters bufParams
             )
+            : this(precisionModel, null, bufParams)
+        { }
+
+        public OffsetCurveBuilder(
+            PrecisionModel precisionModel,
+            ElevationModel em,
+            BufferParameters bufParams
+            )
         {
             _precisionModel = precisionModel;
+            _em = em;
             _bufParams = bufParams;
         }
 
@@ -167,7 +178,7 @@ namespace NetTopologySuite.Operation.Buffer
 
         private OffsetSegmentGenerator GetSegmentGenerator(double distance)
         {
-            return new OffsetSegmentGenerator(_precisionModel, _bufParams, distance);
+            return new OffsetSegmentGenerator(_precisionModel, _em, _bufParams, distance);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Operation/Buffer/OffsetSegmentGenerator.cs
+++ b/src/NetTopologySuite/Operation/Buffer/OffsetSegmentGenerator.cs
@@ -87,13 +87,18 @@ namespace NetTopologySuite.Operation.Buffer
 
         public OffsetSegmentGenerator(PrecisionModel precisionModel,
             BufferParameters bufParams, double distance)
+            : this(precisionModel, null, bufParams, distance)
+        { }
+
+        public OffsetSegmentGenerator(PrecisionModel precisionModel,
+            ElevationModel em, BufferParameters bufParams, double distance)
         {
             _precisionModel = precisionModel;
             _bufParams = bufParams;
 
             // compute intersections in full precision, to provide accuracy
             // the points are rounded as they are inserted into the curve line
-            _li = new RobustLineIntersector();
+            _li = new RobustLineIntersector(em);
 
             int quadSegs = bufParams.QuadrantSegments;
             if (quadSegs < 1) quadSegs = 1;

--- a/src/NetTopologySuite/Operation/GeometryGraphOperation.cs
+++ b/src/NetTopologySuite/Operation/GeometryGraphOperation.cs
@@ -10,7 +10,7 @@ namespace NetTopologySuite.Operation
     public class GeometryGraphOperation
     {
 
-        private LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li;
 
         /// <summary>
         ///
@@ -18,7 +18,7 @@ namespace NetTopologySuite.Operation
         protected LineIntersector lineIntersector
         {
             get => _li;
-            set => _li = value;
+            set { throw new System.NotSupportedException(); }
         }
 
         /// <summary>
@@ -42,10 +42,12 @@ namespace NetTopologySuite.Operation
 
         public GeometryGraphOperation(Geometry g0, Geometry g1, IBoundaryNodeRule boundaryNodeRule)
         {
+
+            // Create the line intersector to use
+            _li = new RobustLineIntersector(g0.Factory == g1.Factory ? g0.Factory.ElevationModel : null);
+
             // use the most precise model for the result
-            if (g0.PrecisionModel.CompareTo(g1.PrecisionModel) >= 0)
-                 ComputationPrecision = g0.PrecisionModel;
-            else ComputationPrecision = g1.PrecisionModel;
+            _li.PrecisionModel = PrecisionModel.MostPrecise(g0.PrecisionModel, g1.PrecisionModel);
 
             arg = new GeometryGraph[2];
             arg[0] = new GeometryGraph(0, g0, boundaryNodeRule);
@@ -58,10 +60,11 @@ namespace NetTopologySuite.Operation
         /// <param name="g0"></param>
         public GeometryGraphOperation(Geometry g0)
         {
-            ComputationPrecision = g0.PrecisionModel;
+            _li = new RobustLineIntersector(g0.Factory.ElevationModel);
+            _li.PrecisionModel = g0.PrecisionModel;
 
             arg = new GeometryGraph[1];
-            arg[0] = new GeometryGraph(0, g0);;
+            arg[0] = new GeometryGraph(0, g0);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Operation/IsSimpleOp.cs
+++ b/src/NetTopologySuite/Operation/IsSimpleOp.cs
@@ -164,7 +164,7 @@ namespace NetTopologySuite.Operation
                 return true;
 
             var graph = new GeometryGraph(0, geom);
-            var li = new RobustLineIntersector();
+            var li = new RobustLineIntersector(geom.Factory.ElevationModel);
             var si = graph.ComputeSelfNodes(li, true);
             // if no self-intersection, must be simple
             if (!si.HasIntersection) return true;

--- a/src/NetTopologySuite/Operation/OverlayNG/EdgeNodingBuilder.cs
+++ b/src/NetTopologySuite/Operation/OverlayNG/EdgeNodingBuilder.cs
@@ -36,18 +36,18 @@ namespace NetTopologySuite.Operation.OverlayNG
          */
         private const bool IsNodingValidated = true;
   
-        private static INoder CreateFixedPrecisionNoder(PrecisionModel pm)
+        private static INoder CreateFixedPrecisionNoder(PrecisionModel pm, Algorithm.ElevationModel em)
         {
             //Noder noder = new MCIndexSnapRounder(pm);
             //Noder noder = new SimpleSnapRounder(pm);
-            var noder = new SnapRoundingNoder(pm);
+            var noder = new SnapRoundingNoder(pm, em);
             return noder;
         }
 
-        private static INoder CreateFloatingPrecisionNoder(bool doValidation)
+        private static INoder CreateFloatingPrecisionNoder(bool doValidation, Algorithm.ElevationModel em)
         {
             var mcNoder = new MCIndexNoder();
-            var li = new RobustLineIntersector();
+            var li = new RobustLineIntersector(em);
             mcNoder.SegmentIntersector = new IntersectionAdder(li);
 
             INoder noder = mcNoder;
@@ -59,6 +59,7 @@ namespace NetTopologySuite.Operation.OverlayNG
         }
 
         private readonly PrecisionModel _pm;
+        private readonly Algorithm.ElevationModel _em;
         private readonly List<ISegmentString> _inputEdges = new List<ISegmentString>();
         private INoder _customNoder;
 
@@ -76,8 +77,21 @@ namespace NetTopologySuite.Operation.OverlayNG
         /// <param name="pm">The precision model to use</param>
         /// <param name="noder">An optional noder to use (may be null)</param>
         public EdgeNodingBuilder(PrecisionModel pm, INoder noder)
+            :this(pm, null, noder)
+        { }
+
+        /// <summary>
+        /// Creates a new builder, with an optional custom noder.
+        /// If the noder is not provided, a suitable one will
+        /// be used based on the supplied precision model.
+        /// </summary>
+        /// <param name="pm">The precision model to use</param>
+        /// <param name="em">The elevation model to use. May be <c>null</c></param>
+        /// <param name="noder">An optional noder to use (may be null)</param>
+        public EdgeNodingBuilder(PrecisionModel pm, Algorithm.ElevationModel em, INoder noder)
         {
             _pm = pm;
+            _em = em;
             _customNoder = noder;
         }
 
@@ -96,8 +110,8 @@ namespace NetTopologySuite.Operation.OverlayNG
             {
                 if (_customNoder != null) return _customNoder;
                 if (OverlayUtility.IsFloating(_pm))
-                    return CreateFloatingPrecisionNoder(IsNodingValidated);
-                return CreateFixedPrecisionNoder(_pm);
+                    return CreateFloatingPrecisionNoder(IsNodingValidated, _em);
+                return CreateFixedPrecisionNoder(_pm, _em);
             }
             set => _customNoder = value;
         }

--- a/src/NetTopologySuite/Operation/OverlayNG/ElevationModel.cs
+++ b/src/NetTopologySuite/Operation/OverlayNG/ElevationModel.cs
@@ -26,7 +26,7 @@ namespace NetTopologySuite.Operation.OverlayNG
     /// in an overlay result geometry.
     /// </summary>
     /// <author>Martin Davis</author>
-    class ElevationModel
+    class ElevationModel : Algorithm.ElevationModel
     {
 
         private const int DEFAULT_CELL_NUM = 3;
@@ -71,7 +71,8 @@ namespace NetTopologySuite.Operation.OverlayNG
         /// <param name="extent">The XY extent to cover</param>
         /// <param name="numCellX">The number of grid cells in the X dimension</param>
         /// <param name="numCellY">The number of grid cells in the Y dimension</param>
-        public ElevationModel(Envelope extent, int numCellX, int numCellY)
+        public ElevationModel(Envelope extent, int numCellX, int numCellY) :
+            base(double.NaN, extent)
         {
             _extent = extent;
             _numCellX = numCellX;
@@ -147,17 +148,19 @@ namespace NetTopologySuite.Operation.OverlayNG
         /// If the model has no elevation computed (i.e. due
         /// to empty input), the value is returned as <see cref="double.NaN"/>
         /// </summary>
-        /// <param name="x">x-ordinate of the location</param>
-        /// <param name="y">y-ordinate of the location</param>
+        /// <param name="xy">xy-ordinate of the location</param>
+        /// <param name="z">z-ordinate of the location</param>
         /// <returns>The computed Z value</returns>
-        public double GetZ(double x, double y)
+        public override void GetZ(ReadOnlySpan<double> xy, Span<double> z)
         {
             if (!_isInitialized)
                 Init();
-            var cell = GetCell(x, y, false);
-            if (cell == null)
-                return _averageZ;
-            return cell.Z;
+
+            for (int i = 0, j = 0; i < z.Length; i++)
+            {
+                var cell = GetCell(xy[j++], xy[j++], false);
+                z[i] = cell == null ? _averageZ : cell.Z;
+            }
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Operation/OverlayNG/OverlayNG.cs
+++ b/src/NetTopologySuite/Operation/OverlayNG/OverlayNG.cs
@@ -294,6 +294,7 @@ namespace NetTopologySuite.Operation.OverlayNG
         private readonly InputGeometry _inputGeom;
         private readonly GeometryFactory _geomFact;
         private readonly PrecisionModel _pm;
+        private readonly Algorithm.ElevationModel _em;
         private bool _isOutputNodedEdges;
 
         /// <summary>
@@ -305,6 +306,25 @@ namespace NetTopologySuite.Operation.OverlayNG
         /// <param name="pm">The precision model to use</param>
         /// <param name="opCode">The overlay opcode</param>
         public OverlayNG(Geometry geom0, Geometry geom1, PrecisionModel pm, SpatialFunction opCode)
+            : this(geom0, geom1, pm, GetElevationModel(geom0, geom1), opCode)
+        { }
+
+        private static Algorithm.ElevationModel GetElevationModel(Geometry geom0, Geometry geom1)
+        {
+            return (geom1 == null || geom0.Factory == geom1.Factory) ? geom0.Factory.ElevationModel : (ElevationModel)null;
+        }
+
+
+        /// <summary>
+        /// Creates an overlay operation on the given geometries,
+        /// with a defined precision model.
+        /// </summary>
+        /// <param name="geom0">The A operand geometry</param>
+        /// <param name="geom1">The B operand geometry (may be <c>null</c>)</param>
+        /// <param name="pm">The precision model to use</param>
+        /// <param name="em">The elevation model to use. May be <c>null</c></param>
+        /// <param name="opCode">The overlay opcode</param>
+        public OverlayNG(Geometry geom0, Geometry geom1, PrecisionModel pm, Algorithm.ElevationModel em, SpatialFunction opCode)
         {
             if (geom0 == null)
             {
@@ -324,6 +344,7 @@ namespace NetTopologySuite.Operation.OverlayNG
             }
 
             _pm = pm;
+            _em = em;
             _opCode = opCode;
             _geomFact = geom0.Factory;
             _inputGeom = new InputGeometry(geom0, geom1);
@@ -499,7 +520,7 @@ namespace NetTopologySuite.Operation.OverlayNG
             /*
              * Node the edges, using whatever noder is being used
              */
-            var nodingBuilder = new EdgeNodingBuilder(_pm, Noder);
+            var nodingBuilder = new EdgeNodingBuilder(_pm, _em, Noder);
 
             /*
              * Optimize Intersection and Difference by clipping to the 

--- a/src/NetTopologySuite/Operation/OverlayNG/OverlayNGRobust.cs
+++ b/src/NetTopologySuite/Operation/OverlayNG/OverlayNGRobust.cs
@@ -257,7 +257,7 @@ namespace NetTopologySuite.Operation.OverlayNG
         private static Geometry SnapSelf(Geometry geom, double snapTol)
         {
             var ov = new OverlayNG(geom, null);
-            var snapNoder = new SnappingNoder(snapTol);
+            var snapNoder = new SnappingNoder(snapTol, geom.Factory.ElevationModel);
             ov.Noder = snapNoder;
             /*
              * Ensure the result is not mixed-dimension,
@@ -270,7 +270,7 @@ namespace NetTopologySuite.Operation.OverlayNG
 
         private static Geometry OverlaySnapTol(Geometry geom0, Geometry geom1, SpatialFunction opCode, double snapTol)
         {
-            var snapNoder = new SnappingNoder(snapTol);
+            var snapNoder = new SnappingNoder(snapTol, geom0.Factory.ElevationModel);
             return OverlayNG.Overlay(geom0, geom1, opCode, snapNoder);
         }
 

--- a/src/NetTopologySuite/Operation/Predicate/SegmentIntersectionTester.cs
+++ b/src/NetTopologySuite/Operation/Predicate/SegmentIntersectionTester.cs
@@ -12,7 +12,7 @@ namespace NetTopologySuite.Operation.Predicate
     public class SegmentIntersectionTester
     {
         // for purposes of intersection testing, don't need to set precision model
-        private readonly LineIntersector li = new RobustLineIntersector();
+        private readonly LineIntersector _li = new RobustLineIntersector(ElevationModel.NoZ);
 
         private bool _hasIntersection;
         private readonly Coordinate pt00 = new Coordinate();
@@ -53,8 +53,8 @@ namespace NetTopologySuite.Operation.Predicate
                 {
                     seq1.GetCoordinate(j - 1, pt10);
                     seq1.GetCoordinate(j, pt11);
-                    li.ComputeIntersection(pt00, pt01, pt10, pt11);
-                    if (li.HasIntersection)
+                    _li.ComputeIntersection(pt00, pt01, pt10, pt11);
+                    if (_li.HasIntersection)
                         _hasIntersection = true;
                 }
             }

--- a/src/NetTopologySuite/Operation/Relate/RelateComputer.cs
+++ b/src/NetTopologySuite/Operation/Relate/RelateComputer.cs
@@ -21,7 +21,7 @@ namespace NetTopologySuite.Operation.Relate
     /// </summary>
     public class RelateComputer
     {
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li;
         private readonly PointLocator _ptLocator = new PointLocator();
         private readonly GeometryGraph[] _arg;     // the arg(s) of the operation
         private readonly NodeMap _nodes = new NodeMap(new RelateNodeFactory());
@@ -32,7 +32,11 @@ namespace NetTopologySuite.Operation.Relate
         /// </summary>
         /// <param name="arg"></param>
         public RelateComputer(GeometryGraph[] arg)
+            : this(null, arg) { }
+
+        public RelateComputer(ElevationModel em, GeometryGraph[] arg)
         {
+            _li = new RobustLineIntersector(em);
             _arg = arg;
         }
 

--- a/src/NetTopologySuite/Operation/RelateNG/EdgeSegmentIntersector.cs
+++ b/src/NetTopologySuite/Operation/RelateNG/EdgeSegmentIntersector.cs
@@ -11,11 +11,17 @@ namespace NetTopologySuite.Operation.RelateNG
     /// <author>Martin Davis</author>
     internal class EdgeSegmentIntersector : ISegmentIntersector
     {
-        private readonly RobustLineIntersector _li = new RobustLineIntersector();
+        private readonly RobustLineIntersector _li;
         private readonly TopologyComputer _topoComputer;
 
         public EdgeSegmentIntersector(TopologyComputer topoComputer)
+            :this(null, topoComputer)
         {
+        }
+
+        public EdgeSegmentIntersector(ElevationModel em, TopologyComputer topoComputer)
+        {
+            _li = new RobustLineIntersector(em);
             _topoComputer = topoComputer;
         }
 

--- a/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
+++ b/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
@@ -257,7 +257,8 @@ namespace NetTopologySuite.Operation.Valid
         {
             if (geom.IsEmpty) return true;
             var segStrings = ExtractSegmentStrings(geom);
-            var segInt = new NonSimpleIntersectionFinder(_isClosedEndpointsInInterior, FindAllLocations, _nonSimplePts);
+            var segInt = new NonSimpleIntersectionFinder(geom.Factory.ElevationModel,
+                _isClosedEndpointsInInterior, FindAllLocations, _nonSimplePts);
             var noder = new MCIndexNoder();
             noder.SegmentIntersector = segInt;
             noder.ComputeNodes(segStrings);
@@ -323,7 +324,7 @@ namespace NetTopologySuite.Operation.Valid
             private readonly bool _isClosedEndpointsInInterior;
             private readonly bool _isFindAll;
 
-            readonly LineIntersector _li = new RobustLineIntersector();
+            private readonly LineIntersector _li;
             private readonly List<Coordinate> _intersectionPts;
 
             //private bool _hasInteriorInt;
@@ -337,9 +338,10 @@ namespace NetTopologySuite.Operation.Valid
             /// <param name="isClosedEndpointsInInterior">A flag indicating if closed endpoints belong to the interior</param>
             /// <param name="isFindAll">A flag indicating that all non-simple intersection points should be found</param>
             /// <param name="intersectionPts">A list to add the non-simple intersection points to.</param>
-            public NonSimpleIntersectionFinder(bool isClosedEndpointsInInterior, bool isFindAll,
+            public NonSimpleIntersectionFinder(ElevationModel em, bool isClosedEndpointsInInterior, bool isFindAll,
                 List<Coordinate> intersectionPts)
             {
+                _li = new RobustLineIntersector(em);
                 _isClosedEndpointsInInterior = isClosedEndpointsInInterior;
                 _isFindAll = isFindAll;
                 _intersectionPts = intersectionPts;

--- a/src/NetTopologySuite/Operation/Valid/PolygonIntersectionAnalyzer.cs
+++ b/src/NetTopologySuite/Operation/Valid/PolygonIntersectionAnalyzer.cs
@@ -19,7 +19,7 @@ namespace NetTopologySuite.Operation.Valid
         //private const int NoInvalidIntersection = -1;
         private readonly bool _isInvertedRingValid;
 
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li;
         private TopologyValidationErrors _invalidCode = TopologyValidationErrors.NoInvalidIntersection;
         private Coordinate _invalidLocation;
 
@@ -31,8 +31,17 @@ namespace NetTopologySuite.Operation.Valid
         /// </summary>
         /// <param name="isInvertedRingValid"><c>true</c> if inverted rings are valid.</param>
         public PolygonIntersectionAnalyzer(bool isInvertedRingValid)
+            : this(isInvertedRingValid, null) { }
+
+        /// <summary>
+        /// Creates a new finder, allowing for the mode where inverted rings are valid.
+        /// </summary>
+        /// <param name="isInvertedRingValid"><c>true</c> if inverted rings are valid.</param>
+        /// <param name="em"></param>
+        public PolygonIntersectionAnalyzer(bool isInvertedRingValid, ElevationModel em)
         {
             _isInvertedRingValid = isInvertedRingValid;
+            _li = new RobustLineIntersector(em);
         }
 
         public bool IsDone => IsInvalid || _hasDoubleTouch;

--- a/src/NetTopologySuite/Operation/Valid/PolygonTopologyAnalyzer.cs
+++ b/src/NetTopologySuite/Operation/Valid/PolygonTopologyAnalyzer.cs
@@ -309,7 +309,7 @@ namespace NetTopologySuite.Operation.Valid
                 return;
             var segStrings = CreateSegmentStrings(geom, _isInvertedRingValid);
             _polyRings = GetPolygonRings(segStrings);
-            _intFinder = AnalyzeIntersections(segStrings);
+            _intFinder = AnalyzeIntersections(geom.Factory.ElevationModel, segStrings);
 
             if (_intFinder.HasDoubleTouch)
             {
@@ -318,9 +318,9 @@ namespace NetTopologySuite.Operation.Valid
             }
         }
 
-        private PolygonIntersectionAnalyzer AnalyzeIntersections(IList<ISegmentString> segStrings)
+        private PolygonIntersectionAnalyzer AnalyzeIntersections(ElevationModel em, IList<ISegmentString> segStrings)
         {
-            var segInt = new PolygonIntersectionAnalyzer(_isInvertedRingValid);
+            var segInt = new PolygonIntersectionAnalyzer(_isInvertedRingValid, em);
             var noder = new MCIndexNoder();
             noder.SegmentIntersector = segInt;
             noder.ComputeNodes(segStrings);

--- a/src/NetTopologySuite/Simplify/TaggedLineStringSimplifier.cs
+++ b/src/NetTopologySuite/Simplify/TaggedLineStringSimplifier.cs
@@ -1,8 +1,6 @@
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
 using System;
-using System.Diagnostics;
-using System.Net.NetworkInformation;
 
 namespace NetTopologySuite.Simplify
 {
@@ -13,7 +11,7 @@ namespace NetTopologySuite.Simplify
     /// </summary>
     public class TaggedLineStringSimplifier
     {
-        private readonly LineIntersector _li = new RobustLineIntersector();
+        private readonly LineIntersector _li = new RobustLineIntersector(ElevationModel.NoZ);
         private readonly LineSegmentIndex _inputIndex;
         private readonly LineSegmentIndex _outputIndex;
         private readonly ComponentJumpChecker _jumpChecker;

--- a/src/NetTopologySuite/Triangulate/Polygon/PolygonHoleJoiner.cs
+++ b/src/NetTopologySuite/Triangulate/Polygon/PolygonHoleJoiner.cs
@@ -122,7 +122,7 @@ namespace NetTopologySuite.Triangulate.Polygon
 
         private void NodeRings()
         {
-            var noder = new PolygonNoder(_shellRing, _holeRings);
+            var noder = new PolygonNoder(_shellRing, _holeRings, _inputPolygon.Factory.ElevationModel);
             noder.Node();
             if (noder.IsShellNoded)
             {
@@ -473,7 +473,7 @@ namespace NetTopologySuite.Triangulate.Polygon
         private class InteriorIntersectionDetector : ISegmentIntersector
         {
 
-            private readonly LineIntersector li = new RobustLineIntersector();
+            private readonly LineIntersector _li = new RobustLineIntersector(ElevationModel.NoZ);
 
             public bool HasIntersection { get; private set; }
 
@@ -484,14 +484,14 @@ namespace NetTopologySuite.Triangulate.Polygon
                 var p10 = ss1.Coordinates[segIndex1];
                 var p11 = ss1.Coordinates[segIndex1 + 1];
 
-                li.ComputeIntersection(p00, p01, p10, p11);
-                if (li.IntersectionNum == 0)
+                _li.ComputeIntersection(p00, p01, p10, p11);
+                if (_li.IntersectionNum == 0)
                 {
                     return;
                 }
-                else if (li.IntersectionNum == 1)
+                else if (_li.IntersectionNum == 1)
                 {
-                    if (li.IsInteriorIntersection())
+                    if (_li.IsInteriorIntersection())
                         HasIntersection = true;
                 }
                 else

--- a/src/NetTopologySuite/Triangulate/Tri/Tri.cs
+++ b/src/NetTopologySuite/Triangulate/Tri/Tri.cs
@@ -408,7 +408,7 @@ namespace NetTopologySuite.Triangulate.Tri
             Assert.IsTrue(e1.Equals2D(n0), "Edge coord not equal");
 
             //--- check that no edges cross
-            var li = new RobustLineIntersector();
+            var li = new RobustLineIntersector(ElevationModel.NoZ);
             for (int i = 0; i < 3; i++)
             {
                 for (int j = 0; j < 3; j++)

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/ElevationModelTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/ElevationModelTest.cs
@@ -1,0 +1,122 @@
+﻿using NetTopologySuite.Algorithm;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Tests.NUnit.Algorithm
+{
+    internal class ElevationModelTest
+    {
+        [Test]
+        public void TestDefaultConstructor()
+        {
+            var emdl = new ElevationModel();
+            Assert.That(emdl, Is.Not.Null);
+            Assert.That(emdl.Extent, Is.Null);
+            Assert.That(emdl.SRID, Is.EqualTo(0));
+
+            foreach ((var pos, double z) in SamplePosZs(double.NaN))
+                Assert.That(emdl.GetZ(pos), Is.EqualTo(double.NaN));
+        }
+
+        [Test]
+        public void TestConstructorWithDefaultZValue()
+        {
+            var emdl = new ElevationModel(1d);
+            Assert.That(emdl, Is.Not.Null);
+            Assert.That(emdl.Extent, Is.Null);
+            Assert.That(emdl.SRID, Is.EqualTo(0));
+
+            foreach((var pos, double z) in SamplePosZs(1d))
+                Assert.That(emdl.GetZ(pos), Is.EqualTo(1d));
+        }
+
+        [TestCase(4326, -10, 10, 30, 60, 10)]
+        public void TestConstructorWithAllArguments(int srid, double minX, double maxX, double minY, double maxY, double defaultZ)
+        {
+            var emdl = new ElevationModel(defaultZ, new Envelope(minX, maxX, minY, maxY), srid);
+
+            Assert.That(emdl, Is.Not.Null);
+            Assert.That(emdl.Extent, Is.Not.Null);
+            Assert.That(emdl.SRID, Is.EqualTo(srid));
+
+            int i = 0;
+            foreach ((var pos, double z) in SamplePosZs(emdl.Extent, defaultZ))
+            {
+                Assert.That(emdl.GetZ(pos), Is.EqualTo(z), $"Assertion failed for test position {i} at {pos}.");
+                i++;
+            }
+        }
+
+        [Test]
+        public void TestCopyWithZ()
+        {
+            var emdl = new ElevationModel(10);
+
+            var pos = new Coordinate(1, 1);
+            var posZ = emdl.CopyWithZ(pos);
+            Assert.That(posZ, Is.Not.Null);
+            Assert.That(posZ, Is.TypeOf<CoordinateZ>());
+            Assert.That(posZ.Z, Is.EqualTo(10));
+
+            pos = new CoordinateZ(1, 1, 9);
+            posZ = emdl.CopyWithZ(pos);
+            Assert.That(posZ, Is.Not.Null);
+            Assert.That(posZ, Is.TypeOf<CoordinateZ>());
+            Assert.That(posZ.Z, Is.EqualTo(9));
+
+            pos = new CoordinateM(1, 1, 8);
+            posZ = emdl.CopyWithZ(pos);
+            Assert.That(posZ, Is.Not.Null);
+            Assert.That(posZ, Is.TypeOf<CoordinateZM>());
+            Assert.That(posZ.Z, Is.EqualTo(10));
+            Assert.That(posZ.M, Is.EqualTo(8));
+        }
+
+        private static IEnumerable<(Coordinate pos, double z)> SamplePosZs(double defaultZ)
+        {
+            yield return (new Coordinate(), defaultZ);
+        }
+
+
+        private static IEnumerable<(Coordinate pos, double z)> SamplePosZs(Envelope extent, double defaultZ)
+        {
+            if (extent == null || extent.Area == 0d)
+            {
+                Assert.Ignore("extent is null or empty");
+                yield break;
+            }
+
+            double testDX = 0.1 * extent.Width;
+            double testDY = 0.1 * extent.Height;
+
+            yield return (extent.Centre, defaultZ);
+
+            // left bottom
+            yield return (new Coordinate(extent.MinX, extent.MinY), defaultZ);
+            yield return (new Coordinate(extent.MinX - testDX, extent.MinY), Coordinate.NullOrdinate);
+            yield return (new Coordinate(extent.MinX + testDX, extent.MinY), defaultZ);
+            yield return (new Coordinate(extent.MinX, extent.MinY - testDY), Coordinate.NullOrdinate);
+            yield return (new Coordinate(extent.MinX, extent.MinY + testDY), defaultZ);
+            //left top
+            yield return (new Coordinate(extent.MinX, extent.MaxY), defaultZ);
+            yield return (new Coordinate(extent.MinX - testDX, extent.MaxY), Coordinate.NullOrdinate);
+            yield return (new Coordinate(extent.MinX + testDX, extent.MaxY), defaultZ);
+            yield return (new Coordinate(extent.MinX, extent.MaxY - testDY), defaultZ);
+            yield return (new Coordinate(extent.MinX, extent.MaxY + testDY), Coordinate.NullOrdinate);
+            //right top
+            yield return (new Coordinate(extent.MaxX, extent.MaxY), defaultZ);
+            yield return (new Coordinate(extent.MaxX - testDX, extent.MaxY), defaultZ);
+            yield return (new Coordinate(extent.MaxX + testDX, extent.MaxY), Coordinate.NullOrdinate);
+            yield return (new Coordinate(extent.MaxX, extent.MaxY - testDY), defaultZ);
+            yield return (new Coordinate(extent.MaxX, extent.MaxY + testDY), Coordinate.NullOrdinate);
+            //right bottom
+            yield return (new Coordinate(extent.MaxX, extent.MinY), defaultZ);
+            yield return (new Coordinate(extent.MaxX - testDX, extent.MinY), defaultZ);
+            yield return (new Coordinate(extent.MaxX + testDX, extent.MinY), Coordinate.NullOrdinate);
+            yield return (new Coordinate(extent.MaxX, extent.MinY - testDY), Coordinate.NullOrdinate);
+            yield return (new Coordinate(extent.MaxX, extent.MinY + testDY), defaultZ);
+        }
+
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/ElevationModelTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/ElevationModelTest.cs
@@ -13,7 +13,6 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm
             var emdl = new ElevationModel();
             Assert.That(emdl, Is.Not.Null);
             Assert.That(emdl.Extent, Is.Null);
-            Assert.That(emdl.SRID, Is.EqualTo(0));
 
             foreach ((var pos, double z) in SamplePosZs(double.NaN))
                 Assert.That(emdl.GetZ(pos), Is.EqualTo(double.NaN));
@@ -25,20 +24,18 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm
             var emdl = new ElevationModel(1d);
             Assert.That(emdl, Is.Not.Null);
             Assert.That(emdl.Extent, Is.Null);
-            Assert.That(emdl.SRID, Is.EqualTo(0));
 
             foreach((var pos, double z) in SamplePosZs(1d))
                 Assert.That(emdl.GetZ(pos), Is.EqualTo(1d));
         }
 
-        [TestCase(4326, -10, 10, 30, 60, 10)]
-        public void TestConstructorWithAllArguments(int srid, double minX, double maxX, double minY, double maxY, double defaultZ)
+        [TestCase(-10, 10, 30, 60, 10)]
+        public void TestConstructorWithAllArguments(double minX, double maxX, double minY, double maxY, double defaultZ)
         {
-            var emdl = new ElevationModel(defaultZ, new Envelope(minX, maxX, minY, maxY), srid);
+            var emdl = new ElevationModel(defaultZ, new Envelope(minX, maxX, minY, maxY));
 
             Assert.That(emdl, Is.Not.Null);
             Assert.That(emdl.Extent, Is.Not.Null);
-            Assert.That(emdl.SRID, Is.EqualTo(srid));
 
             int i = 0;
             foreach ((var pos, double z) in SamplePosZs(emdl.Extent, defaultZ))
@@ -77,7 +74,6 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm
         {
             yield return (new Coordinate(), defaultZ);
         }
-
 
         private static IEnumerable<(Coordinate pos, double z)> SamplePosZs(Envelope extent, double defaultZ)
         {

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/ExtraDimensionalCoordinateTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/ExtraDimensionalCoordinateTest.cs
@@ -1,0 +1,111 @@
+﻿using NetTopologySuite.Geometries;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries
+{
+    public class ExtraDimensionalCoordinateTest
+    {
+        [Test]
+        public void TestCreate4DM2()
+        {
+            var edc = new ExtraDimensionalCoordinate(4, 2);
+            Assert.That(edc, Is.Not.Null);
+            Assert.That(edc.Dimension == 4);
+            Assert.That(edc.Measures == 2);
+            Assert.That(edc.Z, Is.EqualTo(double.NaN));
+        }
+
+        [Test]
+        public void TestIncreaseDimension()
+        {
+            var edc0 = new ExtraDimensionalCoordinate(4, 2) { X = 10, Y = 11 };
+            edc0[Ordinate.Measure1] = 20;
+            edc0[Ordinate.Measure2] = 21;
+
+            var edc1 = new ExtraDimensionalCoordinate(edc0.Dimension + 1, edc0.Measures) { CoordinateValue = edc0, Z = 1 };
+            Assert.That(edc1.Dimension == 5);
+            Assert.That(edc1.Measures == 2);
+            Assert.That(edc1.X, Is.EqualTo(10d));
+            Assert.That(edc1.Y, Is.EqualTo(11d));
+            Assert.That(edc1.Z, Is.EqualTo(1d));
+            Assert.That(edc1[Ordinate.Measure1], Is.EqualTo(20d));
+            Assert.That(edc1[Ordinate.Measure2], Is.EqualTo(21d));
+        }
+
+        [TestCase(2, 0, 2, 0)]
+        [TestCase(3, 0, 2, 0)]
+        [TestCase(3, 1, 2, 0)]
+        [TestCase(4, 1, 3, 0)]
+        [TestCase(4, 2, 3, 1)]
+        [TestCase(4, 2, 3, 2)]
+        [TestCase(4, 2, 2, 2)]
+        [TestCase(3, 0, 4, 1)]
+        [TestCase(3, 1, 4, 2)]
+        [TestCase(3, 2, 4, 2)]
+        [TestCase(2, 2, 4, 2)]
+        public void TestCoordinateValue(int numSpatialFrom, int numMeasuresFrom, int numSpatialTo, int numMeasuresTo)
+        {
+            var fromCoord = Create(numSpatialFrom, numMeasuresFrom);
+            var toCoord = Create(numSpatialTo, numMeasuresTo, false);
+
+            toCoord.CoordinateValue = fromCoord;
+
+            CheckEqual(fromCoord, toCoord, numSpatialFrom == numSpatialTo && numMeasuresFrom == numMeasuresTo);
+        }
+
+        private void CheckEqual(ExtraDimensionalCoordinate c0, ExtraDimensionalCoordinate c1, bool everything)
+        {
+            if (everything)
+            {
+                Assert.That(c1.Dimension, Is.EqualTo(c0.Dimension));
+                Assert.That(c1.Measures, Is.EqualTo(c0.Measures));
+            }
+
+            Assert.That(c1.X, Is.EqualTo(c0.X));
+            Assert.That(c1.Y, Is.EqualTo(c0.Y));
+            Assert.That(c1.X, Is.EqualTo(c0.X));
+            Assert.That(c1.Y, Is.EqualTo(c0.Y));
+
+            int numSpatial0 = c0.Dimension - c0.Measures;
+            int numSpatial1 = c1.Dimension - c1.Measures;
+
+            if (numSpatial0 > 2 && numSpatial1 > 2)
+                Assert.That(c0.Z, Is.EqualTo(c1.Z));
+            else if (numSpatial1 == 2)
+                Assert.That(c1.Z, Is.EqualTo(double.NaN));
+
+            int numSpatialToTest = System.Math.Min(numSpatial0, numSpatial1);
+            int i = 0;
+            for (; i < numSpatialToTest; i++)
+                Assert.That(c1[i], Is.EqualTo(c0[i]), $"this[{i}] values differ: {c0[i]} != {c1[i]}");
+
+            int numMeasuresToTest = System.Math.Min(c0.Measures, c1.Measures);
+            int j0 = numSpatial0;
+            int j1 = numSpatial1;
+            for (i = 0; i < numMeasuresToTest; i++, j0++, j1++)
+            {
+                Assert.That(c1[j1], Is.EqualTo(c0[j0]), $"this[{i}] values differ: {c0[j0]} != {c1[j1]}");
+            }
+        }
+
+        private static ExtraDimensionalCoordinate Create(int numSpatial, int numMeasures, bool initValues = true)
+        {
+            if (numSpatial < 2 || numSpatial > 16)
+                Assert.Ignore($"Number of spatial dimensions ({numSpatial}) is out of range \u2115[2..16]");
+            if (numMeasures < 0 || numMeasures > 16)
+                Assert.Ignore($"Number of measure dimensions ({numMeasures}) is out of range \u2115[0..16]");
+
+            var res = new ExtraDimensionalCoordinate(numSpatial + numMeasures, numMeasures);
+            if (initValues)
+            {
+                int i = 0;
+                for (; i < numSpatial; i++)
+                    res[i] = 10 + i;
+                for (; i < res.Dimension; i++)
+                    res[i] = 50 + i;
+            }
+            return res;
+        }
+
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/ExtraDimensionalCoordinateTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/ExtraDimensionalCoordinateTest.cs
@@ -8,23 +8,27 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         [Test]
         public void TestCreate4DM2()
         {
-            var edc = new ExtraDimensionalCoordinate(4, 2);
+            var edc = Coordinates.Create(4, 2);
             Assert.That(edc, Is.Not.Null);
-            Assert.That(edc.Dimension == 4);
-            Assert.That(edc.Measures == 2);
+            Assert.That(Coordinates.Dimension(edc) == 4);
+            Assert.That(Coordinates.Measures(edc) == 2);
             Assert.That(edc.Z, Is.EqualTo(double.NaN));
         }
 
         [Test]
         public void TestIncreaseDimension()
         {
-            var edc0 = new ExtraDimensionalCoordinate(4, 2) { X = 10, Y = 11 };
+            var edc0 = Coordinates.Create(4, 2);
+            edc0.X = 10;
+            edc0.Y = 11;
             edc0[Ordinate.Measure1] = 20;
             edc0[Ordinate.Measure2] = 21;
 
-            var edc1 = new ExtraDimensionalCoordinate(edc0.Dimension + 1, edc0.Measures) { CoordinateValue = edc0, Z = 1 };
-            Assert.That(edc1.Dimension == 5);
-            Assert.That(edc1.Measures == 2);
+            var edc1 = Coordinates.Create(Coordinates.Dimension(edc0) + 1, Coordinates.Measures(edc0));
+            edc1.CoordinateValue = edc0;
+            edc1.Z = 1;
+            Assert.That(Coordinates.Dimension(edc1) == 5);
+            Assert.That(Coordinates.Measures(edc1) == 2);
             Assert.That(edc1.X, Is.EqualTo(10d));
             Assert.That(edc1.Y, Is.EqualTo(11d));
             Assert.That(edc1.Z, Is.EqualTo(1d));
@@ -53,19 +57,19 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             CheckEqual(fromCoord, toCoord, numSpatialFrom == numSpatialTo && numMeasuresFrom == numMeasuresTo);
         }
 
-        private void CheckEqual(ExtraDimensionalCoordinate c0, ExtraDimensionalCoordinate c1, bool everything)
+        private void CheckEqual(Coordinate c0, Coordinate c1, bool everything)
         {
             if (everything)
             {
-                Assert.That(c1.Dimension, Is.EqualTo(c0.Dimension));
-                Assert.That(c1.Measures, Is.EqualTo(c0.Measures));
+                Assert.That(Coordinates.Dimension(c1), Is.EqualTo(Coordinates.Dimension(c0)));
+                Assert.That(Coordinates.Measures(c1), Is.EqualTo(Coordinates.Measures(c0)));
             }
 
             Assert.That(c1.X, Is.EqualTo(c0.X));
             Assert.That(c1.Y, Is.EqualTo(c0.Y));
 
-            int numSpatial0 = c0.Dimension - c0.Measures;
-            int numSpatial1 = c1.Dimension - c1.Measures;
+            int numSpatial0 = Coordinates.Dimension(c0) - Coordinates.Measures(c0);
+            int numSpatial1 = Coordinates.Dimension(c1) - Coordinates.Measures(c1);
 
             if (numSpatial0 > 2 && numSpatial1 > 2)
                 Assert.That(c0.Z, Is.EqualTo(c1.Z));
@@ -77,7 +81,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             for (; i < numSpatialToTest; i++)
                 Assert.That(c1[i], Is.EqualTo(c0[i]), $"this[{i}] values differ: {c0[i]} != {c1[i]}");
 
-            int numMeasuresToTest = System.Math.Min(c0.Measures, c1.Measures);
+            int numMeasuresToTest = System.Math.Min(Coordinates.Measures(c0), Coordinates.Measures(c1));
             int j0 = numSpatial0;
             int j1 = numSpatial1;
             for (i = 0; i < numMeasuresToTest; i++, j0++, j1++)
@@ -86,20 +90,20 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
             }
         }
 
-        private static ExtraDimensionalCoordinate Create(int numSpatial, int numMeasures, bool initValues = true)
+        private static Coordinate Create(int numSpatial, int numMeasures, bool initValues = true)
         {
             if (numSpatial < 2 || numSpatial > 16)
                 Assert.Ignore($"Number of spatial dimensions ({numSpatial}) is out of range \u2115[2..16]");
             if (numMeasures < 0 || numMeasures > 16)
                 Assert.Ignore($"Number of measure dimensions ({numMeasures}) is out of range \u2115[0..16]");
 
-            var res = new ExtraDimensionalCoordinate(numSpatial + numMeasures, numMeasures);
+            var res = Coordinates.Create(numSpatial + numMeasures, numMeasures);
             if (initValues)
             {
                 int i = 0;
                 for (; i < numSpatial; i++)
                     res[i] = 10 + i;
-                for (; i < res.Dimension; i++)
+                for (; i < Coordinates.Dimension(res); i++)
                     res[i] = 50 + i;
             }
             return res;

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/ExtraDimensionalCoordinateTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/ExtraDimensionalCoordinateTest.cs
@@ -63,8 +63,6 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
 
             Assert.That(c1.X, Is.EqualTo(c0.X));
             Assert.That(c1.Y, Is.EqualTo(c0.Y));
-            Assert.That(c1.X, Is.EqualTo(c0.X));
-            Assert.That(c1.Y, Is.EqualTo(c0.Y));
 
             int numSpatial0 = c0.Dimension - c0.Measures;
             int numSpatial1 = c1.Dimension - c1.Measures;


### PR DESCRIPTION
Based on previous attempts to get `RobustLineIntersector` to work with an elevation model I have come up with this variant.

At its hart we have the (base) `ElevationModel` class that returns a pre-defined z-ordinate value for every `GetZ(Coordinate)` call.
Derived from it we now have a `LocalElevationModel` that is private to `RobustLineIntersector` and implements the logic currently used to get or interpolate z-ordinate values inside `RobustLineIntersector`.

The elevation model to use is created by a factory method that
1. looks for assigned elevation model and use that if present
2. checks if a `LocalElevationModel` should be created and used
3. returns a double.NaN returning elevation model.

I'd like input on the overall design. Suggestions for a better factory method/maybe strategy class or delegate.
There are some methods on ElevationModel that are currently not used but might help in looking for an appropriate elevation model. We can ditch/change/append these.

@bjornharrtell please have a look, too.