### PR TITLE
Add MathUtil.Hypot and update call sites (JTS #1112)

### DIFF
--- a/src/NetTopologySuite/Algorithm/Length.cs
+++ b/src/NetTopologySuite/Algorithm/Length.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Mathematics;
 
 namespace NetTopologySuite.Algorithm
 {
@@ -38,7 +39,7 @@ namespace NetTopologySuite.Algorithm
                 double dx = x1 - x0;
                 double dy = y1 - y0;
 
-                len += Math.Sqrt(dx * dx + dy * dy);
+                len += MathUtil.Hypot(dx, dy);
 
                 x0 = x1;
                 y0 = y1;

--- a/src/NetTopologySuite/Algorithm/LineIntersector.cs
+++ b/src/NetTopologySuite/Algorithm/LineIntersector.cs
@@ -3,6 +3,7 @@ namespace NetTopologySuite.Algorithm
     using System;
     using System.Text;
     using NetTopologySuite.Geometries;
+    using NetTopologySuite.Mathematics;
     using Utilities;
 
     /// <summary>
@@ -100,7 +101,7 @@ namespace NetTopologySuite.Algorithm
         {
             double dx = p.X - p1.X;
             double dy = p.Y - p1.Y;
-            double dist = Math.Sqrt(dx * dx + dy * dy);   // dummy value
+            double dist = MathUtil.Hypot(dx, dy);   // dummy value
             Assert.IsTrue(! (dist == 0.0 && ! p.Equals(p1)), "Invalid distance calculation");
             return dist;
         }

--- a/src/NetTopologySuite/Algorithm/MinimumBoundingCircle.cs
+++ b/src/NetTopologySuite/Algorithm/MinimumBoundingCircle.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Mathematics;
 using NetTopologySuite.Utilities;
 
 namespace NetTopologySuite.Algorithm
@@ -375,7 +376,7 @@ namespace NetTopologySuite.Algorithm
                 double dx = p.X - P.X;
                 double dy = p.Y - P.Y;
                 if (dy < 0) dy = -dy;
-                double len = Math.Sqrt(dx * dx + dy * dy);
+                double len = MathUtil.Hypot(dx, dy);
                 double sin = dy / len;
 
                 if (sin < minSin)

--- a/src/NetTopologySuite/Geometries/Coordinate.cs
+++ b/src/NetTopologySuite/Geometries/Coordinate.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using NetTopologySuite.Mathematics;
 
 namespace NetTopologySuite.Geometries
 {
@@ -396,7 +397,7 @@ namespace NetTopologySuite.Geometries
         {
             double dx = X - c.X;
             double dy = Y - c.Y;
-            return Math.Sqrt(dx * dx + dy * dy);
+            return MathUtil.Hypot(dx, dy);
         }
 
 #region System.Object overrides

--- a/src/NetTopologySuite/Geometries/Envelope.cs
+++ b/src/NetTopologySuite/Geometries/Envelope.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using NetTopologySuite.Mathematics;
 
 namespace NetTopologySuite.Geometries
 {
@@ -301,7 +302,7 @@ namespace NetTopologySuite.Geometries
 
                 double w = Width;
                 double h = Height;
-                return Math.Sqrt(w * w + h * h);
+                return MathUtil.Hypot(w, h);
             }
         }
 
@@ -771,7 +772,7 @@ namespace NetTopologySuite.Geometries
             if (dy == 0.0)
                 return dx;
 
-            return Math.Sqrt(dx * dx + dy * dy);
+            return MathUtil.Hypot(dx, dy);
         }
 
         /// <inheritdoc />

--- a/src/NetTopologySuite/Geometries/LineSegment.cs
+++ b/src/NetTopologySuite/Geometries/LineSegment.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.IO;
+using NetTopologySuite.Mathematics;
 
 namespace NetTopologySuite.Geometries
 {
@@ -332,7 +333,7 @@ namespace NetTopologySuite.Geometries
 
             double dx = _p1.X - _p0.X;
             double dy = _p1.Y - _p0.Y;
-            double len = Math.Sqrt(dx * dx + dy * dy);
+            double len = MathUtil.Hypot(dx, dy);
             double ux = 0.0;
             double uy = 0.0;
             if (offsetDistance != 0.0)

--- a/src/NetTopologySuite/Geometries/Utilities/AffineTransformation.cs
+++ b/src/NetTopologySuite/Geometries/Utilities/AffineTransformation.cs
@@ -1,4 +1,5 @@
 using System;
+using NetTopologySuite.Mathematics;
 
 namespace NetTopologySuite.Geometries.Utilities
 {
@@ -485,7 +486,7 @@ namespace NetTopologySuite.Geometries.Utilities
             }
             double dx = x1 - x0;
             double dy = y1 - y0;
-            double d = Math.Sqrt(dx * dx + dy * dy);
+            double d = MathUtil.Hypot(dx, dy);
             double sin = dy / d;
             double cos = dx / d;
             double cs2 = 2 * sin * cos;
@@ -515,7 +516,7 @@ namespace NetTopologySuite.Geometries.Utilities
             // rotate vector to positive x axis direction
             double dx = x1 - x0;
             double dy = y1 - y0;
-            double d = Math.Sqrt(dx * dx + dy * dy);
+            double d = MathUtil.Hypot(dx, dy);
             double sin = dy / d;
             double cos = dx / d;
             Rotate(-sin, cos);
@@ -568,7 +569,7 @@ namespace NetTopologySuite.Geometries.Utilities
             }
 
             // rotate vector to positive x axis direction
-            double d = Math.Sqrt(x * x + y * y);
+            double d = MathUtil.Hypot(x, y);
             double sin = y / d;
             double cos = x / d;
             Rotate(-sin, cos);

--- a/src/NetTopologySuite/Index/Strtree/EnvelopeDistance.cs
+++ b/src/NetTopologySuite/Index/Strtree/EnvelopeDistance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Mathematics;
 
 namespace NetTopologySuite.Index.Strtree
 {
@@ -32,7 +33,7 @@ namespace NetTopologySuite.Index.Strtree
         {
             double dx = x2 - x1;
             double dy = y2 - y1;
-            return Math.Sqrt(dx * dx + dy * dy);
+            return MathUtil.Hypot(dx, dy);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Mathematics/MathUtil.cs
+++ b/src/NetTopologySuite/Mathematics/MathUtil.cs
@@ -56,6 +56,28 @@
             int div = num / denom;
             return div * denom >= num ? div : div + 1;
         }
+        /// <summary>
+        /// Computes the length of the hypotenuse of a right triangle with sides
+        /// of length <paramref name="x"/> and <paramref name="y"/>, i.e. the
+        /// length of vector (<paramref name="x"/>, <paramref name="y"/>).
+        /// <para/>
+        /// This is the naive formula: <c>Sqrt(x² + y²)</c>. It is faster than
+        /// the overflow-safe scaled formula used by <c>java.lang.Math.hypot</c>
+        /// (the variant JTS replaces with this method). It does NOT guard
+        /// against intermediate overflow when |x| or |y| approaches
+        /// <c>sqrt(double.MaxValue)</c>; if your inputs may reach that
+        /// magnitude, prefer a scaled variant.
+        /// <para/>
+        /// JTS: <c>MathUtil.hypot</c> (added in JTS 1.21, locationtech/jts#1112).
+        /// </summary>
+        /// <param name="x">The x ordinate</param>
+        /// <param name="y">The y ordinate</param>
+        /// <returns>The length of vector (<paramref name="x"/>, <paramref name="y"/>)</returns>
+        public static double Hypot(double x, double y)
+        {
+            return System.Math.Sqrt(x * x + y * y);
+        }
+
         // ReSharper disable InconsistentNaming
         private static readonly double LOG10 = System.Math.Log(10);
         // ReSharper restore InconsistentNaming

--- a/src/NetTopologySuite/Mathematics/Vector2D.cs
+++ b/src/NetTopologySuite/Mathematics/Vector2D.cs
@@ -202,7 +202,7 @@ namespace NetTopologySuite.Mathematics
         /// <returns></returns>
         public double Length()
         {
-            return System.Math.Sqrt(_x * _x + _y * _y);
+            return MathUtil.Hypot(_x, _y);
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace NetTopologySuite.Mathematics
         {
             double delx = v._x - _x;
             double dely = v._y - _y;
-            return System.Math.Sqrt(delx * delx + dely * dely);
+            return MathUtil.Hypot(delx, dely);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Operation/Buffer/OffsetSegmentGenerator.cs
+++ b/src/NetTopologySuite/Operation/Buffer/OffsetSegmentGenerator.cs
@@ -2,6 +2,7 @@
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.GeometriesGraph;
+using NetTopologySuite.Mathematics;
 using Position = NetTopologySuite.Geometries.Position;
 
 namespace NetTopologySuite.Operation.Buffer
@@ -395,7 +396,7 @@ namespace NetTopologySuite.Operation.Buffer
             int sideSign = side == Position.Left ? 1 : -1;
             double dx = seg.P1.X - seg.P0.X;
             double dy = seg.P1.Y - seg.P0.Y;
-            double len = Math.Sqrt(dx * dx + dy * dy);
+            double len = MathUtil.Hypot(dx, dy);
             // u is the vector that is the length of the offset, in the direction of the segment
             double ux = sideSign * distance * dx / len;
             double uy = sideSign * distance * dy / len;

--- a/src/NetTopologySuite/Operation/Overlay/Validate/OffsetPointGenerator.cs
+++ b/src/NetTopologySuite/Operation/Overlay/Validate/OffsetPointGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Utilities;
+using NetTopologySuite.Mathematics;
 
 namespace NetTopologySuite.Operation.Overlay.Validate
 {
@@ -80,7 +81,7 @@ namespace NetTopologySuite.Operation.Overlay.Validate
         {
             double dx = p1.X - p0.Y;
             double dy = p1.Y - p0.Y;
-            double len = Math.Sqrt(dx * dx + dy * dy);
+            double len = MathUtil.Hypot(dx, dy);
             // u is the vector that is the length of the offset, in the direction of the segment
             double ux = offsetDistance * dx / len;
             double uy = offsetDistance * dy / len;

--- a/src/NetTopologySuite/Triangulate/QuadEdge/Vertex.cs
+++ b/src/NetTopologySuite/Triangulate/QuadEdge/Vertex.cs
@@ -1,6 +1,7 @@
 using System;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Mathematics;
 
 namespace NetTopologySuite.Triangulate.QuadEdge
 {
@@ -182,7 +183,7 @@ namespace NetTopologySuite.Triangulate.QuadEdge
 
         private double Magnitude()
         {
-            return (Math.Sqrt(_p.X*_p.X + _p.Y*_p.Y));
+            return (MathUtil.Hypot(_p.X, _p.Y));
         }
 
         /* returns k X v (cross product). this is a vector perpendicular to v */

--- a/test/NetTopologySuite.Tests.NUnit/Mathematics/MathUtilTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Mathematics/MathUtilTest.cs
@@ -1,0 +1,47 @@
+using System;
+using NetTopologySuite.Mathematics;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Mathematics
+{
+    public class MathUtilTest
+    {
+        private const double Tolerance = 1e-12;
+
+        [Test]
+        public void TestHypot_ZeroAndZero()
+        {
+            Assert.That(MathUtil.Hypot(0, 0), Is.EqualTo(0).Within(Tolerance));
+        }
+
+        [Test]
+        public void TestHypot_AlongX()
+        {
+            Assert.That(MathUtil.Hypot(3, 0), Is.EqualTo(3).Within(Tolerance));
+            Assert.That(MathUtil.Hypot(-3, 0), Is.EqualTo(3).Within(Tolerance));
+        }
+
+        [Test]
+        public void TestHypot_AlongY()
+        {
+            Assert.That(MathUtil.Hypot(0, 4), Is.EqualTo(4).Within(Tolerance));
+            Assert.That(MathUtil.Hypot(0, -4), Is.EqualTo(4).Within(Tolerance));
+        }
+
+        [Test]
+        public void TestHypot_ThreeFourFive()
+        {
+            Assert.That(MathUtil.Hypot(3, 4), Is.EqualTo(5).Within(Tolerance));
+            Assert.That(MathUtil.Hypot(-3, -4), Is.EqualTo(5).Within(Tolerance));
+        }
+
+        [Test]
+        public void TestHypot_MatchesNaiveFormula()
+        {
+            // JTS Hypot is deliberately the naive formula (not the overflow-safe
+            // scaled variant). Document and pin this with explicit equivalence.
+            double x = 1.5, y = 2.5;
+            Assert.That(MathUtil.Hypot(x, y), Is.EqualTo(Math.Sqrt(x * x + y * y)).Within(Tolerance));
+        }
+    }
+}


### PR DESCRIPTION
Ports `MathUtil.hypot(double, double)` from JTS 1.21 (#1112) and replaces
direct `Math.Sqrt(dx*dx + dy*dy)` usage for improved numerical stability.

This PR is the functional deliverable for epic #817.

Related: #828