### PR TITLE
Target .NET 10 for test and console apps

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Get source
       uses: actions/checkout@v2
 
-    - name: Setup .NET 8
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8
+        dotnet-version: 10
 
     - name: Build
       run: dotnet build -c Release -v minimal -p:WarningLevel=3
@@ -48,10 +48,10 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
 
     steps:
-    - name: Setup .NET 8
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8
+        dotnet-version: 10
 
     - name: Download Package Files
       uses: actions/download-artifact@v5
@@ -73,10 +73,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
-    - name: Setup .NET 8
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8
+        dotnet-version: 10
 
     - name: Download Package Files
       uses: actions/download-artifact@v5

--- a/src/NetTopologySuite.TestRunner.Console/NetTopologySuite.TestRunner.Console.csproj
+++ b/src/NetTopologySuite.TestRunner.Console/NetTopologySuite.TestRunner.Console.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>NetTopologySuite</RootNamespace>
     <OutputType>Exe</OutputType>
     <ApplicationIcon>App.ico</ApplicationIcon>

--- a/test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
+++ b/test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>NetTopologySuite.Samples</RootNamespace>
     <OutputType>Exe</OutputType>
     <StartupObject>NetTopologySuite.Samples.SimpleTests.Program</StartupObject>

--- a/test/NetTopologySuite.Tests.NUnit.Performance/NetTopologySuite.Tests.NUnit.Performance.csproj
+++ b/test/NetTopologySuite.Tests.NUnit.Performance/NetTopologySuite.Tests.NUnit.Performance.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <!--<TargetFrameworks>net9.0;net48</TargetFrameworks>-->
+    <TargetFramework>net10.0</TargetFramework>
+    <!--<TargetFrameworks>net10.0;net48</TargetFrameworks>-->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/test/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj
+++ b/test/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <!--<TargetFrameworks>net9.0;net48</TargetFrameworks>-->
+    <TargetFramework>net10.0</TargetFramework>
+    <!--<TargetFrameworks>net10.0;net48</TargetFrameworks>-->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/test/NetTopologySuite.Tests.Vivid.XUnit/NetTopologySuite.Tests.Vivid.XUnit.csproj
+++ b/test/NetTopologySuite.Tests.Vivid.XUnit/NetTopologySuite.Tests.Vivid.XUnit.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>NetTopologySuite.Tests.XUnit</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Current .NET target for test and console apps was a bit mixed making it more difficult than it should be run them locally (require .NET 6, 8, 9). This PR makes .NET 10 the target for the apps (while the lib has the same .net standard target for compatiblity).

ref https://github.com/NetTopologySuite/NetTopologySuite/issues/807