### PR TITLE
[Design record] curves: CircularString, CompoundCurve, CurvePolygon, Triangle, Tin (superseded — see #857)

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -15,16 +15,24 @@ jobs:
     - name: Get source
       uses: actions/checkout@v2
 
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 3.1.406
+        dotnet-version: 10
 
     - name: Build
       run: dotnet build -c Release -v minimal -p:WarningLevel=3
 
-    - name: Test
-      run: dotnet test -c Release --no-build --filter '(TestCategory!=LongRunning)&(TestCategory!=Stress)&(TestCategory!=FailureCase)'
+    - name: Test NUnit
+      run: dotnet test test/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj -c Release --no-build --filter '(TestCategory!=LongRunning)&(TestCategory!=Stress)&(TestCategory!=FailureCase)'
+      shell: bash # defaults disagree on how to quote the filter string
+
+    - name: Test Samples
+      run: dotnet test test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj -c Release --no-build --filter '(TestCategory!=LongRunning)&(TestCategory!=Stress)&(TestCategory!=FailureCase)'
+      shell: bash # defaults disagree on how to quote the filter string
+
+    - name: Test Vivid XUnit
+      run: dotnet test test/NetTopologySuite.Tests.Vivid.XUnit/NetTopologySuite.Tests.Vivid.XUnit.csproj -c Release --no-build --filter '(TestCategory!=LongRunning)&(TestCategory!=Stress)&(TestCategory!=FailureCase)'
       shell: bash # defaults disagree on how to quote the filter string
 
     - name: Pack
@@ -44,10 +52,10 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
 
     steps:
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 3.1.406
+        dotnet-version: 10
 
     - name: Download Package Files
       uses: actions/download-artifact@v5
@@ -69,10 +77,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
 
     steps:
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 3.1.406
+        dotnet-version: 10
 
     - name: Download Package Files
       uses: actions/download-artifact@v5

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 3.1.406
 
@@ -31,7 +31,7 @@ jobs:
       run: dotnet pack -c Release --no-build -o artifacts -p:NoWarn=NU5105
 
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: NuGet Package Files (${{ matrix.os }})
         path: artifacts
@@ -45,12 +45,12 @@ jobs:
 
     steps:
     - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 3.1.406
 
     - name: Download Package Files
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v5
       with:
         name: NuGet Package Files (ubuntu-latest)
         path: artifacts
@@ -70,12 +70,12 @@ jobs:
 
     steps:
     - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 3.1.406
 
     - name: Download Package Files
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v5
       with:
         name: NuGet Package Files (ubuntu-latest)
         path: artifacts

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,7 @@
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' == 'True' ">
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <NtsBuildMetadata Condition=" '$(NtsBuildMetadata)' == '' ">ci.github.$(GITHUB_ACTION)</NtsBuildMetadata>
+    <NtsBuildMetadata Condition=" '$(NtsBuildMetadata)' == '' ">ci.github.$(GITHUB_RUN_ID)</NtsBuildMetadata>
 
     <NtsOfficialRelease Condition=" '$(GITHUB_REF)' == 'refs/heads/master' And '$(GITHUB_EVENT_NAME)' == 'push' ">true</NtsOfficialRelease>
   </PropertyGroup>

--- a/src/NetTopologySuite.TestRunner.Console/NetTopologySuite.TestRunner.Console.csproj
+++ b/src/NetTopologySuite.TestRunner.Console/NetTopologySuite.TestRunner.Console.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>NetTopologySuite</RootNamespace>
     <OutputType>Exe</OutputType>
     <ApplicationIcon>App.ico</ApplicationIcon>

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA-CA CircularString on top of the
+// foundational Curve/Surface abstractions already on enhancement/curved.
+// Not for merge into develop without further design discussion -- see the PR
+// description for scope, decisions, and open questions.
+
+using System;
+using System.Collections.Generic;
+using NetTopologySuite.Algorithm;
+using NetTopologySuite.Operation;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA-CA <c>CircularString</c>: a sequence of circular arc segments,
+    /// each defined by three consecutive coordinates (start, point on arc, end).
+    /// </summary>
+    /// <remarks>
+    /// A <c>CircularString</c> with <c>2n + 1</c> coordinates encodes <c>n</c> arcs,
+    /// with adjacent arcs sharing endpoints.  An empty <c>CircularString</c> has zero
+    /// coordinates.
+    /// <para/>
+    /// This is a prototype.  In particular, <c>Length</c> and <c>Boundary</c> currently
+    /// fall back to chord-based computations (treating the control points as a polyline)
+    /// rather than analytical arc geometry; the inherited <see cref="Curve.IsClosed"/>
+    /// semantics still apply (start equals end).
+    /// </remarks>
+    [Serializable]
+    public class CircularString : Curve
+    {
+        /// <summary>The control points of the arcs.</summary>
+        private readonly CoordinateSequence _points;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularString"/> class.
+        /// </summary>
+        /// <param name="points">The coordinate sequence of control points</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If the sequence has fewer than 3 points or an even number of points
+        /// (must be 0 or odd and at least 3).
+        /// </exception>
+        public CircularString(CoordinateSequence points, GeometryFactory factory) : base(factory)
+        {
+            if (points == null)
+            {
+                points = factory.CoordinateSequenceFactory.Create(0, 2);
+            }
+            if (points.Count != 0)
+            {
+                if (points.Count < 3)
+                {
+                    throw new ArgumentException(
+                        "A non-empty CircularString must have at least 3 control points " +
+                        "(start, on-arc, end of the first arc).", nameof(points));
+                }
+                if (points.Count % 2 == 0)
+                {
+                    throw new ArgumentException(
+                        "A CircularString must have an odd number of control points " +
+                        "(2n + 1 points encode n arcs).", nameof(points));
+                }
+            }
+            _points = points;
+        }
+
+        /// <summary>The control points of this <c>CircularString</c>.</summary>
+        public CoordinateSequence CoordinateSequence => _points;
+
+        /// <summary>The number of arc segments encoded by this <c>CircularString</c>.</summary>
+        public int NumArcs => _points.Count == 0 ? 0 : (_points.Count - 1) / 2;
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints => _points.Count;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _points.Count == 0;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => IsEmpty ? null : _points.GetCoordinate(0);
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates => _points.ToCoordinateArray();
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinateFlag = (Ordinates)(1 << (int)ordinate);
+            if ((_points.Ordinates & ordinateFlag) != ordinateFlag)
+            {
+                var nulls = new double[_points.Count];
+                for (int i = 0; i < nulls.Length; i++) nulls[i] = Coordinate.NullOrdinate;
+                return nulls;
+            }
+            var vals = new double[_points.Count];
+            for (int i = 0; i < _points.Count; i++) vals[i] = _points.GetOrdinate(i, (int)ordinate);
+            return vals;
+        }
+
+        /// <inheritdoc cref="Curve.StartPoint"/>
+        public override Point StartPoint =>
+            IsEmpty ? Point.Empty : Factory.CreatePoint(_points.GetCoordinate(0));
+
+        /// <inheritdoc cref="Curve.EndPoint"/>
+        public override Point EndPoint =>
+            IsEmpty ? Point.Empty : Factory.CreatePoint(_points.GetCoordinate(_points.Count - 1));
+
+        /// <inheritdoc cref="Curve.IsClosed"/>
+        public override bool IsClosed
+        {
+            get
+            {
+                if (IsEmpty) return false;
+                return _points.GetCoordinate(0).Equals2D(_points.GetCoordinate(_points.Count - 1));
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CircularString";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CircularString;
+
+        /// <summary>
+        /// Length approximated by summing arc-chord lengths.  Analytical arc-length
+        /// computation is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Length => Algorithm.Length.OfLine(_points);
+
+        /// <inheritdoc cref="Geometry.Boundary"/>
+        public override Geometry Boundary => new BoundaryOp(this).GetBoundary();
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            if (IsEmpty) return new Envelope();
+            // Conservative: enclose all control points. The true analytical
+            // envelope of an arc may extend beyond control points by up to the
+            // sagitta of the arc; a follow-up will tighten this.
+            var env = new Envelope();
+            for (int i = 0; i < _points.Count; i++)
+                env.ExpandToInclude(_points.GetCoordinate(i));
+            return env;
+        }
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CircularString)other;
+            if (_points.Count != o._points.Count) return false;
+            var cec = Factory.CoordinateEqualityComparer;
+            for (int i = 0; i < _points.Count; i++)
+            {
+                if (!cec.Equals(_points.GetCoordinate(i), o._points.GetCoordinate(i), tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            for (int i = 0; i < _points.Count; i++) filter.Filter(_points.GetCoordinate(i));
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            if (_points.Count == 0) return;
+            for (int i = 0; i < _points.Count; i++)
+            {
+                filter.Filter(_points, i);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            filter.Filter(_points);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal() => new CircularString(_points.Copy(), Factory);
+
+        /// <inheritdoc/>
+        public override void Normalize()
+        {
+            // Two normalization choices for an arc string: (a) keep direction,
+            // (b) flip endpoints when start > end in lex order. Mirror LineString:
+            if (IsEmpty) return;
+            var lex = _points.GetCoordinate(0).CompareTo(_points.GetCoordinate(_points.Count - 1));
+            if (lex > 0) CoordinateSequences.Reverse(_points);
+        }
+
+        /// <inheritdoc/>
+        public override Geometry Reverse()
+        {
+            var rev = _points.Copy();
+            CoordinateSequences.Reverse(rev);
+            return new CircularString(rev, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal() => Reverse();
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CircularString;
+
+        /// <summary>
+        /// CompareTo for two CircularStrings uses coordinate-sequence lex order.
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CircularString)o;
+            int n = Math.Min(_points.Count, other._points.Count);
+            for (int i = 0; i < n; i++)
+            {
+                int c = _points.GetCoordinate(i).CompareTo(other._points.GetCoordinate(i));
+                if (c != 0) return c;
+            }
+            return _points.Count.CompareTo(other._points.Count);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            return comp.Compare(_points, ((CircularString)o)._points);
+        }
+
+        // NOTE: SortIndex falls back to LineString here so this prototype can
+        // be CompareTo'd against ordinary geometries without modifying the
+        // protected SortIndexValue enum in Geometry.cs. A proper port should
+        // add a dedicated CircularString sort index.
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.LineString;
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Fable 5)
+//
+// Status: PLAYGROUND -- in-tree port of the SQL/MM CompoundCurve prototype from
+// the out-of-tree NetTopologySuite.Curve repository, following the maintainer
+// discussion on the PR ("in-tree is the way to go"). Not for merge into develop
+// without further design discussion -- see the PR description.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// A SQL/MM Spatial (ISO/IEC 13249-3) <c>CompoundCurve</c>: a single, contiguous
+    /// curve composed of a sequence of <see cref="Curve"/> components -- in this
+    /// prototype either <see cref="LineString"/>s or <see cref="CircularString"/>s --
+    /// where each component starts at the end point of its predecessor.
+    /// </summary>
+    /// <remarks>
+    /// Nested <c>CompoundCurve</c> components are rejected, keeping the component
+    /// list flat (matching SQL/MM and common implementations).
+    /// <para/>
+    /// This is a prototype.  Like <see cref="CircularString"/>, metric properties
+    /// (<c>Length</c>, envelopes) fall back to the chord-based computations of the
+    /// components rather than analytical arc geometry.
+    /// </remarks>
+    [Serializable]
+    public class CompoundCurve : Curve
+    {
+        /// <summary>The component curves.</summary>
+        private readonly Curve[] _curves;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompoundCurve"/> class.
+        /// </summary>
+        /// <param name="curves">The component curves, in traversal order</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If a component is <c>null</c>, empty, or a <c>CompoundCurve</c> itself, or
+        /// if a component does not start at the end point of its predecessor.
+        /// </exception>
+        public CompoundCurve(Curve[] curves, GeometryFactory factory) : base(factory)
+        {
+            if (curves == null)
+            {
+                curves = new Curve[0];
+            }
+            for (int i = 0; i < curves.Length; i++)
+            {
+                if (curves[i] == null)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain null components.", nameof(curves));
+                }
+                if (curves[i].IsEmpty)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain empty components.", nameof(curves));
+                }
+                if (curves[i] is CompoundCurve)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain nested CompoundCurve components.",
+                        nameof(curves));
+                }
+                if (i > 0)
+                {
+                    var previousEnd = curves[i - 1].EndPoint.Coordinate;
+                    var currentStart = curves[i].StartPoint.Coordinate;
+                    if (!previousEnd.Equals2D(currentStart))
+                    {
+                        throw new ArgumentException(
+                            "The components of a CompoundCurve must be contiguous: component " + i +
+                            " starts at " + currentStart + " but its predecessor ends at " + previousEnd + ".",
+                            nameof(curves));
+                    }
+                }
+            }
+            _curves = curves;
+        }
+
+        /// <summary>
+        /// Gets the component curves of this <c>CompoundCurve</c>.
+        /// </summary>
+        public IReadOnlyList<Curve> Curves => _curves;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _curves.Length == 0;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => IsEmpty ? null : _curves[0].Coordinate;
+
+        /// <summary>
+        /// The coordinates of the components, concatenated in traversal order with
+        /// the shared join point of adjacent components emitted only once.
+        /// </summary>
+        public override Coordinate[] Coordinates
+        {
+            get
+            {
+                var coordinates = new List<Coordinate>();
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    var componentCoordinates = _curves[i].Coordinates;
+                    for (int j = i == 0 ? 0 : 1; j < componentCoordinates.Length; j++)
+                    {
+                        coordinates.Add(componentCoordinates[j]);
+                    }
+                }
+                return coordinates.ToArray();
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints
+        {
+            get
+            {
+                if (IsEmpty) return 0;
+                int numPoints = _curves[0].NumPoints;
+                for (int i = 1; i < _curves.Length; i++)
+                {
+                    numPoints += _curves[i].NumPoints - 1;
+                }
+                return numPoints;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinates = new List<double>();
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                double[] componentOrdinates = _curves[i].GetOrdinates(ordinate);
+                for (int j = i == 0 ? 0 : 1; j < componentOrdinates.Length; j++)
+                {
+                    ordinates.Add(componentOrdinates[j]);
+                }
+            }
+            return ordinates.ToArray();
+        }
+
+        /// <inheritdoc cref="Curve.StartPoint"/>
+        public override Point StartPoint =>
+            IsEmpty ? Point.Empty : _curves[0].StartPoint;
+
+        /// <inheritdoc cref="Curve.EndPoint"/>
+        public override Point EndPoint =>
+            IsEmpty ? Point.Empty : _curves[_curves.Length - 1].EndPoint;
+
+        /// <inheritdoc cref="Curve.IsClosed"/>
+        public override bool IsClosed
+        {
+            get
+            {
+                if (IsEmpty) return false;
+                return StartPoint.Coordinate.Equals2D(EndPoint.Coordinate);
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CompoundCurve";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CompoundCurve;
+
+        /// <summary>
+        /// Length approximated by summing component lengths.  For
+        /// <see cref="CircularString"/> components this is the chord-based fallback;
+        /// analytical arc-length computation is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Length
+        {
+            get
+            {
+                double length = 0d;
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    length += _curves[i].Length;
+                }
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The boundary of a curve per the Mod-2 rule: empty when the curve is empty
+        /// or closed, otherwise the two end points.
+        /// </summary>
+        public override Geometry Boundary
+        {
+            get
+            {
+                if (IsEmpty || IsClosed)
+                {
+                    return Factory.CreateMultiPoint();
+                }
+                return Factory.CreateMultiPoint(new[] { StartPoint, EndPoint });
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            var env = new Envelope();
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                env.ExpandToInclude(_curves[i].EnvelopeInternal);
+            }
+            return env;
+        }
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CompoundCurve)other;
+            if (_curves.Length != o._curves.Length) return false;
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                if (!_curves[i].EqualsExact(o._curves[i], tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++) _curves[i].Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                _curves[i].Apply(filter);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                _curves[i].Apply(filter);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            for (int i = 0; i < _curves.Length; i++) _curves[i].Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var curves = new Curve[_curves.Length];
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                curves[i] = (Curve)_curves[i].Copy();
+            }
+            return new CompoundCurve(curves, Factory);
+        }
+
+        /// <inheritdoc/>
+        public override void Normalize()
+        {
+            // Mirror the CircularString choice: flip traversal direction when the
+            // start point is lexicographically greater than the end point.
+            if (IsEmpty) return;
+            if (StartPoint.Coordinate.CompareTo(EndPoint.Coordinate) > 0)
+            {
+                Array.Reverse(_curves);
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    _curves[i] = (Curve)_curves[i].Reverse();
+                }
+                GeometryChanged();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override Geometry Reverse()
+        {
+            var curves = new Curve[_curves.Length];
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                curves[i] = (Curve)_curves[_curves.Length - 1 - i].Reverse();
+            }
+            return new CompoundCurve(curves, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal() => Reverse();
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CompoundCurve;
+
+        /// <summary>
+        /// CompareTo for two CompoundCurves uses lex order of the concatenated
+        /// coordinates (type-blind across component kinds).
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CompoundCurve)o;
+            var a = Coordinates;
+            var b = other.Coordinates;
+            int n = Math.Min(a.Length, b.Length);
+            for (int i = 0; i < n; i++)
+            {
+                int c = a[i].CompareTo(b[i]);
+                if (c != 0) return c;
+            }
+            return a.Length.CompareTo(b.Length);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            var other = (CompoundCurve)o;
+            var factory = Factory.CoordinateSequenceFactory;
+            return comp.Compare(factory.Create(Coordinates), factory.Create(other.Coordinates));
+        }
+
+        // NOTE: SortIndex falls back to LineString for the same reason
+        // CircularString falls back to LineString -- prototype hygiene. A proper
+        // SortIndex entry should be added when this leaves playground status.
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.LineString;
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Fable 5)
+//
+// Status: PLAYGROUND -- in-tree port of the SQL/MM CurvePolygon prototype from
+// the out-of-tree NetTopologySuite.Curve repository, following the maintainer
+// discussion on the PR ("in-tree is the way to go"). This carries the F-CP
+// structural contract of the SFA Curve Awareness epic (locationtech/jts#1195,
+// Phase 1): rings are exposed as Curve, never collapsed to LinearRing.
+// Not for merge into develop without further design discussion -- see the PR
+// description.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// A SQL/MM Spatial (ISO/IEC 13249-3) <c>CurvePolygon</c>: a planar surface like
+    /// <see cref="Polygon"/>, but whose exterior and interior rings are
+    /// <see cref="Curve"/>s -- <see cref="LinearRing"/>s, closed
+    /// <see cref="CircularString"/>s or closed <see cref="CompoundCurve"/>s.
+    /// </summary>
+    /// <remarks>
+    /// Because <c>CurvePolygon</c> extends <c>Surface&lt;Curve&gt;</c> rather than
+    /// <c>Polygon</c>, the ring accessors are typed <see cref="Curve"/> and never
+    /// collapse a curved ring to a flat <see cref="LinearRing"/> (the F-CP
+    /// structural contract).
+    /// <para/>
+    /// This is a prototype.  <c>Area</c> and <c>Length</c> fall back to chord-based
+    /// computations that treat the control points of curved rings as polylines;
+    /// analytical arc geometry and linearization are tracked in the prototype
+    /// roadmap.
+    /// </remarks>
+    [Serializable]
+    public class CurvePolygon : Surface<Curve>
+    {
+        /// <summary>The exterior ring.</summary>
+        private readonly Curve _shell;
+
+        /// <summary>The interior rings.</summary>
+        private readonly Curve[] _holes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurvePolygon"/> class with no
+        /// interior rings.
+        /// </summary>
+        /// <param name="shell">The exterior ring, a closed <c>Curve</c> (or null for an empty polygon)</param>
+        /// <param name="factory">The geometry factory</param>
+        public CurvePolygon(Curve shell, GeometryFactory factory)
+            : this(shell, null, factory)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurvePolygon"/> class.
+        /// </summary>
+        /// <param name="shell">The exterior ring, a closed <c>Curve</c> (or null for an empty polygon)</param>
+        /// <param name="holes">The interior rings, closed <c>Curve</c>s</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If a ring is not closed, a hole is <c>null</c>, or the shell is empty while
+        /// holes are not.
+        /// </exception>
+        public CurvePolygon(Curve shell, Curve[] holes, GeometryFactory factory) : base(factory)
+        {
+            if (shell == null)
+            {
+                shell = new CircularString(factory.CoordinateSequenceFactory.Create(0, 2), factory);
+            }
+            if (holes == null)
+            {
+                holes = new Curve[0];
+            }
+            foreach (var hole in holes)
+            {
+                if (hole == null)
+                {
+                    throw new ArgumentException(
+                        "A CurvePolygon must not contain null holes.", nameof(holes));
+                }
+            }
+            if (shell.IsEmpty && HasNonEmptyElements(holes))
+            {
+                throw new ArgumentException("shell is empty but holes are not", nameof(holes));
+            }
+            if (!shell.IsEmpty && !shell.IsClosed)
+            {
+                throw new ArgumentException(
+                    "The shell of a CurvePolygon must be closed.", nameof(shell));
+            }
+            foreach (var hole in holes)
+            {
+                if (!hole.IsEmpty && !hole.IsClosed)
+                {
+                    throw new ArgumentException(
+                        "The holes of a CurvePolygon must be closed.", nameof(holes));
+                }
+            }
+            _shell = shell;
+            _holes = holes;
+        }
+
+        private static bool HasNonEmptyElements(Curve[] curves)
+        {
+            foreach (var curve in curves)
+            {
+                if (!curve.IsEmpty) return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc cref="Surface{T}.ExteriorRing"/>
+        public override Curve ExteriorRing => _shell;
+
+        /// <inheritdoc cref="Surface{T}.NumInteriorRings"/>
+        public override int NumInteriorRings => _holes.Length;
+
+        /// <inheritdoc cref="Surface{T}.GetInteriorRingN"/>
+        public override Curve GetInteriorRingN(int index) => _holes[index];
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CurvePolygon";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CurvePolygon;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _shell.IsEmpty;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => _shell.Coordinate;
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates
+        {
+            get
+            {
+                if (IsEmpty) return new Coordinate[0];
+                var coordinates = new List<Coordinate>(_shell.Coordinates);
+                foreach (var hole in _holes)
+                {
+                    coordinates.AddRange(hole.Coordinates);
+                }
+                return coordinates.ToArray();
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints
+        {
+            get
+            {
+                int numPoints = _shell.NumPoints;
+                foreach (var hole in _holes)
+                {
+                    numPoints += hole.NumPoints;
+                }
+                return numPoints;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinates = new List<double>(_shell.GetOrdinates(ordinate));
+            foreach (var hole in _holes)
+            {
+                ordinates.AddRange(hole.GetOrdinates(ordinate));
+            }
+            return ordinates.ToArray();
+        }
+
+        /// <summary>
+        /// Area approximated by treating the control points of the rings as polyline
+        /// rings (chord-based, consistent with <see cref="CircularString"/>'s
+        /// chord-based <c>Length</c>).  For curved rings the true area differs by the
+        /// circular segments; analytical arc area is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Area
+        {
+            get
+            {
+                if (IsEmpty) return 0d;
+                double area = Algorithm.Area.OfRing(_shell.Coordinates);
+                foreach (var hole in _holes)
+                {
+                    area -= Algorithm.Area.OfRing(hole.Coordinates);
+                }
+                return area;
+            }
+        }
+
+        /// <summary>
+        /// Perimeter approximated by summing ring lengths (chord-based for curved
+        /// rings).
+        /// </summary>
+        public override double Length
+        {
+            get
+            {
+                double length = _shell.Length;
+                foreach (var hole in _holes)
+                {
+                    length += hole.Length;
+                }
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The rings of this surface.  Returned as a <see cref="GeometryCollection"/>
+        /// of <see cref="Curve"/>s for now -- a dedicated <c>MultiCurve</c> type is
+        /// part of the prototype roadmap.
+        /// </summary>
+        public override Geometry Boundary
+        {
+            get
+            {
+                if (IsEmpty)
+                {
+                    return Factory.CreateGeometryCollection();
+                }
+                var rings = new Geometry[1 + _holes.Length];
+                rings[0] = _shell;
+                for (int i = 0; i < _holes.Length; i++)
+                {
+                    rings[i + 1] = _holes[i];
+                }
+                return Factory.CreateGeometryCollection(rings);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal() => _shell.EnvelopeInternal;
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CurvePolygon)other;
+            if (!_shell.EqualsExact(o._shell, tolerance)) return false;
+            if (_holes.Length != o._holes.Length) return false;
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                if (!_holes[i].EqualsExact(o._holes[i], tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            _shell.Apply(filter);
+            foreach (var hole in _holes) hole.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (!filter.Done)
+            {
+                foreach (var hole in _holes)
+                {
+                    hole.Apply(filter);
+                    if (filter.Done) break;
+                }
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (!filter.Done)
+            {
+                foreach (var hole in _holes)
+                {
+                    hole.Apply(filter);
+                    if (filter.Done) break;
+                }
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            _shell.Apply(filter);
+            foreach (var hole in _holes) hole.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var holes = new Curve[_holes.Length];
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                holes[i] = (Curve)_holes[i].Copy();
+            }
+            return new CurvePolygon((Curve)_shell.Copy(), holes, Factory);
+        }
+
+        /// <summary>
+        /// Normalization of ring orientation and hole ordering requires orientation
+        /// of curved rings, which is part of the prototype roadmap.  This prototype
+        /// implementation does nothing.
+        /// </summary>
+        public override void Normalize()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Geometry Reverse()
+        {
+            var holes = new Curve[_holes.Length];
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                holes[i] = (Curve)_holes[i].Reverse();
+            }
+            return new CurvePolygon((Curve)_shell.Reverse(), holes, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal() => Reverse();
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CurvePolygon;
+
+        /// <summary>
+        /// CompareTo for two CurvePolygons uses lex order of the shell coordinates,
+        /// then the hole count, then lex order of the hole coordinates (type-blind
+        /// across ring kinds).
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CurvePolygon)o;
+            int c = CompareCoordinates(_shell.Coordinates, other._shell.Coordinates);
+            if (c != 0) return c;
+            c = _holes.Length.CompareTo(other._holes.Length);
+            if (c != 0) return c;
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                c = CompareCoordinates(_holes[i].Coordinates, other._holes[i].Coordinates);
+                if (c != 0) return c;
+            }
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            var other = (CurvePolygon)o;
+            var factory = Factory.CoordinateSequenceFactory;
+            return comp.Compare(factory.Create(Coordinates), factory.Create(other.Coordinates));
+        }
+
+        private static int CompareCoordinates(Coordinate[] a, Coordinate[] b)
+        {
+            int n = Math.Min(a.Length, b.Length);
+            for (int i = 0; i < n; i++)
+            {
+                int c = a[i].CompareTo(b[i]);
+                if (c != 0) return c;
+            }
+            return a.Length.CompareTo(b.Length);
+        }
+
+        // NOTE: SortIndex falls back to Polygon for the same reason Triangle falls
+        // back to Polygon -- prototype hygiene. A proper SortIndex entry should be
+        // added when this leaves playground status.
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.Polygon;
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/Tin.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Tin.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure: AI-drafted, human-reviewed.
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA-CA Triangulated Irregular
+// Network (TIN), modeled as a GeometryCollection of Triangle (also defined in
+// this Curves namespace).  Not for merge.
+
+using System;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA-CA Triangulated Irregular Network: a homogeneous collection of
+    /// <see cref="Triangle"/>s.  Conceptually a piecewise-linear surface, but
+    /// represented here as a <see cref="GeometryCollection"/> for tooling
+    /// compatibility on the prototype branch.
+    /// </summary>
+    /// <remarks>
+    /// All elements are required to be <see cref="Triangle"/> instances; the
+    /// constructor enforces this.  Adjacency, shared-edge consistency, and
+    /// orientation invariants are not currently checked -- those are downstream
+    /// validity properties that should accompany an eventual
+    /// <c>IsValid</c>-style predicate.
+    /// </remarks>
+    [Serializable]
+    public class Tin : GeometryCollection
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Tin"/> class.
+        /// </summary>
+        /// <param name="triangles">The constituent triangles (may be empty or null)</param>
+        /// <param name="factory">The geometry factory</param>
+        public Tin(Triangle[] triangles, GeometryFactory factory)
+            : base(triangles ?? new Triangle[0], factory)
+        {
+            // The base ctor accepts Geometry[]; the array contravariance is fine
+            // here because Triangle inherits from Geometry. The element-type
+            // constraint is encoded in the (Triangle[]) parameter signature, so
+            // downstream code can't slip a non-Triangle in through this entry
+            // point. The Geometry[] form on the base class is still reachable
+            // via the inherited APIs; an IsValid-style invariant check would
+            // catch that case.
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "TIN";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.TIN;
+
+        /// <summary>The dimension of a TIN is that of a surface (2).</summary>
+        public override Dimension Dimension => Dimension.Surface;
+
+        /// <summary>The boundary of a TIN is curvilinear (the perimeter of the union).</summary>
+        public override Dimension BoundaryDimension => Dimension.Curve;
+
+        /// <summary>
+        /// Gets the triangle at the given index.
+        /// </summary>
+        public Triangle GetTriangleN(int index) => (Triangle)GetGeometryN(index);
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var copies = new Triangle[NumGeometries];
+            for (int i = 0; i < NumGeometries; i++)
+            {
+                copies[i] = (Triangle)GetGeometryN(i).Copy();
+            }
+            return new Tin(copies, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is Tin;
+
+        /// <summary>
+        /// The total area of the TIN, computed as the sum of triangle areas.
+        /// Adjacent triangles that overlap will double-count; the prototype
+        /// assumes a well-formed TIN.
+        /// </summary>
+        public override double Area
+        {
+            get
+            {
+                double total = 0.0;
+                for (int i = 0; i < NumGeometries; i++)
+                {
+                    total += ((Triangle)GetGeometryN(i)).Area;
+                }
+                return total;
+            }
+        }
+
+        // SortIndex: fall back to MultiPolygon for the same prototype reason as
+        // CircularString/Triangle. Proper sort key follow-up.
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.MultiPolygon;
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/Triangle.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Triangle.cs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure: AI-drafted, human-reviewed.
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA Triangle on the enhancement/curved
+// foundational Surface<T> abstraction.  Not for merge.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA <c>Triangle</c>: a <see cref="Surface{T}"/> whose exterior ring has
+    /// exactly four coordinates (three distinct vertices plus a closing repeat) and
+    /// no interior rings.
+    /// </summary>
+    /// <remarks>
+    /// This is a sibling of the existing <see cref="Geometries.Triangle"/> utility
+    /// class -- they live in different namespaces.  The utility class provides
+    /// <c>InCentre</c> / <c>IsAcute</c> / <c>PerpendicularBisector</c> on raw
+    /// <see cref="Coordinate"/>s without participating in the geometry hierarchy;
+    /// this class is a full <see cref="Geometry"/> that takes part in WKT, WKB,
+    /// envelopes, predicates, etc.
+    /// </remarks>
+    [Serializable]
+    public class Triangle : Surface<LinearRing>
+    {
+        private readonly LinearRing _shell;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Triangle"/> class from a
+        /// closed 4-coordinate shell.
+        /// </summary>
+        /// <param name="shell">A linear ring with exactly four coordinates (or empty)</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If the shell is non-empty and does not have exactly four coordinates.
+        /// </exception>
+        public Triangle(LinearRing shell, GeometryFactory factory) : base(factory)
+        {
+            shell = shell ?? factory.CreateLinearRing((CoordinateSequence)null);
+            if (!shell.IsEmpty && shell.NumPoints != 4)
+            {
+                throw new ArgumentException(
+                    "A Triangle must have a 4-coordinate shell (3 distinct vertices " +
+                    "plus a closing repeat), got " + shell.NumPoints + " points.",
+                    nameof(shell));
+            }
+            _shell = shell;
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "Triangle";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.Triangle;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _shell.IsEmpty;
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints => _shell.NumPoints;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => _shell.Coordinate;
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates => _shell.Coordinates;
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate) => _shell.GetOrdinates(ordinate);
+
+        /// <inheritdoc cref="Surface{T}.ExteriorRing"/>
+        public override LinearRing ExteriorRing => _shell;
+
+        /// <inheritdoc cref="Surface{T}.NumInteriorRings"/>
+        public override int NumInteriorRings => 0;
+
+        /// <inheritdoc cref="Surface{T}.GetInteriorRingN"/>
+        public override LinearRing GetInteriorRingN(int index)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index),
+                "A Triangle has no interior rings.");
+        }
+
+        /// <summary>
+        /// Signed twice-area of the triangle (positive for CCW vertices, negative
+        /// for CW, zero for a degenerate triangle).
+        /// </summary>
+        public double SignedDoubleArea
+        {
+            get
+            {
+                if (IsEmpty) return 0.0;
+                var c = _shell.Coordinates;
+                return (c[1].X - c[0].X) * (c[2].Y - c[0].Y)
+                     - (c[2].X - c[0].X) * (c[1].Y - c[0].Y);
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.Area"/>
+        public override double Area => Math.Abs(SignedDoubleArea) / 2.0;
+
+        /// <inheritdoc cref="Geometry.Length"/>
+        public override double Length => _shell.Length;
+
+        /// <inheritdoc cref="Geometry.Boundary"/>
+        public override Geometry Boundary => IsEmpty
+            ? (Geometry)Factory.CreateMultiLineString()
+            : Factory.CreateLineString(_shell.CoordinateSequence.Copy());
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal() => _shell.EnvelopeInternal;
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (Triangle)other;
+            return _shell.EqualsExact(o._shell, tolerance);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter) => _shell.Apply(filter);
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            _shell.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal() => new Triangle((LinearRing)_shell.Copy(), Factory);
+
+        /// <inheritdoc/>
+        public override void Normalize() => _shell.Normalize();
+
+        /// <inheritdoc/>
+        public override Geometry Reverse() => new Triangle((LinearRing)_shell.Reverse(), Factory);
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal() => Reverse();
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is Triangle;
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o)
+        {
+            return _shell.CompareTo(((Triangle)o)._shell);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            return comp.Compare(_shell.CoordinateSequence, ((Triangle)o)._shell.CoordinateSequence);
+        }
+
+        // NOTE: SortIndex falls back to Polygon for the same reason CircularString
+        // falls back to LineString -- prototype hygiene. A proper SortIndex entry
+        // should be added when this leaves playground status.
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.Polygon;
+    }
+}

--- a/src/NetTopologySuite/Geometries/OgcGeometryType.cs
+++ b/src/NetTopologySuite/Geometries/OgcGeometryType.cs
@@ -87,7 +87,11 @@ namespace NetTopologySuite.Geometries
         TIN = 16,
 // ReSharper restore InconsistentNaming
 
-        
+        /// <summary>
+        /// Triangle (SFA-CA). A polygon with exactly three distinct vertices.
+        /// </summary>
+        Triangle = 17,
+
 
 
         /*

--- a/src/NetTopologySuite/IO/WKTConstants.cs
+++ b/src/NetTopologySuite/IO/WKTConstants.cs
@@ -42,6 +42,27 @@ namespace NetTopologySuite.IO
         public const string POLYGON = "POLYGON";
 
         /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CircularString"/> geometries
+        /// </summary>
+        public const string CIRCULARSTRING = "CIRCULARSTRING";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CompoundCurve"/> geometries
+        /// </summary>
+        public const string COMPOUNDCURVE = "COMPOUNDCURVE";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CurvePolygon"/> geometries
+        /// </summary>
+        public const string CURVEPOLYGON = "CURVEPOLYGON";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.Triangle"/> geometries
+        /// </summary>
+        public const string TRIANGLE = "TRIANGLE";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.Tin"/> geometries
+        /// </summary>
+        public const string TIN = "TIN";
+
+        /// <summary>
         /// Token text for empty geometries
         /// </summary>
         public const string EMPTY = "EMPTY";

--- a/src/NetTopologySuite/IO/WKTReader.cs
+++ b/src/NetTopologySuite/IO/WKTReader.cs
@@ -738,6 +738,16 @@ namespace NetTopologySuite.IO
                 returned = ReadMultiPolygonText(tokens, factory, ordinateFlags);
             else if (type.StartsWith(WKTConstants.GEOMETRYCOLLECTION, StringComparison.OrdinalIgnoreCase))
                 returned = ReadGeometryCollectionText(tokens, factory, ordinateFlags);
+            else if (type.StartsWith(WKTConstants.CIRCULARSTRING, StringComparison.OrdinalIgnoreCase))
+                returned = ReadCircularStringText(tokens, factory, ordinateFlags);
+            else if (type.StartsWith(WKTConstants.COMPOUNDCURVE, StringComparison.OrdinalIgnoreCase))
+                returned = ReadCompoundCurveText(tokens, factory, ordinateFlags);
+            else if (type.StartsWith(WKTConstants.CURVEPOLYGON, StringComparison.OrdinalIgnoreCase))
+                returned = ReadCurvePolygonText(tokens, factory, ordinateFlags);
+            else if (type.StartsWith(WKTConstants.TRIANGLE, StringComparison.OrdinalIgnoreCase))
+                returned = ReadTriangleText(tokens, factory, ordinateFlags);
+            else if (type.StartsWith(WKTConstants.TIN, StringComparison.OrdinalIgnoreCase))
+                returned = ReadTinText(tokens, factory, ordinateFlags);
             else
                 returned = ReadOtherGeometryText(type, tokens, factory, ordinateFlags);
 
@@ -973,6 +983,169 @@ namespace NetTopologySuite.IO
             while (nextToken.Equals(","));
 
             return factory.CreateGeometryCollection(geometries.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a <c>CircularString</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CircularString Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CircularString</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CircularString ReadCircularStringText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            var sequence = GetCoordinateSequence(factory, tokens, ordinateFlags);
+            return new Geometries.Curves.CircularString(sequence, factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Curve</c> using the next token in the stream: either a bare
+        /// coordinate list (a <c>LineString</c>), a tagged <c>CIRCULARSTRING</c>, or -- where
+        /// allowed -- a tagged <c>COMPOUNDCURVE</c>.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a curve component.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <param name="allowCompoundCurve">Whether a <c>COMPOUNDCURVE</c> is allowed at this position</param>
+        /// <returns>A <c>Curve</c> specified by the next token in the stream.</returns>
+        private Curve ReadCurveText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags, bool allowCompoundCurve)
+        {
+            string current = LookAheadWord(tokens);
+
+            if (current.Equals(WKTConstants.EMPTY) || current.Equals("("))
+            {
+                var sequence = GetCoordinateSequence(factory, tokens, ordinateFlags);
+                return factory.CreateLineString(sequence);
+            }
+
+            if (current.StartsWith(WKTConstants.CIRCULARSTRING, StringComparison.OrdinalIgnoreCase))
+            {
+                GetNextWord(tokens);
+                return ReadCircularStringText(tokens, factory, ordinateFlags);
+            }
+
+            if (current.StartsWith(WKTConstants.COMPOUNDCURVE, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!allowCompoundCurve)
+                    throw new ParseException("A COMPOUNDCURVE is not allowed as a component of another COMPOUNDCURVE");
+                GetNextWord(tokens);
+                return ReadCompoundCurveText(tokens, factory, ordinateFlags);
+            }
+
+            throw new ParseException("Unexpected token: " + current);
+        }
+
+        /// <summary>
+        /// Creates a <c>CompoundCurve</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CompoundCurve Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CompoundCurve</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CompoundCurve ReadCompoundCurveText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.CompoundCurve(null, factory);
+
+            var curves = new List<Curve>();
+            do
+            {
+                var curve = ReadCurveText(tokens, factory, ordinateFlags, false);
+                curves.Add(curve);
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            while (nextToken.Equals(","));
+
+            return new Geometries.Curves.CompoundCurve(curves.ToArray(), factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>CurvePolygon</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CurvePolygon Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CurvePolygon</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CurvePolygon ReadCurvePolygonText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.CurvePolygon(null, factory);
+
+            var shell = ReadCurveText(tokens, factory, ordinateFlags, true);
+            var holes = new List<Curve>();
+            nextToken = GetNextCloserOrComma(tokens);
+            while (nextToken.Equals(","))
+            {
+                var hole = ReadCurveText(tokens, factory, ordinateFlags, true);
+                holes.Add(hole);
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            return new Geometries.Curves.CurvePolygon(shell, holes.ToArray(), factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Triangle</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a Triangle Text (a Polygon Text without holes).
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>Triangle</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.Triangle ReadTriangleText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            var polygon = ReadPolygonText(tokens, factory, ordinateFlags);
+            if (polygon.IsEmpty)
+                return new Geometries.Curves.Triangle(null, factory);
+            if (polygon.NumInteriorRings != 0)
+                throw new ParseException("A TRIANGLE must not contain interior rings");
+            return new Geometries.Curves.Triangle((LinearRing)polygon.ExteriorRing, factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Tin</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a Tin Text (a MultiPolygon Text whose
+        ///   elements are hole-free triangles).
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>Tin</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.Tin ReadTinText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.Tin(null, factory);
+
+            var triangles = new List<Geometries.Curves.Triangle>();
+            do
+            {
+                var polygon = ReadPolygonText(tokens, factory, ordinateFlags);
+                if (polygon.NumInteriorRings != 0)
+                    throw new ParseException("A TRIANGLE within a TIN must not contain interior rings");
+                triangles.Add(new Geometries.Curves.Triangle((LinearRing)polygon.ExteriorRing, factory));
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            while (nextToken.Equals(","));
+
+            return new Geometries.Curves.Tin(triangles.ToArray(), factory);
         }
     }
 }

--- a/src/NetTopologySuite/IO/WKTWriter.cs
+++ b/src/NetTopologySuite/IO/WKTWriter.cs
@@ -523,6 +523,27 @@ namespace NetTopologySuite.IO
                     AppendMultiPolygonTaggedText(multiPolygon, outputOrdinates, topLevel, useFormatting, level, writer, ordinateFormat);
                     break;
 
+                case Geometries.Curves.CircularString circularString:
+                    AppendCircularStringTaggedText(circularString, outputOrdinates, topLevel, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CompoundCurve compoundCurve:
+                    AppendCompoundCurveTaggedText(compoundCurve, outputOrdinates, topLevel, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CurvePolygon curvePolygon:
+                    AppendCurvePolygonTaggedText(curvePolygon, outputOrdinates, topLevel, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.Triangle triangle:
+                    AppendTriangleTaggedText(triangle, outputOrdinates, topLevel, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                // NB: Tin extends GeometryCollection, so this case must come first.
+                case Geometries.Curves.Tin tin:
+                    AppendTinTaggedText(tin, outputOrdinates, topLevel, useFormatting, level, writer, ordinateFormat);
+                    break;
+
                 case GeometryCollection geometryCollection:
                     AppendGeometryCollectionTaggedText(geometryCollection, outputOrdinates, topLevel, useFormatting, level, writer, ordinateFormat);
                     break;
@@ -989,6 +1010,225 @@ namespace NetTopologySuite.IO
                 }
                 writer.Write(")");
             }
+        }
+
+        /// <summary>
+        /// Converts a <c>CircularString</c> to CircularString Tagged Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="circularString">The <c>CircularString</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="topLevel">A flag indicating if the geometry is stand-alone or part of a collection.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCircularStringTaggedText(Geometries.Curves.CircularString circularString, Ordinates outputOrdinates, bool topLevel, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+            if (topLevel) AppendOrdinateText(outputOrdinates, writer);
+            AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>CompoundCurve</c> to CompoundCurve Tagged Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="compoundCurve">The <c>CompoundCurve</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="topLevel">A flag indicating if the geometry is stand-alone or part of a collection.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCompoundCurveTaggedText(Geometries.Curves.CompoundCurve compoundCurve, Ordinates outputOrdinates, bool topLevel, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.COMPOUNDCURVE} ");
+            if (topLevel) AppendOrdinateText(outputOrdinates, writer);
+            AppendCompoundCurveText(compoundCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>CompoundCurve</c> to CompoundCurve Text format, then appends
+        /// it to the writer. <c>LineString</c> components are written as bare
+        /// coordinate lists, <c>CircularString</c> components with their tag.
+        /// </summary>
+        /// <param name="compoundCurve">The <c>CompoundCurve</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCompoundCurveText(Geometries.Curves.CompoundCurve compoundCurve, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (compoundCurve.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            writer.Write("(");
+            for (int i = 0; i < compoundCurve.Curves.Count; i++)
+            {
+                if (i > 0) writer.Write(", ");
+                var component = compoundCurve.Curves[i];
+                if (component is Geometries.Curves.CircularString circularString)
+                {
+                    writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+                    AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                }
+                else
+                {
+                    AppendSequenceText(((LineString)component).CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                }
+            }
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a <c>CurvePolygon</c> to CurvePolygon Tagged Text format, then
+        /// appends it to the writer. <c>LineString</c> rings are written as bare
+        /// coordinate lists, <c>CircularString</c> and <c>CompoundCurve</c> rings
+        /// with their tags.
+        /// </summary>
+        /// <param name="curvePolygon">The <c>CurvePolygon</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="topLevel">A flag indicating if the geometry is stand-alone or part of a collection.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCurvePolygonTaggedText(Geometries.Curves.CurvePolygon curvePolygon, Ordinates outputOrdinates, bool topLevel, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.CURVEPOLYGON} ");
+            if (topLevel) AppendOrdinateText(outputOrdinates, writer);
+
+            if (curvePolygon.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            writer.Write("(");
+            AppendCurveRingText(curvePolygon.ExteriorRing, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+            for (int i = 0; i < curvePolygon.NumInteriorRings; i++)
+            {
+                writer.Write(", ");
+                AppendCurveRingText(curvePolygon.GetInteriorRingN(i), outputOrdinates, useFormatting, level + 1, writer, ordinateFormat);
+            }
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a single ring of a <c>CurvePolygon</c> to Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="ring">The ring to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCurveRingText(Curve ring, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            switch (ring)
+            {
+                case Geometries.Curves.CircularString circularString:
+                    writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+                    AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CompoundCurve compoundCurve:
+                    writer.Write($"{WKTConstants.COMPOUNDCURVE} ");
+                    AppendCompoundCurveText(compoundCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                default:
+                    AppendSequenceText(((LineString)ring).CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>Triangle</c> to Triangle Tagged Text format, then appends it
+        /// to the writer.
+        /// </summary>
+        /// <param name="triangle">The <c>Triangle</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="topLevel">A flag indicating if the geometry is stand-alone or part of a collection.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTriangleTaggedText(Geometries.Curves.Triangle triangle, Ordinates outputOrdinates, bool topLevel, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.TRIANGLE} ");
+            if (topLevel) AppendOrdinateText(outputOrdinates, writer);
+            AppendTriangleText(triangle, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>Triangle</c> to Triangle Text format (a Polygon Text without
+        /// holes), then appends it to the writer.
+        /// </summary>
+        /// <param name="triangle">The <c>Triangle</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="indentFirst">flag indicating that the first <see cref="Coordinate"/> of the sequence should be indented for better visibility.</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTriangleText(Geometries.Curves.Triangle triangle, Ordinates outputOrdinates, bool useFormatting, int level, bool indentFirst, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (triangle.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            if (indentFirst) Indent(useFormatting, level, writer);
+            writer.Write("(");
+            AppendSequenceText(triangle.ExteriorRing.CoordinateSequence, outputOrdinates,
+                useFormatting, level, false, writer, ordinateFormat);
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a <c>Tin</c> to Tin Tagged Text format, then appends it to the
+        /// writer.
+        /// </summary>
+        /// <param name="tin">The <c>Tin</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="topLevel">A flag indicating if the geometry is stand-alone or part of a collection.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTinTaggedText(Geometries.Curves.Tin tin, Ordinates outputOrdinates, bool topLevel, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.TIN} ");
+            if (topLevel) AppendOrdinateText(outputOrdinates, writer);
+
+            if (tin.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            int level2 = level;
+            bool doIndent = false;
+            writer.Write("(");
+            for (int i = 0; i < tin.NumGeometries; i++)
+            {
+                if (i > 0)
+                {
+                    writer.Write(", ");
+                    level2 = level + 1;
+                    doIndent = true;
+                }
+                AppendTriangleText((Geometries.Curves.Triangle)tin.GetGeometryN(i), outputOrdinates, useFormatting, level2, doIndent, writer, ordinateFormat);
+            }
+            writer.Write(")");
         }
 
         private void IndentCoords(bool useFormatting, int coordIndex, int level, TextWriter writer)

--- a/src/NetTopologySuite/NetTopologySuite.csproj
+++ b/src/NetTopologySuite/NetTopologySuite.csproj
@@ -5,9 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <NoWarn>659,168,1587</NoWarn>
-    <EnableApiCompat>true</EnableApiCompat>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ApiCompatExcludeAttributeList>ApiCompatExcludeAttributes.txt</ApiCompatExcludeAttributeList>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Info">
@@ -28,13 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(EnableApiCompat)' == 'true' ">
-    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21159.11" PrivateAssets="All" />
-    <PackageDownload Include="NetTopologySuite" Version="[2.2.0]" PrivateAssets="All" />
-
-    <ResolvedMatchingContract Include="$(NugetPackageRoot)nettopologysuite\2.2.0\lib\netstandard2.0\NetTopologySuite.dll" />
   </ItemGroup>
 
 </Project>

--- a/test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
+++ b/test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>NetTopologySuite.Samples</RootNamespace>
     <OutputType>Exe</OutputType>
     <StartupObject>NetTopologySuite.Samples.SimpleTests.Program</StartupObject>
@@ -20,6 +20,8 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src\NetTopologySuite\NetTopologySuite.csproj" />
     <ProjectReference Include="$(SolutionDir)src\NetTopologySuite.Lab\NetTopologySuite.Lab.csproj" />
+
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.3" />
   </ItemGroup>
 
 </Project>

--- a/test/NetTopologySuite.Samples.Console/SimpleTests/Geometries/SerializationSamples.cs
+++ b/test/NetTopologySuite.Samples.Console/SimpleTests/Geometries/SerializationSamples.cs
@@ -12,7 +12,9 @@ namespace NetTopologySuite.Samples.SimpleTests.Geometries
     public class SerializationSamples : BaseSamples
     {
         private readonly string filepath = string.Empty;
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
         private IFormatter serializer = null;
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
 
         private Coordinate[] coordinates = null;
         private Point point = null;
@@ -24,7 +26,12 @@ namespace NetTopologySuite.Samples.SimpleTests.Geometries
         {
             filepath = Path.GetTempPath() + "\\testserialization.bin";
 
+            // don't use BinaryFormatter in production. read this instead:
+            // https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+            AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
             serializer = new BinaryFormatter();
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
 
             point = Factory.CreatePoint(new Coordinate(100, 100));
 

--- a/test/NetTopologySuite.Tests.NUnit.Performance/NetTopologySuite.Tests.NUnit.Performance.csproj
+++ b/test/NetTopologySuite.Tests.NUnit.Performance/NetTopologySuite.Tests.NUnit.Performance.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!--<TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>-->
+    <TargetFramework>net10.0</TargetFramework>
+    <!--<TargetFrameworks>net10.0;net48</TargetFrameworks>-->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularStringTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularStringTest.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Opus-4.7)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class CircularStringTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Make(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            var seq = _factory.CoordinateSequenceFactory.Create(coords);
+            return new CircularString(seq, _factory);
+        }
+
+        [Test]
+        public void EmptyCircularStringHasZeroPoints()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, 2), _factory);
+            Assert.That(cs.IsEmpty, Is.True);
+            Assert.That(cs.NumPoints, Is.EqualTo(0));
+            Assert.That(cs.NumArcs, Is.EqualTo(0));
+            Assert.That(cs.IsClosed, Is.False);
+        }
+
+        [Test]
+        public void SingleArcHasThreePoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            Assert.That(cs.NumPoints, Is.EqualTo(3));
+            Assert.That(cs.NumArcs, Is.EqualTo(1));
+            Assert.That(cs.IsEmpty, Is.False);
+            Assert.That(cs.GeometryType, Is.EqualTo("CircularString"));
+            Assert.That(cs.OgcGeometryType, Is.EqualTo(OgcGeometryType.CircularString));
+        }
+
+        [Test]
+        public void TwoArcsHaveFivePoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0), (0, -1), (1, 0));
+            Assert.That(cs.NumPoints, Is.EqualTo(5));
+            Assert.That(cs.NumArcs, Is.EqualTo(2));
+            // The endpoint equals the startpoint, so it's closed.
+            Assert.That(cs.IsClosed, Is.True);
+        }
+
+        [Test]
+        public void NonEmptyMustHaveAtLeastThreePoints()
+        {
+            var seq = _factory.CoordinateSequenceFactory.Create(new[] {
+                new Coordinate(0, 0), new Coordinate(1, 1)
+            });
+            Assert.Throws<ArgumentException>(() => new CircularString(seq, _factory));
+        }
+
+        [Test]
+        public void PointCountMustBeOdd()
+        {
+            var seq = _factory.CoordinateSequenceFactory.Create(new[] {
+                new Coordinate(0, 0), new Coordinate(1, 1),
+                new Coordinate(2, 0), new Coordinate(3, 1)
+            });
+            Assert.Throws<ArgumentException>(() => new CircularString(seq, _factory));
+        }
+
+        [Test]
+        public void StartAndEndPointsAreFirstAndLast()
+        {
+            var cs = Make((1, 2), (3, 4), (5, 6));
+            Assert.That(cs.StartPoint.X, Is.EqualTo(1));
+            Assert.That(cs.StartPoint.Y, Is.EqualTo(2));
+            Assert.That(cs.EndPoint.X, Is.EqualTo(5));
+            Assert.That(cs.EndPoint.Y, Is.EqualTo(6));
+        }
+
+        [Test]
+        public void EnvelopeEnclosesAllControlPoints()
+        {
+            var cs = Make((0, 0), (5, 10), (10, 0));
+            var env = cs.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(10));
+            Assert.That(env.MinY, Is.EqualTo(0));
+            Assert.That(env.MaxY, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void CopyProducesEqualButDistinctObject()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var copy = (CircularString)cs.Copy();
+            Assert.That(copy.EqualsExact(cs), Is.True);
+            Assert.That(ReferenceEquals(copy, cs), Is.False);
+        }
+
+        [Test]
+        public void ReverseFlipsCoordinateOrder()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var rev = (CircularString)cs.Reverse();
+            Assert.That(rev.StartPoint.X, Is.EqualTo(-1));
+            Assert.That(rev.EndPoint.X, Is.EqualTo(1));
+            // Double reverse is identity.
+            var revrev = (CircularString)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cs), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCircularStringFromLineString()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var ls = _factory.CreateLineString(cs.Coordinates);
+            Assert.That(cs.EqualsExact(ls), Is.False,
+                "CircularString and LineString with the same coordinates should not be EqualsExact.");
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CompoundCurveTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CompoundCurveTest.cs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class CompoundCurveTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Arc(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private LineString Line(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLineString(coords);
+        }
+
+        [Test]
+        public void EmptyCompoundCurveHasZeroPoints()
+        {
+            var cc = new CompoundCurve(null, _factory);
+            Assert.That(cc.IsEmpty, Is.True);
+            Assert.That(cc.NumPoints, Is.EqualTo(0));
+            Assert.That(cc.Curves.Count, Is.EqualTo(0));
+            Assert.That(cc.IsClosed, Is.False);
+            Assert.That(cc.GeometryType, Is.EqualTo("CompoundCurve"));
+            Assert.That(cc.OgcGeometryType, Is.EqualTo(OgcGeometryType.CompoundCurve));
+        }
+
+        [Test]
+        public void LineArcLineSharesJoinPoints()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)), Line((3, 0), (4, 0)) },
+                _factory);
+
+            Assert.That(cc.Curves.Count, Is.EqualTo(3));
+            // 2 + 3 + 2 control points, with the two join points emitted once.
+            Assert.That(cc.NumPoints, Is.EqualTo(5));
+            Assert.That(cc.Coordinates.Length, Is.EqualTo(5));
+            Assert.That(cc.StartPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+            Assert.That(cc.EndPoint.Coordinate, Is.EqualTo(new Coordinate(4, 0)));
+            Assert.That(cc.IsClosed, Is.False);
+        }
+
+        [Test]
+        public void MembersRetainSubtypes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+
+            Assert.That(cc.Curves[0], Is.InstanceOf<CircularString>());
+            Assert.That(cc.Curves[1], Is.InstanceOf<LineString>());
+        }
+
+        [Test]
+        public void ClosedCompoundCurveIsClosedAndHasEmptyBoundary()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (0, 0)) },
+                _factory);
+
+            Assert.That(cc.IsClosed, Is.True);
+            Assert.That(cc.Boundary.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void OpenCompoundCurveBoundaryIsEndpoints()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) },
+                _factory);
+
+            var boundary = cc.Boundary;
+            Assert.That(boundary.NumGeometries, Is.EqualTo(2));
+            Assert.That(boundary.GetGeometryN(0).Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+            Assert.That(boundary.GetGeometryN(1).Coordinate, Is.EqualTo(new Coordinate(3, 0)));
+        }
+
+        [Test]
+        public void LengthIsSumOfComponentLengths()
+        {
+            var line = Line((0, 0), (1, 0));
+            var arc = Arc((1, 0), (2, 1), (3, 0));
+            var cc = new CompoundCurve(new Curve[] { line, arc }, _factory);
+
+            Assert.That(cc.Length, Is.EqualTo(line.Length + arc.Length).Within(1e-12));
+        }
+
+        [Test]
+        public void EnvelopeIsUnionOfComponentEnvelopes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 5), (3, 0)) },
+                _factory);
+
+            var env = cc.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(3));
+            Assert.That(env.MinY, Is.EqualTo(0));
+            Assert.That(env.MaxY, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void RejectsNullComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { null }, _factory));
+        }
+
+        [Test]
+        public void RejectsEmptyComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { _factory.CreateLineString() }, _factory));
+        }
+
+        [Test]
+        public void RejectsNonContiguousComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(
+                    new Curve[] { Line((0, 0), (1, 0)), Line((2, 0), (3, 0)) },
+                    _factory));
+        }
+
+        [Test]
+        public void RejectsNestedCompoundCurves()
+        {
+            var inner = new CompoundCurve(new Curve[] { Line((0, 0), (1, 0)) }, _factory);
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { inner }, _factory));
+        }
+
+        [Test]
+        public void CopyProducesEqualButDistinctObjectAndPreservesSubtypes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+            var copy = (CompoundCurve)cc.Copy();
+
+            Assert.That(copy.EqualsExact(cc), Is.True);
+            Assert.That(ReferenceEquals(copy, cc), Is.False);
+            Assert.That(copy.Curves[0], Is.InstanceOf<CircularString>());
+            Assert.That(ReferenceEquals(copy.Curves[0], cc.Curves[0]), Is.False);
+        }
+
+        [Test]
+        public void ReverseFlipsComponentOrderAndDirection()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+            var rev = (CompoundCurve)cc.Reverse();
+
+            Assert.That(rev.Curves[0], Is.InstanceOf<LineString>());
+            Assert.That(rev.Curves[1], Is.InstanceOf<CircularString>());
+            Assert.That(rev.StartPoint.Coordinate, Is.EqualTo(new Coordinate(3, 0)));
+            Assert.That(rev.EndPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+
+            // Double reverse is identity.
+            var revrev = (CompoundCurve)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cc), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCompoundCurveFromLineString()
+        {
+            var cc = new CompoundCurve(new Curve[] { Line((0, 0), (1, 0), (2, 0)) }, _factory);
+            var ls = Line((0, 0), (1, 0), (2, 0));
+            Assert.That(cc.EqualsExact(ls), Is.False,
+                "CompoundCurve and LineString with the same coordinates should not be EqualsExact.");
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+//
+// The "FCP_*" tests are the in-tree port of CurvePolygonStructuralSpec from the
+// out-of-tree NetTopologySuite.Curve repository. They pin the F-CP (Structural
+// CurvePolygon) contract of the SFA Curve Awareness epic (locationtech/jts#1195,
+// Phase 1): rings are exposed as Curve and never collapse to LinearRing on
+// access or copy. Per NTS convention these stay in the codebase indefinitely as
+// a regression net. The out-of-tree sub-TAGs FCP-TL (linearization) and FCP-WKT
+// (round-trip) depend on facilities this prototype does not carry yet; they
+// come back with the linearization / IO follow-ups.
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    [Category("CurveAwareness")]
+    public class CurvePolygonTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Arc(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private LinearRing Ring(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLinearRing(coords);
+        }
+
+        private LineString Line(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLineString(coords);
+        }
+
+        /// <summary>A compound shell made of two semi-circles, plus one linear hole.</summary>
+        private CurvePolygon CompoundShellWithLinearHole()
+        {
+            var shell = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (5, 5), (10, 0)), Arc((10, 0), (5, -5), (0, 0)) },
+                _factory);
+            var hole = Ring((2, -1), (8, -1), (8, 1), (2, 1), (2, -1));
+            return new CurvePolygon(shell, new Curve[] { hole }, _factory);
+        }
+
+        /// <summary>A CurvePolygon with a CircularString hole inside a flat shell.</summary>
+        private CurvePolygon FlatShellWithArcHole()
+        {
+            var shell = Ring((0, 0), (100, 0), (100, 100), (0, 100), (0, 0));
+            var hole = Arc((40, 50), (50, 60), (60, 50), (50, 40), (40, 50));
+            return new CurvePolygon(shell, new Curve[] { hole }, _factory);
+        }
+
+        // ============================================================
+        // F-CP structural contract (ported from CurvePolygonStructuralSpec)
+        // ============================================================
+
+        [Test]
+        public void FCP_S_compound_shell_exposed_as_CompoundCurve()
+        {
+            var cp = CompoundShellWithLinearHole();
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-S: compound shell should be exposed as CompoundCurve, got "
+                + cp.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_S_arc_shell_exposed_as_CircularString()
+        {
+            var cp = new CurvePolygon(Arc((0, 0), (10, 0), (5, 5), (0, 5), (0, 0)), _factory);
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<CircularString>(),
+                "FCP-S: arc shell should be exposed as CircularString, got "
+                + cp.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_MEM_compound_shell_members_retain_subtypes()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var cc = (CompoundCurve)cp.ExteriorRing;
+            Assert.That(cc.Curves.Count, Is.EqualTo(2),
+                "FCP-MEM: compound shell should have two members");
+            Assert.That(cc.Curves[0], Is.InstanceOf<CircularString>(),
+                "FCP-MEM: member 0 should be a CircularString");
+            Assert.That(cc.Curves[1], Is.InstanceOf<CircularString>(),
+                "FCP-MEM: member 1 should be a CircularString");
+        }
+
+        [Test]
+        public void FCP_H_arc_hole_exposed_as_CircularString()
+        {
+            var cp = FlatShellWithArcHole();
+            Assert.That(cp.NumInteriorRings, Is.EqualTo(1),
+                "FCP-H: CurvePolygon has one interior ring");
+            Assert.That(cp.GetInteriorRingN(0), Is.InstanceOf<CircularString>(),
+                "FCP-H: arc hole should be a CircularString, got "
+                + cp.GetInteriorRingN(0).GetType().Name);
+        }
+
+        [Test]
+        public void FCP_CP_copy_preserves_shell_subtype()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var copy = (CurvePolygon)cp.Copy();
+
+            Assert.That(copy.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-CP: copied shell must also be a CompoundCurve, got "
+                + copy.ExteriorRing.GetType().Name);
+            Assert.That(copy.ExteriorRing, Is.Not.SameAs(cp.ExteriorRing),
+                "FCP-CP: copy must be a deep copy of the shell");
+            Assert.That(copy.EqualsExact(cp), Is.True);
+        }
+
+        [Test]
+        public void FCP_CP_copy_preserves_arc_hole_subtype()
+        {
+            var cp = FlatShellWithArcHole();
+            var copy = (CurvePolygon)cp.Copy();
+
+            Assert.That(copy.GetInteriorRingN(0), Is.InstanceOf<CircularString>(),
+                "FCP-CP: copied hole must remain a CircularString, got "
+                + copy.GetInteriorRingN(0).GetType().Name);
+        }
+
+        [Test]
+        public void FCP_DOVE_ring_accessors_are_typed_Curve()
+        {
+            var exteriorRingType = typeof(CurvePolygon).GetProperty(nameof(CurvePolygon.ExteriorRing))?.PropertyType;
+            Assert.That(exteriorRingType, Is.Not.Null,
+                "FCP-DOVE: CurvePolygon must expose an ExteriorRing accessor");
+            Assert.That(exteriorRingType, Is.EqualTo(typeof(Curve)),
+                "FCP-DOVE: CurvePolygon.ExteriorRing must be typed as Curve "
+                + "(the polymorphic base of LinearRing / LineString / CircularString / "
+                + "CompoundCurve). If this returns LinearRing again, the JTS-side "
+                + "FCP-DOVE A/B/C dovetail decision needs to be made here too.");
+        }
+
+        // ============================================================
+        // Construction and basic behavior
+        // ============================================================
+
+        [Test]
+        public void EmptyCurvePolygonHasZeroPoints()
+        {
+            var cp = new CurvePolygon(null, _factory);
+            Assert.That(cp.IsEmpty, Is.True);
+            Assert.That(cp.NumPoints, Is.EqualTo(0));
+            Assert.That(cp.NumInteriorRings, Is.EqualTo(0));
+            Assert.That(cp.Area, Is.EqualTo(0));
+            Assert.That(cp.GeometryType, Is.EqualTo("CurvePolygon"));
+            Assert.That(cp.OgcGeometryType, Is.EqualTo(OgcGeometryType.CurvePolygon));
+        }
+
+        [Test]
+        public void RejectsUnclosedShell()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(Arc((0, 0), (1, 1), (2, 0)), _factory));
+        }
+
+        [Test]
+        public void RejectsUnclosedHole()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(shell, new Curve[] { Line((1, 1), (2, 2)) }, _factory));
+        }
+
+        [Test]
+        public void RejectsEmptyShellWithHoles()
+        {
+            var hole = Ring((2, 2), (4, 2), (4, 4), (2, 4), (2, 2));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(null, new Curve[] { hole }, _factory));
+        }
+
+        [Test]
+        public void RejectsNullHoles()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(shell, new Curve[] { null }, _factory));
+        }
+
+        [Test]
+        public void ChordBasedAreaSubtractsHoles()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            var hole = Ring((2, 2), (4, 2), (4, 4), (2, 4), (2, 2));
+            var cp = new CurvePolygon(shell, new Curve[] { hole }, _factory);
+
+            Assert.That(cp.Area, Is.EqualTo(96).Within(1e-12));
+            Assert.That(cp.Length, Is.EqualTo(40 + 8).Within(1e-12));
+        }
+
+        [Test]
+        public void EnvelopeIsShellEnvelope()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var env = cp.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(10));
+            Assert.That(env.MinY, Is.EqualTo(-5));
+            Assert.That(env.MaxY, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void BoundaryExposesAllRings()
+        {
+            var cp = FlatShellWithArcHole();
+            var boundary = cp.Boundary;
+            Assert.That(boundary.NumGeometries, Is.EqualTo(2));
+            Assert.That(boundary.GetGeometryN(0), Is.InstanceOf<LinearRing>());
+            Assert.That(boundary.GetGeometryN(1), Is.InstanceOf<CircularString>());
+        }
+
+        [Test]
+        public void ReversePreservesRingSubtypes()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var rev = (CurvePolygon)cp.Reverse();
+
+            Assert.That(rev.ExteriorRing, Is.InstanceOf<CompoundCurve>());
+            Assert.That(rev.NumInteriorRings, Is.EqualTo(1));
+
+            // Double reverse is identity.
+            var revrev = (CurvePolygon)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cp), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCurvePolygonFromPolygon()
+        {
+            var shellCoords = new[] { (0d, 0d), (10d, 0d), (10d, 10d), (0d, 10d), (0d, 0d) };
+            var cp = new CurvePolygon(Ring(shellCoords), _factory);
+            var polygon = _factory.CreatePolygon(Ring(shellCoords));
+            Assert.That(cp.EqualsExact(polygon), Is.False,
+                "CurvePolygon and Polygon with the same shell should not be EqualsExact.");
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
@@ -5,14 +5,15 @@
 // out-of-tree NetTopologySuite.Curve repository. They pin the F-CP (Structural
 // CurvePolygon) contract of the SFA Curve Awareness epic (locationtech/jts#1195,
 // Phase 1): rings are exposed as Curve and never collapse to LinearRing on
-// access or copy. Per NTS convention these stay in the codebase indefinitely as
-// a regression net. The out-of-tree sub-TAGs FCP-TL (linearization) and FCP-WKT
-// (round-trip) depend on facilities this prototype does not carry yet; they
-// come back with the linearization / IO follow-ups.
+// access, copy, or WKT round-trip. Per NTS convention these stay in the
+// codebase indefinitely as a regression net. The out-of-tree sub-TAG FCP-TL
+// (linearization) depends on facilities this prototype does not carry yet; it
+// comes back with the linearization follow-up.
 
 using System;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.IO;
 using NUnit.Framework;
 
 namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
@@ -130,6 +131,36 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
             Assert.That(copy.GetInteriorRingN(0), Is.InstanceOf<CircularString>(),
                 "FCP-CP: copied hole must remain a CircularString, got "
                 + copy.GetInteriorRingN(0).GetType().Name);
+        }
+
+        [Test]
+        public void FCP_WKT_roundtrip_preserves_compound_shell()
+        {
+            var cp = CompoundShellWithLinearHole();
+            string emitted = new WKTWriter().Write(cp);
+
+            Assert.That(emitted.ToUpperInvariant(), Does.Contain("COMPOUNDCURVE"),
+                "FCP-WKT: emitted WKT must contain the COMPOUNDCURVE tag, got: " + emitted);
+
+            var roundTripped = (CurvePolygon)new WKTReader().Read(emitted);
+            Assert.That(roundTripped.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-WKT: round-tripped shell must remain a CompoundCurve, got "
+                + roundTripped.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_WKT_roundtrip_preserves_arc_shell()
+        {
+            var cp = new CurvePolygon(Arc((0, 0), (10, 0), (5, 5), (0, 5), (0, 0)), _factory);
+            string emitted = new WKTWriter().Write(cp);
+
+            Assert.That(emitted.ToUpperInvariant(), Does.Contain("CIRCULARSTRING"),
+                "FCP-WKT: emitted WKT must contain the CIRCULARSTRING tag, got: " + emitted);
+
+            var roundTripped = (CurvePolygon)new WKTReader().Read(emitted);
+            Assert.That(roundTripped.ExteriorRing, Is.InstanceOf<CircularString>(),
+                "FCP-WKT: round-tripped shell must remain a CircularString, got "
+                + roundTripped.ExteriorRing.GetType().Name);
         }
 
         [Test]

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWktTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWktTest.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+// The OGC Triangle geometry, not the coordinate utility class.
+using Triangle = NetTopologySuite.Geometries.Curves.Triangle;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// WKT round-trip tests for the curve prototype types (CIRCULARSTRING,
+    /// COMPOUNDCURVE, CURVEPOLYGON, TRIANGLE, TIN).
+    /// </summary>
+    public class CurveWktTest
+    {
+        [TestCase("CIRCULARSTRING (0 0, 1 1, 2 0)", typeof(CircularString))]
+        [TestCase("CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0)", typeof(CircularString))]
+        [TestCase("CIRCULARSTRING EMPTY", typeof(CircularString))]
+        [TestCase("COMPOUNDCURVE ((0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0), (3 0, 4 0))", typeof(CompoundCurve))]
+        [TestCase("COMPOUNDCURVE (CIRCULARSTRING (0 0, 1 1, 2 0), (2 0, 3 0))", typeof(CompoundCurve))]
+        [TestCase("COMPOUNDCURVE EMPTY", typeof(CompoundCurve))]
+        [TestCase("CURVEPOLYGON (CIRCULARSTRING (0 0, 2 2, 4 0, 2 -2, 0 0))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON (COMPOUNDCURVE (CIRCULARSTRING (0 0, 5 5, 10 0), (10 0, 0 0)), (2 1, 8 1, 8 2, 2 2, 2 1))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON ((0 0, 100 0, 100 100, 0 100, 0 0), CIRCULARSTRING (40 50, 50 60, 60 50, 50 40, 40 50))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON EMPTY", typeof(CurvePolygon))]
+        [TestCase("TRIANGLE ((0 0, 1 0, 0 1, 0 0))", typeof(Triangle))]
+        [TestCase("TRIANGLE EMPTY", typeof(Triangle))]
+        [TestCase("TIN (((0 0, 1 0, 0 1, 0 0)), ((1 0, 1 1, 0 1, 1 0)))", typeof(Tin))]
+        [TestCase("TIN EMPTY", typeof(Tin))]
+        [TestCase("GEOMETRYCOLLECTION (CIRCULARSTRING (0 0, 1 1, 2 0), POINT (5 5))", typeof(GeometryCollection))]
+        public void WktRoundTripIsStable(string wkt, Type expectedType)
+        {
+            var reader = new WKTReader();
+
+            var geometry = reader.Read(wkt);
+            Assert.That(geometry, Is.InstanceOf(expectedType));
+
+            string written = geometry.AsText();
+            Assert.That(written, Is.EqualTo(wkt));
+
+            var reparsed = reader.Read(written);
+            Assert.That(reparsed.EqualsExact(geometry), Is.True,
+                "Round-tripped geometry should be EqualsExact to the original.");
+        }
+
+        [Test]
+        public void ReadPreservesComponentAndRingSubtypes()
+        {
+            var reader = new WKTReader();
+
+            var cc = (CompoundCurve)reader.Read("COMPOUNDCURVE ((0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0))");
+            Assert.That(cc.Curves[0], Is.InstanceOf<LineString>());
+            Assert.That(cc.Curves[1], Is.InstanceOf<CircularString>());
+
+            var cp = (CurvePolygon)reader.Read(
+                "CURVEPOLYGON ((0 0, 100 0, 100 100, 0 100, 0 0), CIRCULARSTRING (40 50, 50 60, 60 50, 50 40, 40 50))");
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<LineString>());
+            Assert.That(cp.GetInteriorRingN(0), Is.InstanceOf<CircularString>());
+        }
+
+        [Test]
+        public void ReadSupportsZOrdinates()
+        {
+            var geometry = new WKTReader().Read("CIRCULARSTRING Z(0 0 5, 1 1 5, 2 0 5)");
+
+            var circularString = (CircularString)geometry;
+            Assert.That(circularString.CoordinateSequence.GetZ(0), Is.EqualTo(5));
+            Assert.That(new WKTWriter(3).Write(geometry), Is.EqualTo("CIRCULARSTRING Z(0 0 5, 1 1 5, 2 0 5)"));
+        }
+
+        [Test]
+        public void ReadRejectsNestedCompoundCurves()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("COMPOUNDCURVE (COMPOUNDCURVE ((0 0, 1 0)))"));
+        }
+
+        [Test]
+        public void ReadRejectsTriangleWithInteriorRing()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("TRIANGLE ((0 0, 10 0, 0 10, 0 0), (1 1, 2 1, 1 2, 1 1))"));
+        }
+
+        [Test]
+        public void ReadRejectsUnexpectedCurveComponent()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("CURVEPOLYGON (POINT (0 0))"));
+        }
+
+        [Test]
+        public void ReadRejectsEvenCircularStringPointCount()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new WKTReader().Read("CIRCULARSTRING (0 0, 1 1)"));
+        }
+
+        [Test]
+        public void ReadRejectsNonContiguousCompoundCurve()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new WKTReader().Read("COMPOUNDCURVE ((0 0, 1 0), (2 0, 3 0))"));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/TriangleAndTinTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/TriangleAndTinTest.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Opus-4.7)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+using Triangle = NetTopologySuite.Geometries.Curves.Triangle;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class TriangleAndTinTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private LinearRing TriRing(double ax, double ay, double bx, double by, double cx, double cy)
+        {
+            var coords = new[]
+            {
+                new Coordinate(ax, ay),
+                new Coordinate(bx, by),
+                new Coordinate(cx, cy),
+                new Coordinate(ax, ay),
+            };
+            return _factory.CreateLinearRing(coords);
+        }
+
+        [Test]
+        public void TriangleAcceptsFourCoordRing()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.That(t.NumPoints, Is.EqualTo(4));
+            Assert.That(t.GeometryType, Is.EqualTo("Triangle"));
+            Assert.That(t.OgcGeometryType, Is.EqualTo(OgcGeometryType.Triangle));
+            Assert.That(t.NumInteriorRings, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TriangleAreaIsHalfBaseTimesHeight()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 0, 8), _factory);
+            Assert.That(t.Area, Is.EqualTo(40.0).Within(1e-9));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsPositiveForCCW()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.That(t.SignedDoubleArea, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsNegativeForCW()
+        {
+            var t = new Triangle(TriRing(0, 0, 5, 8, 10, 0), _factory);
+            Assert.That(t.SignedDoubleArea, Is.LessThan(0));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsZeroForCollinear()
+        {
+            var t = new Triangle(TriRing(0, 0, 1, 1, 2, 2), _factory);
+            Assert.That(t.SignedDoubleArea, Is.EqualTo(0).Within(1e-9));
+            Assert.That(t.Area, Is.EqualTo(0).Within(1e-9));
+        }
+
+        [Test]
+        public void TriangleRejectsNon4PointRing()
+        {
+            var ring = _factory.CreateLinearRing(new[]
+            {
+                new Coordinate(0, 0), new Coordinate(10, 0),
+                new Coordinate(10, 10), new Coordinate(0, 10),
+                new Coordinate(0, 0)
+            });
+            Assert.Throws<ArgumentException>(() => new Triangle(ring, _factory));
+        }
+
+        [Test]
+        public void TriangleHasNoInteriorRings()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.Throws<ArgumentOutOfRangeException>(() => t.GetInteriorRingN(0));
+        }
+
+        [Test]
+        public void TriangleCopyIsEqualButDistinct()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var copy = (Triangle)t.Copy();
+            Assert.That(copy.EqualsExact(t), Is.True);
+            Assert.That(ReferenceEquals(copy, t), Is.False);
+        }
+
+        [Test]
+        public void TriangleReverseFlipsVertexOrder()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var rev = (Triangle)t.Reverse();
+            Assert.That(rev.SignedDoubleArea, Is.EqualTo(-t.SignedDoubleArea).Within(1e-9));
+        }
+
+        [Test]
+        public void TinHoldsTriangles()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var t2 = new Triangle(TriRing(10, 0, 20, 0, 15, 8), _factory);
+            var tin = new Tin(new[] { t1, t2 }, _factory);
+            Assert.That(tin.NumGeometries, Is.EqualTo(2));
+            Assert.That(tin.GeometryType, Is.EqualTo("TIN"));
+            Assert.That(tin.OgcGeometryType, Is.EqualTo(OgcGeometryType.TIN));
+        }
+
+        [Test]
+        public void TinAreaIsSumOfTriangleAreas()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 0, 8), _factory);
+            var t2 = new Triangle(TriRing(10, 0, 20, 0, 10, 4), _factory);
+            var tin = new Tin(new[] { t1, t2 }, _factory);
+            Assert.That(tin.Area, Is.EqualTo(40.0 + 20.0).Within(1e-9));
+        }
+
+        [Test]
+        public void EmptyTinHasZeroGeometries()
+        {
+            var tin = new Tin(new Triangle[0], _factory);
+            Assert.That(tin.NumGeometries, Is.EqualTo(0));
+            Assert.That(tin.Area, Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void TinGetTriangleNReturnsTypedElement()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var tin = new Tin(new[] { t1 }, _factory);
+            var got = tin.GetTriangleN(0);
+            Assert.That(got, Is.SameAs(t1));
+        }
+
+        [Test]
+        public void TinCopyDeepCopiesTriangles()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var tin = new Tin(new[] { t1 }, _factory);
+            var copy = (Tin)tin.Copy();
+            Assert.That(copy.NumGeometries, Is.EqualTo(1));
+            Assert.That(copy.GetTriangleN(0).EqualsExact(t1), Is.True);
+            Assert.That(ReferenceEquals(copy.GetTriangleN(0), t1), Is.False);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj
+++ b/test/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!--<TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>-->
+    <TargetFramework>net10.0</TargetFramework>
+    <!--<TargetFrameworks>net10.0;net48</TargetFrameworks>-->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)nts.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -16,6 +16,8 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src\NetTopologySuite\NetTopologySuite.csproj" />
     <ProjectReference Include="$(SolutionDir)src\NetTopologySuite.Lab\NetTopologySuite.Lab.csproj" />
+
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.3" />
   </ItemGroup>
 
 </Project>

--- a/test/NetTopologySuite.Tests.NUnit/Utilities/SerializationUtility.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Utilities/SerializationUtility.cs
@@ -11,7 +11,12 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
         {
             using (var ms = new MemoryStream())
             {
+                // don't use BinaryFormatter in production. read this instead:
+                // https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+                AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
                 var serializer = new BinaryFormatter();
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
                 serializer.Serialize(ms, obj);
                 ms.Seek(0, SeekOrigin.Begin);
                 var reader = new StreamReader(ms);
@@ -25,7 +30,12 @@ namespace NetTopologySuite.Tests.NUnit.Utilities
         {
             using (var ms = new MemoryStream(buffer))
             {
+                // don't use BinaryFormatter in production. read this instead:
+                // https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+                AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
                 var serializer = new BinaryFormatter();
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
                 return (T)serializer.Deserialize(ms);
             }
         }

--- a/test/NetTopologySuite.Tests.Vivid.XUnit/NetTopologySuite.Tests.Vivid.XUnit.csproj
+++ b/test/NetTopologySuite.Tests.Vivid.XUnit/NetTopologySuite.Tests.Vivid.XUnit.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>NetTopologySuite.Tests.XUnit</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
**This is no longer the reviewable PR.** The live work is **[#857](https://github.com/NetTopologySuite/NetTopologySuite/pull/857)** — "Add in-tree SQL/MM curve geometry types and WKT I/O foundation", against `develop`. Review that one. The intermediate MVP [#854](https://github.com/NetTopologySuite/NetTopologySuite/pull/854) was closed on 2026-08-04 in favour of #857, which carries the same five types plus SortIndex, ILinearizable, and MultiCurve / MultiSurface.

This PR stays open as the design record that produced it. Three things were settled here: in-tree versus out-of-tree, the `Triangle` naming, and the attribution correction below.

**The dependency on #526 is gone.** This originally sat on top of [#526 "Required Changes for NetTopologySuite.Curve"](https://github.com/NetTopologySuite/NetTopologySuite/pull/526) — @FObermaier's draft, opened 2021-06-10 and last updated 2024-04-11 — for the abstract `Curve` and `Surface<T>` classes and `ILinearizable<T>`. It turned out the prototype needs only a small subset of that foundation, applied to *current* `develop`. That subset passes package validation against the 2.6.0 baseline with a single suppressed diagnostic (CP0012 on `LineString.IsClosed`, virtual → override — binary-compatible in practice). #854 carried that subset and #857 carries it now, foundation commit co-authored with @FObermaier.

**Direction: in-tree.** Per @airbreather's steer — "too much of NTS assumes that all geometry types are implemented fully in-tree" — this work pivoted from *exercising* the abstractions to *porting the out-of-tree prototypes in*. The `CompoundCurve` and `CurvePolygon` prototypes from the [`NetTopologySuite.Curved`](https://github.com/NetTopologySuite/NetTopologySuite.Curved) lineage moved in-tree here, with their structural contract tests. The sub-namespace compromise for `Triangle` stands per the same discussion.

**AI-assisted contribution**, disclosed per [AI_POLICY.md](https://github.com/NetTopologySuite/NetTopologySuite/blob/develop/AI_POLICY.md). Claude assisted with both the code and this description. I have reviewed and tested the result, and I am responsible for its correctness and licensing under the project's usual terms and my signed CLA.

## Attribution: SQL/MM, not OGC SFA

Raised by @airbreather and confirmed against the source. `CIRCULARSTRING`, `COMPOUNDCURVE` and `CURVEPOLYGON` appear in OGC 06-103r4 only as type codes reserved "for future use" — they are not defined types there. They are **SQL/MM Spatial (ISO/IEC 13249-3)** types, and are attributed that way throughout. `Triangle` and `TIN` are the SFA-described types.

## What this adds

Five concrete geometry types in a new `NetTopologySuite.Geometries.Curves` sub-namespace, on the abstract `Curve` and `Surface<T>` classes:

- **`CircularString : Curve`** — SQL/MM curve composed of *n* circular arcs encoded as *2n+1* control points. The constructor accepts an empty coordinate list or an odd count of at least 3, and rejects everything else. Bounds by control points only for now; sagitta-tightening is tracked below.
- **`CompoundCurve : Curve`** *(ported in-tree)* — a single contiguous curve composed of `LineString` / `CircularString` components sharing join points. Flat component list (nested compounds rejected), contiguity enforced in the constructor, chord-based `Length` consistent with `CircularString`.
- **`CurvePolygon : Surface<Curve>`** *(ported in-tree)* — a surface whose ring accessors are typed `Curve` and never collapse to `LinearRing`. Because it extends `Surface<Curve>` rather than `Polygon`, the question of what a legacy `LinearRing`-typed accessor should return never arises here — that is the structural contract the JTS-side epic tracks as F-CP ([locationtech/jts#1195](https://github.com/locationtech/jts/issues/1195), Phase 1 of the SQL/MM Curve Awareness epic). Chord-based `Area`/`Length` fallbacks; `Boundary` returns a `GeometryCollection` of rings until a `MultiCurve` type exists.
- **`Triangle : Surface<LinearRing>`** — OGC SFA Triangle. Constructor takes a 4-coordinate `LinearRing` (3 distinct vertices plus the closing repeat) and rejects other sizes. `SignedDoubleArea` exposes the cross-product signed area. Always has zero interior rings.
- **`Tin : GeometryCollection`** — OGC SFA Triangulated Irregular Network, element type `Triangle`, `Area` the sum of triangle areas. Adjacency and shared-edge invariants are not checked; see open question 4.

Plus `OgcGeometryType.Triangle = 17`; `TIN = 16` was already in the enum. Both match ISO/IEC 13249-3 §5.1.68 Table 15.

**WKT IO.** `WKTReader` and `WKTWriter` natively read and write `CIRCULARSTRING`, `COMPOUNDCURVE`, `CURVEPOLYGON`, `TRIANGLE` and `TIN` through additive dispatch branches; the `ReadOtherGeometryText` / `AppendOtherGeometryTaggedText` extension points remain for external types. SQL/MM tagging rules apply — `LineString` components and rings are written bare, `CircularString` and `CompoundCurve` with their tags — and curves nest inside `GEOMETRYCOLLECTION` through the existing recursive dispatch.

**Build tooling.** The branch also carries the CI migration to the .NET 10 SDK. That is separable from the geometry work and can be split out if a reviewer would rather see it on its own.

**79 new tests** in `test/NetTopologySuite.Tests.NUnit/Geometries/Curves/`:

- `CircularStringTest` (10) — empty / odd / even rejection, NumArcs, IsClosed, endpoints, envelope, copy and reverse round-trip, type-distinct EqualsExact.
- `CompoundCurveTest` (14) — construction validation (null, empty, non-contiguous, nested), join-point sharing, boundary per the Mod-2 rule, envelope union, subtype-preserving copy and reverse.
- `CurvePolygonTest` (19) — the in-tree port of the out-of-tree `CurvePolygonStructuralSpec`, plus construction validation, chord-based area, boundary, and subtype-preserving reverse. The linearization case comes back with the linearization follow-up (open question 3).
- `CurveWktTest` (22) — exact-string WKT round-trip stability for all five types, including EMPTY forms and curves inside `GEOMETRYCOLLECTION`; subtype preservation on read; Z ordinates; rejection of nested `COMPOUNDCURVE`, `TRIANGLE` holes and malformed arcs.
- `TriangleAndTinTest` (14) — 4-coordinate shell enforced, base × height / 2 area, signed-area sign against orientation, collinear degeneracy, copy and reverse, `Tin` holds triangles, area sums.

## Why the namespace split

The existing `NetTopologySuite.Geometries.Triangle` is a long-standing **utility class** (`InCentre`, `IsAcute`, `PerpendicularBisector` on raw `Coordinate`s) that does not participate in the `Geometry` hierarchy. Reclaiming that name would be a breaking rename for every caller across the ecosystem, so the new OGC `Triangle` **geometry** lives in `NetTopologySuite.Geometries.Curves` instead. The two classes serve different roles, and per the discussion the sub-namespace stands as "a pretty good compromise".

## Build status

- Production project (`netstandard2.0`): builds clean on the .NET 10 SDK.
- Test project: full NUnit suite green locally on .NET 10 — 1835 passed, 0 failed.

## Open questions

These carried forward to #857, where several are now resolved.

1. **SortIndex.** All new types currently fall back to the closest existing `SortIndexValue` (LineString / Polygon / MultiPolygon) to avoid mutating `Geometry.cs` on a playground branch. A proper landing should add dedicated entries.
2. **WKB IO.** WKT read and write are in this PR; WKB is not. The out-of-tree repo has `WKBReaderEx` / `WKBWriterEx` prototypes to port next, for extended type codes 8, 9, 10, 16 and 17.
3. **Linearization.** `ILinearizable<T>` is on the foundation, but the in-tree types do not implement it yet. The out-of-tree repo's arc-linearization machinery (`CircularArc`, `ArcSegmentLength`) is the donor. This unblocks the linearization contract test, analytic `Length` and `Area`, and a sagitta-tight `ComputeEnvelopeInternal`. The client-side arc subdivision shipped for SQL Server in NetTopologySuite.IO.SqlServerBytes#35 is a second reference implementation.
4. **`Tin` adjacency invariant.** "The shared edge between any two adjacent triangles is exactly equal as a coordinate pair" is the minimum-viable `IsValid` for a TIN. Not in this PR; it should accompany an eventual landing.
5. **`MultiCurve` / `MultiSurface`.** Present in the out-of-tree repo. Porting them completes the SQL/MM type set and gives `CurvePolygon.Boundary` its proper return type.

The one I would most like reactions on is the porting order for WKB IO against linearization.

## Companion repository

[`NetTopologySuite/NetTopologySuite.Curved`](https://github.com/NetTopologySuite/NetTopologySuite.Curved) — and its active fork [`grootstebozewolf/NetTopologySuite.Curve`](https://github.com/grootstebozewolf/NetTopologySuite.Curve), whose name drops the *d* — served as the out-of-tree incubator. With the in-tree direction settled, that repo is now the **donor** for the remaining ports (IO, linearization, MultiCurve/MultiSurface) rather than a competing long-term home.
