### PR TITLE
Fix OffsetCurve to support mitre joins for polygons

### DIFF
--- a/src/NetTopologySuite/Operation/Buffer/OffsetCurve.cs
+++ b/src/NetTopologySuite/Operation/Buffer/OffsetCurve.cs
@@ -193,34 +193,34 @@ namespace NetTopologySuite.Operation.Buffer
                 if (geom is Point) return null;
                 if (geom is Polygon poly)
                 {
-                    return ComputePolygonCurve(poly, _parent._distance, _parent._bufferParams);
+                    return _parent.ComputePolygonCurve(poly, _parent._distance);
                 }
                 return _parent.ComputeCurve((LineString)geom, _parent._distance);
             }
+        }
 
-            private static Geometry ComputePolygonCurve(Polygon poly, double distance, BufferParameters bufferParams)
-            {
-                Geometry buffer;
-                if (bufferParams == null)
-                    buffer = BufferOp.Buffer(poly, distance);
-                else
-                    buffer = BufferOp.Buffer(poly, distance, bufferParams);
-                return ToLineString(buffer.Boundary);
-            }
+        private Geometry ComputePolygonCurve(Polygon poly, double distance)
+        {
+            Geometry buffer;
+            if (_bufferParams == null)
+                buffer = BufferOp.Buffer(poly, distance);
+            else
+                buffer = BufferOp.Buffer(poly, distance, _bufferParams);
+            return ToLineString(buffer.Boundary);
+        }
 
-            /// <summary>
-            /// Force LinearRings to be LineStrings.
-            /// </summary>
-            /// <param name="geom">A geometry, which may be a <c>LinearRing</c></param>
-            /// <returns>A geometry which will be a <c>LineString</c> or <c>MulitLineString</c></returns>
-            private static Geometry ToLineString(Geometry geom)
+        /// <summary>
+        /// Force LinearRings to be LineStrings.
+        /// </summary>
+        /// <param name="geom">A geometry, which may be a <c>LinearRing</c></param>
+        /// <returns>A geometry which will be a <c>LineString</c> or <c>MulitLineString</c></returns>
+        private static Geometry ToLineString(Geometry geom)
+        {
+            if (geom is LinearRing ring)
             {
-                if (geom is LinearRing ring)
-                {
-                    return geom.Factory.CreateLineString(ring.CoordinateSequence);
-                }
-                return geom;
+                return geom.Factory.CreateLineString(ring.CoordinateSequence);
             }
+            return geom;
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Operation/Buffer/OffsetCurve.cs
+++ b/src/NetTopologySuite/Operation/Buffer/OffsetCurve.cs
@@ -191,11 +191,21 @@ namespace NetTopologySuite.Operation.Buffer
             public Geometry Map(Geometry geom)
             {
                 if (geom is Point) return null;
-                if (geom is Polygon)
+                if (geom is Polygon poly)
                 {
-                    return ToLineString(geom.Buffer(_parent._distance).Boundary);
+                    return ComputePolygonCurve(poly, _parent._distance, _parent._bufferParams);
                 }
                 return _parent.ComputeCurve((LineString)geom, _parent._distance);
+            }
+
+            private static Geometry ComputePolygonCurve(Polygon poly, double distance, BufferParameters bufferParams)
+            {
+                Geometry buffer;
+                if (bufferParams == null)
+                    buffer = BufferOp.Buffer(poly, distance);
+                else
+                    buffer = BufferOp.Buffer(poly, distance, bufferParams);
+                return ToLineString(buffer.Boundary);
             }
 
             /// <summary>
@@ -203,7 +213,7 @@ namespace NetTopologySuite.Operation.Buffer
             /// </summary>
             /// <param name="geom">A geometry, which may be a <c>LinearRing</c></param>
             /// <returns>A geometry which will be a <c>LineString</c> or <c>MulitLineString</c></returns>
-            private Geometry ToLineString(Geometry geom)
+            private static Geometry ToLineString(Geometry geom)
             {
                 if (geom is LinearRing ring)
                 {

--- a/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/OffsetCurveTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/OffsetCurveTest.cs
@@ -320,6 +320,21 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Buffer
 
         }
 
+        [Test]
+        public void TestPolygonMitreJoin()
+        {
+            CheckOffsetCurve(
+                "POLYGON ((1 1, 1 7, 5 4, 8 8, 8 1, 1 1))",
+                1, 0, JoinStyle.Mitre, 5,
+                "LINESTRING (0 0, 0 9, 4.8 5.4, 9 11, 9 0, 0 0)",
+                0.0001);
+            CheckOffsetCurve(
+                "POLYGON ((1 1, 1 7, 5 4, 8 8, 8 1, 1 1))",
+                -1, 0, JoinStyle.Mitre, 5,
+                "LINESTRING (2 2, 2 5, 5.2 2.6, 7 5, 7 2, 2 2)",
+                0.0001);
+        }
+
         //-------------------------------------------------
 
         [Test]


### PR DESCRIPTION
Port of JTS commit e83b7e40a (Fix OffsetCurve to support mitre joins for polygons #1109).

`OffsetCurveMapOp.Map()` was calling `geom.Buffer(distance)` ignoring the parent's `_bufferParams` when the geometry was a Polygon. This prevented join style settings (e.g. Mitre) from taking effect for polygonal input.

Fix: pass `_bufferParams` through the new `ComputePolygonCurve()` static helper. Also converts `ToLineString` to a static method on the inner class.

Adds `TestPolygonMitreJoin` test case.

Closes #815