### PR TITLE
Fix RelateNG to cache in prepared A-L cases

### DIFF
--- a/data/NetTopologySuite.TestRunner.Tests/misc/TestRelateGC.xml
+++ b/data/NetTopologySuite.TestRunner.Tests/misc/TestRelateGC.xml
@@ -577,7 +577,7 @@ GEOMETRYCOLLECTION (POLYGON ((1 9, 5 9, 6 6, 1 5, 1 9), (2 6, 4 8, 6 6, 2 6)), P
 </case>
 
 <case>
-  <desc>GC:AL/A - polygon with overlapping line equal to polygon </desc>
+  <desc>GC:AL/A - polygon with line in boundary and interior equal to polygon </desc>
   <a>
     GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), 
       LINESTRING (0 2, 0 5, 5 5))
@@ -596,6 +596,17 @@ GEOMETRYCOLLECTION (POLYGON ((1 9, 5 9, 6 6, 1 5, 1 9), (2 6, 4 8, 6 6, 2 6)), P
   <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
   <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
   <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+
+  <test><op name="contains"   arg1="B" arg2="A"> true </op></test>
+  <test><op name="coveredBy"  arg1="B" arg2="A"> true </op></test>
+  <test><op name="covers"     arg1="B" arg2="A"> true </op></test>
+  <test><op name="crosses"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="disjoint"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="equalsTopo" arg1="B" arg2="A"> true </op></test>
+  <test><op name="intersects" arg1="B" arg2="A"> true </op></test>
+  <test><op name="overlaps"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="touches"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="within"     arg1="B" arg2="A"> true </op></test>
 </case>
 
 </run>

--- a/src/NetTopologySuite/Operation/RelateNG/RelateGeometry.cs
+++ b/src/NetTopologySuite/Operation/RelateNG/RelateGeometry.cs
@@ -176,6 +176,8 @@ namespace NetTopologySuite.Operation.RelateNG
 
         public bool HasEdges { get => _hasLines || _hasAreas; }
 
+        public bool HasAreaAndLine => _hasAreas && _hasLines;
+
         private RelatePointLocator GetLocator()
         {
             if (_locator == null)
@@ -242,6 +244,10 @@ namespace NetTopologySuite.Operation.RelateNG
 
                 //-- a GC with a single polygon does not need noding
                 if (_hasAreas && _geom.NumGeometries == 1)
+                    return false;
+
+                //-- GCs with only points do not need noding
+                if (!_hasAreas && !_hasLines)
                     return false;
 
                 return true;

--- a/src/NetTopologySuite/Operation/RelateNG/TopologyComputer.cs
+++ b/src/NetTopologySuite/Operation/RelateNG/TopologyComputer.cs
@@ -119,13 +119,23 @@ namespace NetTopologySuite.Operation.RelateNG
         /// Self-noding is required for geometries which may self-cross
         /// - i.e.lines, and overlapping polygons in GeometryCollections.
         /// Self-noding is required for geometries which may
-        /// have self-crossing linework.
+        /// have self-crossing linework, or may have lines lying in the boundary of an area.
         /// This causes the coordinates of nodes created by
         /// crossing segments to be computed explicitly.
         /// This ensures that node locations match in situations
         /// where a self-crossing and mutual crossing occur at the same logical location.
         /// The canonical example is a self-crossing line tested against a single segment
         /// identical to one of the crossed segments.
+        /// <para/>
+        /// Currently, requiring self-noding prevents noder caching.
+        /// So it is important to limit the cases which require self-noding.
+        /// Currently self-noding is required for:
+        /// <list type="bullet">
+        /// <item><description>A geoms which require self-noding (lines or GCs, except for single-polygon GCs)</description></item>
+        /// <item><description>B geoms which are mixed A/L GCs</description></item>
+        /// </list>
+        /// Note that linear B inputs do not require self-noding in all cases.
+        /// In particular, if A is polygonal then predicates with linear B do not require self-noding.
         /// </summary>
         public bool IsSelfNodingRequired
         {

--- a/src/NetTopologySuite/Operation/RelateNG/TopologyComputer.cs
+++ b/src/NetTopologySuite/Operation/RelateNG/TopologyComputer.cs
@@ -131,11 +131,16 @@ namespace NetTopologySuite.Operation.RelateNG
         {
             get
             {
-                if (_predicate.RequireSelfNoding())
-                {
-                    if (_geomA.IsSelfNodingRequired ||
-                        _geomB.IsSelfNodingRequired) return true;
-                }
+                if (!_predicate.RequireSelfNoding())
+                    return false;
+
+                if (_geomA.IsSelfNodingRequired)
+                    return true;
+
+                //-- if B is a mixed GC with A and L require full noding
+                if (_geomB.HasAreaAndLine)
+                    return true;
+
                 return false;
             }
         }

--- a/test/NetTopologySuite.Tests.NUnit.Performance/Performance/Operation/RelateNG/RelateNGPolygonLinesOverlappingPerfTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit.Performance/Performance/Operation/RelateNG/RelateNGPolygonLinesOverlappingPerfTest.cs
@@ -1,0 +1,144 @@
+﻿using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Prepared;
+using NetTopologySuite.Geometries.Utilities;
+using NetTopologySuite.Operation.RelateNG;
+
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Performance.Operation.RelateNG
+{
+    internal class RelateNGPolygonLinesOverlappingPerfTest : PerformanceTestCase
+    {
+        private const int N_ITER = 1;
+
+        static readonly double ORG_X = 100;
+        static readonly double ORG_Y = ORG_X;
+        static readonly double SIZE = 2 * ORG_X;
+        static readonly int N_ARMS = 6;
+        static readonly double ARM_RATIO = 0.3;
+
+        static readonly int GRID_SIZE = 100;
+        static readonly double GRID_CELL_SIZE = SIZE / GRID_SIZE;
+
+        static readonly int NUM_CASES = GRID_SIZE * GRID_SIZE;
+
+        private const int B_SIZE_FACTOR = 20;
+        private static readonly GeometryFactory factory = NtsGeometryServices.Instance.CreateGeometryFactory();
+
+        private Geometry geomA;
+
+        private Geometry[] geomB;
+
+        public RelateNGPolygonLinesOverlappingPerfTest() : base(nameof(RelateNGPolygonLinesOverlappingPerfTest))
+        {
+            RunSize = new int[] { 100, 1000, 10000, 100000, 200000 };
+            //setRunSize(new int[] { 200000 });
+            RunIterations = N_ITER;
+        }
+
+        public override void SetUp()
+        {
+            TestContext.WriteLine("RelateNG Polygon overlapping Lines perf test");
+            TestContext.WriteLine("SineStar: origin: ("
+                + ORG_X + ", " + ORG_Y + ")  size: " + SIZE
+                + "  # arms: " + N_ARMS + "  arm ratio: " + ARM_RATIO);
+            TestContext.WriteLine("# Iterations: " + N_ITER);
+            TestContext.WriteLine("# B geoms: " + NUM_CASES);
+        }
+
+        public override void StartRun(int npts)
+        {
+            var sineStar = SineStarFactory.Create(new Coordinate(ORG_X, ORG_Y), SIZE, npts, N_ARMS, ARM_RATIO);
+            geomA = sineStar;
+
+            int nptsB = npts * B_SIZE_FACTOR / NUM_CASES;
+            if (nptsB < 10) nptsB = 10;
+
+            geomB = CreateSineStarGrid(NUM_CASES, nptsB);
+            //geomB =  createCircleGrid(NUM_CASES, nptsB);
+
+            TestContext.WriteLine("\n-------  Running with A: polygon # pts = " + npts
+                + "   B # pts = " + nptsB + "  x " + NUM_CASES + " lines");
+
+            /*
+            if (npts == 999) {
+              TestContext.WriteLine(geomA);
+
+              for (Geometry g : geomB) {
+                TestContext.WriteLine(g);
+              }
+            }
+        */
+        }
+
+        public void RunContainsOld()
+        {
+            foreach (var b in geomB)
+            {
+                geomA.Contains(b);
+            }
+        }
+
+        public void RunContainsOldPrep()
+        {
+            var pgA = PreparedGeometryFactory.Prepare(geomA);
+            foreach (var b in geomB)
+            {
+                pgA.Contains(b);
+            }
+        }
+
+        public void RunContainsNG()
+        {
+            foreach (var b in geomB)
+            {
+                NetTopologySuite.Operation.RelateNG.RelateNG.Relate(geomA, b, RelatePredicate.Contains());
+            }
+        }
+
+        public void RunContainsNGPrep()
+        {
+            var rng = NetTopologySuite.Operation.RelateNG.RelateNG.Prepare(geomA);
+            foreach (var b in geomB)
+            {
+                rng.Evaluate(b, RelatePredicate.Contains());
+            }
+        }
+
+        private static Geometry[] CreateSineStarGrid(int nGeoms, int npts)
+        {
+            var geoms = new Geometry[NUM_CASES];
+            int index = 0;
+            for (int i = 0; i < GRID_SIZE; i++)
+            {
+                for (int j = 0; j < GRID_SIZE; j++)
+                {
+                    double x = GRID_CELL_SIZE / 2 + i * GRID_CELL_SIZE;
+                    double y = GRID_CELL_SIZE / 2 + j * GRID_CELL_SIZE;
+                    var geom = SineStarFactory.Create(new Coordinate(x, y), GRID_CELL_SIZE, npts, N_ARMS, ARM_RATIO);
+                    geoms[index++] = geom.Boundary;
+                }
+            }
+            return geoms;
+        }
+
+        private static Geometry[] CreateCircleGrid(int nGeoms, int npts)
+        {
+            var geoms = new Geometry[NUM_CASES];
+            int index = 0;
+            for (int i = 0; i < GRID_SIZE; i++)
+            {
+                for (int j = 0; j < GRID_SIZE; j++)
+                {
+                    double x = GRID_CELL_SIZE / 2 + i * GRID_CELL_SIZE;
+                    double y = GRID_CELL_SIZE / 2 + j * GRID_CELL_SIZE;
+                    var p = new Coordinate(x, y);
+                    var geom = factory.CreatePoint(p).Buffer(GRID_CELL_SIZE / 2.0);
+                    geoms[index++] = geom;
+                }
+            }
+            return geoms;
+        }
+
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Operation/RelateNG/RelateNGGCTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/RelateNG/RelateNGGCTest.cs
@@ -253,6 +253,10 @@ namespace NetTopologySuite.Tests.NUnit.Operation.RelateNG
             const string a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
             const string b = "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), LINESTRING (0 2, 0 5))";
             CheckEquals(a, b, true);
+            CheckContainsWithin(a, b, true);
+            CheckCoversCoveredBy(a, b, true);
+            CheckContainsWithin(b, a, true);
+            CheckCoversCoveredBy(b, a, true);
         }
 
         [Test]
@@ -261,6 +265,10 @@ namespace NetTopologySuite.Tests.NUnit.Operation.RelateNG
             const string a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
             const string b = "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), LINESTRING (0 2, 0 5, 5 5))";
             CheckEquals(a, b, true);
+            CheckContainsWithin(a, b, true);
+            CheckCoversCoveredBy(a, b, true);
+            CheckContainsWithin(b, a, true);
+            CheckCoversCoveredBy(b, a, true);
         }
 
     }


### PR DESCRIPTION
Port of JTS commit https://github.com/locationtech/jts/commit/c3d56e6bc66ebd9ae2354600e09687bb54cc1921 (Fix RelateNG to cache in prepared A-L cases #1099).

RelateNG was requiring self-noding (which prevents noder caching) more broadly than needed. This caused poor performance for prepared relate operations involving mixed Area-Line geometry collections.

Changes:
- `RelateGeometry`: add `HasAreaAndLine` property (true when geometry has both areas and lines)
- `RelateGeometry.IsSelfNodingRequired`: add early return when geometry has no areas or lines (e.g. point-only GC)
- `TopologyComputer.IsSelfNodingRequired`: rewrite to check geomB for mixed A/L separately (linear-only B does not require self-noding against polygonal A)

Adds `CheckContainsWithin` and `CheckCoversCoveredBy` assertions to two existing `RelateNGGCTest` tests.

Closes #819
