### PR TITLE
Add KdTree.NearestNeighbor and NearestNeighbors from JTS 1.21 (#814)

### DIFF
--- a/src/NetTopologySuite/Index/KdTree/KdTree.NearestNeighbors.cs
+++ b/src/NetTopologySuite/Index/KdTree/KdTree.NearestNeighbors.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Utilities;
+
+namespace NetTopologySuite.Index.KdTree
+{
+    public partial class KdTree<T>
+    {
+        /// <summary>
+        /// Finds the nearest node in the tree to the given query point.
+        /// </summary>
+        /// <param name="query">The query point</param>
+        /// <returns>The nearest node, or <c>null</c> if the tree is empty</returns>
+        public KdNode<T> NearestNeighbor(Coordinate query)
+        {
+            if (_root == null)
+                return null;
+
+            KdNode<T> bestNode = null;
+            double bestDistSq = double.PositiveInfinity;
+
+            var stack = new Stack<NNFrame>();
+            stack.Push(new NNFrame(_root, isAxisX: true));
+
+            while (stack.Count > 0)
+            {
+                var frame = stack.Pop();
+                var node = frame.Node;
+                if (node == null) continue;
+
+                //-- 1. visit this node
+                double dx = query.X - node.X;
+                double dy = query.Y - node.Y;
+                double dSq = dx * dx + dy * dy;
+                if (dSq < bestDistSq)
+                {
+                    bestDistSq = dSq;
+                    bestNode = node;
+                    if (dSq == 0)
+                        break; // perfect hit
+                }
+
+                //-- 2. decide which child to explore first
+                bool axisIsX = frame.IsAxisX;
+                double diff = axisIsX ? dx : dy;
+
+                var nearChild = (diff < 0) ? node.Left : node.Right;
+                var farChild = (diff < 0) ? node.Right : node.Left;
+
+                //-- 3. depth-first: push far side only if it can still win
+                if (farChild != null && diff * diff < bestDistSq)
+                {
+                    stack.Push(new NNFrame(farChild, isAxisX: !axisIsX));
+                }
+                if (nearChild != null)
+                {
+                    stack.Push(new NNFrame(nearChild, isAxisX: !axisIsX));
+                }
+            }
+            return bestNode;
+        }
+
+        /// <summary>
+        /// Finds the nearest <paramref name="k"/> nodes in the tree to the given query point.
+        /// </summary>
+        /// <param name="query">The query point</param>
+        /// <param name="k">The number of nearest nodes to find</param>
+        /// <returns>A list of the nearest nodes, sorted by distance (closest first),
+        /// or an empty list if the tree is empty or <paramref name="k"/> is non-positive.</returns>
+        public IList<KdNode<T>> NearestNeighbors(Coordinate query, int k)
+        {
+            if (_root == null || k <= 0)
+                return new List<KdNode<T>>();
+
+            //-- Max-heap (Neighbor.CompareTo inverts ordering) so Peek() / Poll()
+            //-- return the worst (farthest) kept candidate.
+            var heap = new PriorityQueue<Neighbor>();
+            double worstDistSq = double.PositiveInfinity; // updated when heap full
+
+            //-- depth-first search with an explicit stack
+            var stack = new Stack<NNStackFrame>();
+            var node = _root;
+            bool axisIsX = true;
+
+            while (node != null || stack.Count > 0)
+            {
+                //-- a) descend
+                if (node != null)
+                {
+                    //-- visit the current node
+                    double dx = query.X - node.X;
+                    double dy = query.Y - node.Y;
+                    double distSq = dx * dx + dy * dy;
+
+                    if (heap.Size < k) // not full yet
+                    {
+                        heap.Add(new Neighbor(node, distSq));
+                        if (heap.Size == k)
+                            worstDistSq = heap.Peek().DistSq;
+                    }
+                    else if (distSq < worstDistSq) // better than worst
+                    {
+                        heap.Poll(); // discard worst
+                        heap.Add(new Neighbor(node, distSq));
+                        worstDistSq = heap.Peek().DistSq;
+                    }
+
+                    //-- choose near / far child
+                    double split = axisIsX ? node.X : node.Y;
+                    double diff = axisIsX ? dx : dy;
+
+                    var nearChild = (diff < 0) ? node.Left : node.Right;
+                    var farChild = (diff < 0) ? node.Right : node.Left;
+
+                    //-- push the far branch (if it exists) together with split info
+                    if (farChild != null)
+                    {
+                        stack.Push(new NNStackFrame(farChild, axisIsX, split, !axisIsX));
+                    }
+
+                    //-- tail-recurse into the near branch
+                    node = nearChild;
+                    axisIsX = !axisIsX;
+                }
+                //-- b) backtrack
+                else
+                {
+                    var sf = stack.Pop();
+                    double diff = sf.ParentSplitAxis
+                        ? query.X - sf.ParentSplitValue
+                        : query.Y - sf.ParentSplitValue;
+                    double diffSq = diff * diff;
+
+                    if (heap.Size < k || diffSq < worstDistSq)
+                    {
+                        node = sf.Node;
+                        axisIsX = sf.NodeAxisX;
+                    }
+                    else
+                    {
+                        node = null; // prune whole subtree
+                    }
+                }
+            }
+
+            //-- Drain the max-heap to an array worst-first, then reverse for best-first.
+            int count = heap.Size;
+            var result = new KdNode<T>[count];
+            for (int i = count - 1; i >= 0; i--)
+            {
+                result[i] = heap.Poll().Node;
+            }
+            return result;
+        }
+
+        private readonly struct NNFrame
+        {
+            public NNFrame(KdNode<T> node, bool isAxisX)
+            {
+                Node = node;
+                IsAxisX = isAxisX;
+            }
+
+            public KdNode<T> Node { get; }
+            public bool IsAxisX { get; }
+        }
+
+        private readonly struct NNStackFrame
+        {
+            public NNStackFrame(KdNode<T> node, bool parentSplitAxis, double parentSplitValue, bool nodeAxisX)
+            {
+                Node = node;
+                ParentSplitAxis = parentSplitAxis;
+                ParentSplitValue = parentSplitValue;
+                NodeAxisX = nodeAxisX;
+            }
+
+            public KdNode<T> Node { get; }
+            public bool ParentSplitAxis { get; }
+            public double ParentSplitValue { get; }
+            public bool NodeAxisX { get; }
+        }
+
+        /// <summary>
+        /// Heap entry for k-NN search. <see cref="CompareTo"/> reverses natural ordering
+        /// so <see cref="PriorityQueue{T}"/> behaves as a max-heap (Peek/Poll yield the worst-so-far).
+        /// </summary>
+        private sealed class Neighbor : IComparable<Neighbor>
+        {
+            public Neighbor(KdNode<T> node, double distSq)
+            {
+                Node = node;
+                DistSq = distSq;
+            }
+
+            public KdNode<T> Node { get; }
+            public double DistSq { get; }
+
+            public int CompareTo(Neighbor other)
+            {
+                if (other == null) return -1;
+                return other.DistSq.CompareTo(DistSq);
+            }
+        }
+    }
+}

--- a/src/NetTopologySuite/Index/KdTree/KdTreeExtensions.cs
+++ b/src/NetTopologySuite/Index/KdTree/KdTreeExtensions.cs
@@ -13,70 +13,13 @@ namespace NetTopologySuite.Index.KdTree
         /// </summary>
         /// <param name="self">The KdTree to look for the nearest neighbor</param>
         /// <param name="coord">The point to search the nearset neighbor for</param>
+        /// <remarks>
+        /// Equivalent to <see cref="KdTree{T}.NearestNeighbor(Coordinate)"/> and retained
+        /// for backwards compatibility. Prefer the first-class method on <see cref="KdTree{T}"/>.
+        /// </remarks>
         public static KdNode<T> NearestNeighbor<T>(this KdTree<T> self, Coordinate coord) where T : class
         {
-            KdNode<T> result = null;
-            double closestDistSq = double.MaxValue;
-            NearestNeighbor(self.Root, coord, ref result, ref closestDistSq, true);
-            return result;
-        }
-
-        private static void NearestNeighbor<T>(
-            KdNode<T> currentNode, Coordinate queryCoordinate,
-            ref KdNode<T> closestNode, ref double closestDistanceSq,
-            bool isOddLevel) where T : class
-        {
-            while (true)
-            {
-                if (currentNode == null)
-                    return;
-
-                double distSq = Math.Pow(currentNode.X - queryCoordinate.X, 2) +
-                             Math.Pow(currentNode.Y - queryCoordinate.Y, 2);
-
-                if (distSq < closestDistanceSq)
-                {
-                    closestNode = currentNode;
-                    closestDistanceSq = distSq;
-                }
-
-                // Start with the branch that is more likely to produce the final result
-                var firstBranch = currentNode.Left;
-                var secondBranch = currentNode.Right;
-                if (currentNode.Left != null &&
-                    (isOddLevel ? queryCoordinate.X >= currentNode.X : queryCoordinate.Y >= currentNode.Y))
-                {
-                    firstBranch = currentNode.Right;
-                    secondBranch = currentNode.Left;
-                }
-
-                if (firstBranch != null
-                    && NeedsToBeSearched(queryCoordinate, currentNode, closestDistanceSq,
-                                         firstBranch == currentNode.Left, isOddLevel))
-                {
-                    NearestNeighbor(firstBranch, queryCoordinate, ref closestNode, ref closestDistanceSq, !isOddLevel);
-                }
-
-                if (secondBranch != null
-                    && NeedsToBeSearched(queryCoordinate, currentNode, closestDistanceSq,
-                                         secondBranch == currentNode.Left, isOddLevel))
-                {
-                    currentNode = secondBranch;
-                    isOddLevel = !isOddLevel;
-                    continue;
-                }
-
-                break;
-
-            }
-        }
-
-        private static bool NeedsToBeSearched<T>(Coordinate target, KdNode<T> node,
-            double closestDistSq, bool left, bool isOddLevel) where T : class
-        {
-            if (isOddLevel)
-                return (left ? target.X <= node.X : target.X >= node.X) || Math.Pow(target.X - node.X, 2) < closestDistSq;
-            return (left ? target.Y <= node.Y : target.Y >= node.Y) || Math.Pow(target.Y - node.Y, 2) < closestDistSq;
+            return self.NearestNeighbor(coord);
         }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Index/KdTree/KdTreeTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Index/KdTree/KdTreeTest.cs
@@ -72,6 +72,152 @@ namespace NetTopologySuite.Tests.NUnit.Index.KdTree
         }
 
         [Test]
+        public void TestNearestNeighborEmptyTree()
+        {
+            var kd = new KdTree<string>();
+            Assert.That(kd.NearestNeighbor(new Coordinate(0, 0)), Is.Null);
+        }
+
+        [Test]
+        public void TestNearestNeighborsEmptyTree()
+        {
+            var kd = new KdTree<string>();
+            var result = kd.NearestNeighbors(new Coordinate(0, 0), 5);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Count, Is.Zero);
+        }
+
+        [Test]
+        public void TestNearestNeighborsZeroK()
+        {
+            var kd = new KdTree<string>();
+            kd.Insert(new Coordinate(1, 1), "A");
+            kd.Insert(new Coordinate(2, 2), "B");
+            var result = kd.NearestNeighbors(new Coordinate(0, 0), 0);
+            Assert.That(result.Count, Is.Zero);
+        }
+
+        [Test]
+        public void TestNearestNeighborsOrderedClosestFirst()
+        {
+            var kd = new KdTree<string>();
+            kd.Insert(new Coordinate(0, 0), "Origin");
+            kd.Insert(new Coordinate(1, 0), "East1");
+            kd.Insert(new Coordinate(5, 0), "East5");
+            kd.Insert(new Coordinate(10, 0), "East10");
+
+            var result = kd.NearestNeighbors(new Coordinate(0, 0), 3);
+            Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result[0].Data, Is.EqualTo("Origin"));
+            Assert.That(result[1].Data, Is.EqualTo("East1"));
+            Assert.That(result[2].Data, Is.EqualTo("East5"));
+        }
+
+        [Test]
+        public void TestNearestNeighborsRequestMoreThanAvailable()
+        {
+            var kd = new KdTree<string>();
+            kd.Insert(new Coordinate(1, 1), "A");
+            kd.Insert(new Coordinate(2, 2), "B");
+            kd.Insert(new Coordinate(3, 3), "C");
+
+            // k larger than tree size — should return all available, still sorted.
+            var result = kd.NearestNeighbors(new Coordinate(0, 0), 10);
+            Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result[0].Data, Is.EqualTo("A"));
+            Assert.That(result[1].Data, Is.EqualTo("B"));
+            Assert.That(result[2].Data, Is.EqualTo("C"));
+        }
+
+        [Test]
+        public void TestNearestNeighborBruteForce()
+        {
+            // Compare KdTree.NearestNeighbor against a brute-force scan over 1000 random points,
+            // running 500 queries against the same tree. Matches the JTS test pattern.
+            const int n = 1000;
+            const int queries = 500;
+            var rand = new Random(1337);
+
+            var tree = new KdTree<object>();
+            var points = new System.Collections.Generic.List<Coordinate>(n);
+            for (int i = 0; i < n; i++)
+            {
+                var p = new Coordinate(rand.NextDouble(), rand.NextDouble());
+                tree.Insert(p);
+                points.Add(p);
+            }
+
+            for (int i = 0; i < queries; i++)
+            {
+                var q = new Coordinate(rand.NextDouble(), rand.NextDouble());
+                var nearestNode = tree.NearestNeighbor(q);
+                var bruteForce = BruteForceNearestNeighbor(points, q);
+                Assert.That(nearestNode.Coordinate, Is.EqualTo(bruteForce),
+                    $"Query #{i} at ({q.X}, {q.Y}) mismatched brute force");
+            }
+        }
+
+        [Test]
+        public void TestNearestNeighborsBruteForce()
+        {
+            // Compare KdTree.NearestNeighbors(k) against a brute-force k-NN over 2500 random points,
+            // running 50 trials with different seeds. Matches the JTS test pattern.
+            const int n = 2500;
+            const int numTrials = 50;
+            var rand = new Random(0);
+
+            for (int trial = 0; trial < numTrials; trial++)
+            {
+                var tree = new KdTree<object>();
+                var points = new System.Collections.Generic.List<Coordinate>(n);
+                for (int i = 0; i < n; i++)
+                {
+                    var p = new Coordinate(rand.NextDouble(), rand.NextDouble());
+                    tree.Insert(p);
+                    points.Add(p);
+                }
+
+                var query = new Coordinate(rand.NextDouble(), rand.NextDouble());
+                int k = rand.Next(n / 10);
+
+                var nearestNodes = tree.NearestNeighbors(query, k);
+                var bruteForce = BruteForceNearestNeighbors(points, query, k);
+
+                Assert.That(nearestNodes.Count, Is.EqualTo(k));
+                for (int i = 0; i < k; i++)
+                {
+                    Assert.That(nearestNodes[i].Coordinate, Is.EqualTo(bruteForce[i]),
+                        $"Trial {trial} position {i} mismatched brute force (k={k})");
+                }
+            }
+        }
+
+        private static Coordinate BruteForceNearestNeighbor(
+            System.Collections.Generic.List<Coordinate> points, Coordinate query)
+        {
+            Coordinate nearest = null;
+            double minDist = double.PositiveInfinity;
+            foreach (var p in points)
+            {
+                double d = query.Distance(p);
+                if (d < minDist)
+                {
+                    minDist = d;
+                    nearest = p;
+                }
+            }
+            return nearest;
+        }
+
+        private static System.Collections.Generic.List<Coordinate> BruteForceNearestNeighbors(
+            System.Collections.Generic.List<Coordinate> points, Coordinate query, int k)
+        {
+            var sorted = new System.Collections.Generic.List<Coordinate>(points);
+            sorted.Sort((a, b) => query.Distance(a).CompareTo(query.Distance(b)));
+            return sorted.GetRange(0, System.Math.Min(k, sorted.Count));
+        }
+
+        [Test]
         public void TestMultiplePoint()
         {
             TestQuery("MULTIPOINT ( (1 1), (2 2) )", 0,


### PR DESCRIPTION
## Summary

Adds two first-class k-nearest-neighbor methods on `KdTree<T>`, ported from JTS 1.21 ([locationtech/jts#1114](https://github.com/locationtech/jts/issues/1114)). Resolves [#814](https://github.com/NetTopologySuite/NetTopologySuite/issues/814).

```csharp
public KdNode<T> NearestNeighbor(Coordinate query);
public IList<KdNode<T>> NearestNeighbors(Coordinate query, int k);
```

Both use an iterative depth-first search with branch-distance pruning.

- `NearestNeighbor` matches the existing extension-method behaviour but is now a real method on `KdTree<T>` (the issue asks for both as first-class methods).
- `NearestNeighbors(k)` returns the `k` closest nodes sorted by distance (closest first). Uses a max-heap (NTS `PriorityQueue<T>` with inverted `CompareTo`) to track the worst kept candidate; subtrees whose split-plane distance exceeds the heap's worst are pruned.

## Files

- `src/NetTopologySuite/Index/KdTree/KdTree.NearestNeighbors.cs` — new partial-class file containing both methods + supporting private types (`NNFrame`, `NNStackFrame`, `Neighbor`).
- `src/NetTopologySuite/Index/KdTree/KdTreeExtensions.cs` — the existing `NearestNeighbor` extension method now delegates to the new first-class method. Backwards compatible.
- `test/NetTopologySuite.Tests.NUnit/Index/KdTree/KdTreeTest.cs` — adds 7 new tests.

## NTS-idiomatic adaptations

- JTS 1.21 added an `axisIsX` field to `KdNode` (breaking change to the ctor). NTS's `KdNode` doesn't carry that field — the axis is tracked through traversal state instead, matching the existing NTS `KdTreeExtensions` style. No `KdNode` ctor changes here.
- JTS's `java.util.PriorityQueue` (natural-order min-heap) becomes NTS's `PriorityQueue<T>` with `T : IComparable<T>`; the `Neighbor` helper inverts `CompareTo` to get max-heap semantics.

## Test plan

- [x] All 17 KdTreeTest cases pass (10 pre-existing + 7 new)
- [x] Index regression suite green (163 pass)
- [x] Full NTS suite green (2575 pass, 25 pre-existing skips, 0 failed)
- [x] CI green across all target frameworks

The new tests include:
- Two brute-force-comparison tests ported from JTS: 1000-point / 500-query for single-NN and 2500-point / 50-trial for k-NN. Both use deterministic seeds.
- Empty-tree and `k <= 0` boundary tests.
- Ordering and `k > tree.Count` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)