### PR TITLE
Fix OffsetCurve simplifyFactor parameter handling

### DIFF
--- a/src/NetTopologySuite/Operation/Buffer/OffsetCurve.cs
+++ b/src/NetTopologySuite/Operation/Buffer/OffsetCurve.cs
@@ -154,6 +154,7 @@ namespace NetTopologySuite.Operation.Buffer
                 _bufferParams.QuadrantSegments = quadSegs;
                 _bufferParams.JoinStyle = bufParams.JoinStyle;
                 _bufferParams.MitreLimit = bufParams.MitreLimit;
+                _bufferParams.SimplifyFactor = bufParams.SimplifyFactor;
             }
         }
 

--- a/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/OffsetCurveTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/OffsetCurveTest.cs
@@ -445,6 +445,17 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Buffer
             );
         }
 
+        //---------------------------------------
+
+        [Test]
+        public void TestSimplifyFactor()
+        {
+            CheckOffsetCurveSimplify(
+                "LINESTRING (-74.10825983114643 205.2512862651522, -61.59032155710979 183.66416102497575, -56.17516937041343 177.39645645603244, -45.87664216572637 163.28009296700202, -32.80606824944878 140.06145723770865)",
+                -70, 0.0001,
+                "LINESTRING (-134.66360133032907 170.13646580544648, -122.14566305629245 148.54934056527003, -114.55900733787851 137.9004382015626, -111.02744383471095 133.81287132602836, -104.85483126202604 125.3519680316891, -93.80502418590495 105.72303306503763)",
+                0.00001);
+        }
 
         //=======================================
 
@@ -499,6 +510,19 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Buffer
 
             if (wktExpected == null)
                 return;
+
+            var expected = Read(wktExpected);
+            CheckEqual(expected, result, tolerance);
+        }
+
+        private void CheckOffsetCurveSimplify(string wkt,
+            double distance, double simplifyFactor,
+            string wktExpected, double tolerance)
+        {
+            var geom = Read(wkt);
+            var param = new BufferParameters { SimplifyFactor = simplifyFactor };
+            var oc = new OffsetCurve(geom, distance, param);
+            var result = oc.GetCurve();
 
             var expected = Read(wktExpected);
             CheckEqual(expected, result, tolerance);

--- a/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/OffsetCurveTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/OffsetCurveTest.cs
@@ -446,7 +446,7 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Buffer
         }
 
         //---------------------------------------
-
+        // see https://github.com/locationtech/jts/issues/1147
         [Test]
         public void TestSimplifyFactor()
         {


### PR DESCRIPTION
Fix OffsetCurve simplifyFactor parameter handling

This copies the following fix in JTS:
See https://github.com/locationtech/jts/pull/1151/commits/727e2230079b925c1ed98a4d3cbbafb48217638e

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [X] I have provided test coverage for my change (where applicable)

### Description

As mentioned in [issue 790](https://github.com/NetTopologySuite/NetTopologySuite/issues/790) there is a bugfix in JTS related to the simplify parameter in the OffsetCurve algorithm. This PR copies that fix to NTS.