### PR TITLE
Fix BoundaryChainNoder to make CoverageUnion and CoverageGapFinder produce correct results (ports JTS fix)

### DIFF
--- a/src/NetTopologySuite/Noding/BasicSegmentString.cs
+++ b/src/NetTopologySuite/Noding/BasicSegmentString.cs
@@ -17,6 +17,17 @@ namespace NetTopologySuite.Noding
     public class BasicSegmentString : ISegmentString
     {
 
+        public static BasicSegmentString Substring(ISegmentString segString, int start, int end)
+        {
+            var pts = new Coordinate[end - start + 1];
+            int ipts = 0;
+            for (int i = start; i < end + 1; i++)
+            {
+                pts[ipts++] = segString.GetCoordinate(i).Copy();
+            }
+            return new BasicSegmentString(pts, segString.Context);
+        }
+
         private readonly Coordinate[] _pts;
 
         /// <summary>

--- a/src/NetTopologySuite/Noding/BoundaryChainNoder.cs
+++ b/src/NetTopologySuite/Noding/BoundaryChainNoder.cs
@@ -36,11 +36,17 @@ namespace NetTopologySuite.Noding
         /// <inheritdoc/>
         public void ComputeNodes(IList<ISegmentString> segStrings)
         {
-            var segSet = new HashSet<Segment>();
+            var boundarySegSet = new HashSet<Segment>();
             var boundaryChains = new BoundaryChainMap[segStrings.Count];
-            AddSegments(segStrings, segSet, boundaryChains);
-            MarkBoundarySegments(segSet);
+            AddSegments(segStrings, boundarySegSet, boundaryChains);
+            MarkBoundarySegments(boundarySegSet);
             _chainList = ExtractChains(boundaryChains);
+
+            // check for self-touching nodes and split chains at those nodes
+        var nodePts = FindNodePts(_chainList);
+            if (nodePts.Count > 0) {
+            _chainList = NodeChains(_chainList, nodePts);
+            }
         }
 
         private static void AddSegments(ICollection<ISegmentString> segStrings, HashSet<Segment> segSet,
@@ -85,6 +91,67 @@ namespace NetTopologySuite.Noding
                 chainMap.CreateChains(sectionList);
             }
             return sectionList;
+        }
+
+        private static HashSet<Coordinate> FindNodePts(ICollection<ISegmentString> segStrings)
+        {
+            var interorVertices = new HashSet<Coordinate>();
+            var nodes = new HashSet<Coordinate>();
+            foreach (var ss in segStrings)
+            {
+                // endpoints are nodes
+                nodes.Add(ss.GetCoordinate(0));
+                nodes.Add(ss.GetCoordinate(ss.Count - 1));
+
+                // check for duplicate interior points
+                for (int i = 1; i < ss.Count - 1; i++)
+                {
+                    var p = ss.GetCoordinate(i);
+                    if (interorVertices.Contains(p))
+                    {
+                        nodes.Add(p);
+                    }
+                    interorVertices.Add(p);
+                }
+            }
+            return nodes;
+        }
+
+        private static List<ISegmentString> NodeChains(List<ISegmentString> chains, HashSet<Coordinate> nodePts)
+        {
+            var nodedChains = new List<ISegmentString>();
+            foreach (var chain in chains)
+            {
+                NodeChain(chain, nodePts, nodedChains);
+            }
+            return nodedChains;
+        }
+
+        private static void NodeChain(ISegmentString chain, HashSet<Coordinate> nodePts, ICollection<ISegmentString> nodedChains)
+        {
+            int start = 0;
+            while (start < chain.Count - 1)
+            {
+                int end = FindNodeIndex(chain, start, nodePts);
+                // if no interior nodes found, keep original chain
+                if (start == 0 && end == chain.Count - 1)
+                {
+                    nodedChains.Add(chain);
+                    return;
+                }
+                nodedChains.Add(BasicSegmentString.Substring(chain, start, end));
+                start = end;
+            }
+        }
+
+        private static int FindNodeIndex(ISegmentString chain, int start, HashSet<Coordinate> nodePts)
+        {
+            for (int i = start + 1; i < chain.Count; i++)
+            {
+                if (nodePts.Contains(chain.GetCoordinate(i)))
+                    return i;
+            }
+            return chain.Count - 1;
         }
 
         /// <inheritdoc/>

--- a/test/NetTopologySuite.Tests.NUnit/Coverage/CoverageUnionTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Coverage/CoverageUnionTest.cs
@@ -25,6 +25,33 @@ namespace NetTopologySuite.Tests.NUnit.Coverage
                 );
         }
 
+        [Test]
+        public void TestHoleTouchingSide()
+        {
+            CheckUnion(
+                "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 5 3, 9 6, 9 1, 1 1)))",
+                "POLYGON ((9 6, 9 1, 1 1, 1 9, 9 9, 9 6), (9 6, 2 6, 5 3, 9 6))"
+                );
+        }
+
+        [Test]
+        public void TestHolesTouchingSide()
+        {
+            CheckUnion(
+                "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 9 6, 9 1, 1 1)))",
+                "POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 9 6, 5 7), (2 6, 4 3, 5 7, 2 6))"
+                );
+        }
+
+        [Test]
+        public void TestHolesTouching() {
+            CheckUnion(
+                "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 7 7, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 7 7, 9 6, 9 1, 1 1)))",
+                "POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 7 7, 5 7), (2 6, 4 3, 5 7, 2 6))"
+                );
+        }
+
+
         private void CheckUnion(string wktCoverage, string wktExpected)
         {
             var covGeom = Read(wktCoverage);

--- a/test/NetTopologySuite.Tests.NUnit/Operation/OverlayNG/CoverageUnionTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/OverlayNG/CoverageUnionTest.cs
@@ -28,6 +28,30 @@ namespace NetTopologySuite.Tests.NUnit.Operation.OverlayNG
         }
 
         [Test]
+        public void TestHoleTouchingSide()
+        {
+            CheckUnion(
+                "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 5 3, 9 6, 9 1, 1 1)))",
+                "POLYGON ((9 6, 9 1, 1 1, 1 9, 9 9, 9 6), (9 6, 2 6, 5 3, 9 6))");
+        }
+
+        [Test]
+        public void TestHolesTouchingSide()
+        {
+            CheckUnion(
+                "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 9 6, 9 1, 1 1)))",
+                "POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 9 6, 5 7), (2 6, 4 3, 5 7, 2 6))");
+        }
+
+        [Test]
+        public void TestHolesTouching()
+        {
+            CheckUnion(
+                "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 7 7, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 7 7, 9 6, 9 1, 1 1)))",
+                "POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 7 7, 5 7), (2 6, 4 3, 5 7, 2 6))");
+        }
+
+        [Test]
         public void TestPolygonsNested()
         {
             CheckUnion("GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (3 7, 3 3, 7 3, 7 7, 3 7)), POLYGON ((3 7, 7 7, 7 3, 3 3, 3 7)))",
@@ -59,7 +83,7 @@ namespace NetTopologySuite.Tests.NUnit.Operation.OverlayNG
         }
 
         /**
-         * Overlapping lines are noded with common portions merged 
+         * Overlapping lines are noded with common portions merged
          */
         [Test]
         public void TestLinesOverlapping()


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix BoundaryChainNoder to split chains at self-touch nodes. Issue described in #804 

The code in this PR is a port of JTS commit https://github.com/locationtech/jts/commit/8c5ba9234ba1f48b0abd437b8cc89be565766fb0 which in turn references this JTS issue https://github.com/locationtech/jts/pull/1134
