### PR TITLE
Add in-tree SQL/MM curve geometry types and WKT I/O foundation

### DIFF
--- a/src/NetTopologySuite/Algorithm/Centroid.cs
+++ b/src/NetTopologySuite/Algorithm/Centroid.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NetTopologySuite.Algorithm.Construct;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
 
 namespace NetTopologySuite.Algorithm
 {
@@ -92,6 +93,8 @@ namespace NetTopologySuite.Algorithm
         {
             if (geom.IsEmpty)
                 return;
+            if (CurvedGeometry.ContainsCurvedType(geom))
+                throw new NotSupportedException($"Centroid is not supported for {geom.GeometryType}.");
             if (geom is Point)
             {
                 AddPoint(geom.Coordinate);
@@ -112,6 +115,10 @@ namespace NetTopologySuite.Algorithm
                 {
                     Add(gc.GetGeometryN(i));
                 }
+            }
+            else
+            {
+                throw new NotSupportedException($"Centroid is not supported for {geom.GeometryType}.");
             }
         }
 

--- a/src/NetTopologySuite/Algorithm/InteriorPoint.cs
+++ b/src/NetTopologySuite/Algorithm/InteriorPoint.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NetTopologySuite.Algorithm.Construct;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
 
 namespace NetTopologySuite.Algorithm
 {
@@ -63,6 +64,8 @@ namespace NetTopologySuite.Algorithm
         {
             if (geom.IsEmpty)
                 return null;
+
+            CurvedGeometry.CheckNotCurved(geom, "InteriorPoint");
 
             Coordinate interiorPt;
             //var dim = geom.Dimension;

--- a/src/NetTopologySuite/CompatibilitySuppressions.xml
+++ b/src/NetTopologySuite/CompatibilitySuppressions.xml
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!--
+  CP0012 on LineString.IsClosed: the member changes from 'virtual' (newslot) to
+  'override' (reuseslot) because the abstract Curve base class now declares
+  IsClosed for all curves. Virtual dispatch through a LineString reference and
+  existing external overrides of LineString.IsClosed keep working - the slot is
+  resolved through the inheritance chain at JIT time - so the change is
+  binary-compatible in practice. It cannot be expressed differently: an
+  override cannot simultaneously create a new slot.
+-->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>M:NetTopologySuite.Geometries.LineString.get_IsClosed</Target>
+    <Left>lib/netstandard2.0/NetTopologySuite.dll</Left>
+    <Right>lib/netstandard2.0/NetTopologySuite.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>P:NetTopologySuite.Geometries.LineString.IsClosed</Target>
+    <Left>lib/netstandard2.0/NetTopologySuite.dll</Left>
+    <Right>lib/netstandard2.0/NetTopologySuite.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>M:NetTopologySuite.Geometries.LineString.get_IsClosed</Target>
+    <Left>lib/netstandard2.1/NetTopologySuite.dll</Left>
+    <Right>lib/netstandard2.1/NetTopologySuite.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>P:NetTopologySuite.Geometries.LineString.IsClosed</Target>
+    <Left>lib/netstandard2.1/NetTopologySuite.dll</Left>
+    <Right>lib/netstandard2.1/NetTopologySuite.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/NetTopologySuite/Geometries/Curve.cs
+++ b/src/NetTopologySuite/Geometries/Curve.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// Abstract base class for geometries that have a <c>Dimension</c> of
+    /// <see cref="Geometries.Dimension.Curve"/> and consist of <b>only</b> <c>1</c> component.
+    /// </summary>
+    [Serializable]
+    public abstract class Curve : Geometry, ILineal
+    {
+        /// <summary>
+        /// Creates an instance of this class
+        /// </summary>
+        /// <param name="factory">The factory creating this <c>Curve</c></param>
+        protected Curve(GeometryFactory factory) : base(factory)
+        {
+        }
+
+        /// <inheritdoc cref="Geometry.Dimension"/>
+        public sealed override Dimension Dimension => Dimension.Curve;
+
+
+        /// <inheritdoc cref="Geometry.BoundaryDimension"/>
+        public override Dimension BoundaryDimension
+        {
+            get
+            {
+                if (IsClosed)
+                {
+                    return Dimension.False;
+                }
+                return Dimension.Point;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating if this <c>Curve</c> forms a ring.
+        /// </summary>
+        public bool IsRing { get => IsClosed & IsSimple; }
+
+        /// <summary>
+        /// Gets a value indicating that this <c>Curve</c> is closed.<br/>
+        /// A curve is closed if <c><see cref="StartPoint"/> == <see cref="EndPoint"/></c>.
+        /// </summary>
+        public abstract bool IsClosed { get; }
+
+        /// <summary>
+        /// Gets a value indicating the start point of this <c>CURVE</c>
+        /// </summary>
+        public abstract Point StartPoint { get; }
+
+        /// <summary>
+        /// Gets a value indicating the end point of this <c>CURVE</c>
+        /// </summary>
+        public abstract Point EndPoint { get; }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA-CA CircularString on top of the
+// foundational Curve/Surface abstractions already on enhancement/curved.
+// Not for merge into develop without further design discussion -- see the PR
+// description for scope, decisions, and open questions.
+
+using System;
+using System.Collections.Generic;
+using NetTopologySuite.Algorithm;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA-CA <c>CircularString</c>: a sequence of circular arc segments,
+    /// each defined by three consecutive coordinates (start, point on arc, end).
+    /// </summary>
+    /// <remarks>
+    /// A <c>CircularString</c> with <c>2n + 1</c> coordinates encodes <c>n</c> arcs,
+    /// with adjacent arcs sharing endpoints.  An empty <c>CircularString</c> has zero
+    /// coordinates.
+    /// <para/>
+    /// This is a prototype.  In particular, <c>Length</c> and <c>Boundary</c> currently
+    /// fall back to chord-based computations (treating the control points as a polyline)
+    /// rather than analytical arc geometry; the inherited <see cref="Curve.IsClosed"/>
+    /// semantics still apply (start equals end).
+    /// </remarks>
+    [Serializable]
+    public class CircularString : Curve, ILinearizable<LineString>
+    {
+        /// <summary>The control points of the arcs.</summary>
+        private readonly CoordinateSequence _points;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularString"/> class.
+        /// </summary>
+        /// <param name="points">The coordinate sequence of control points</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If the sequence has fewer than 3 points or an even number of points
+        /// (must be 0 or odd and at least 3).
+        /// </exception>
+        public CircularString(CoordinateSequence points, GeometryFactory factory) : base(factory)
+        {
+            if (points == null)
+            {
+                points = factory.CoordinateSequenceFactory.Create(0, Ordinates.XY);
+            }
+            if (points.Count != 0)
+            {
+                if (points.Count < 3)
+                {
+                    throw new ArgumentException(
+                        "A non-empty CircularString must have at least 3 control points " +
+                        "(start, on-arc, end of the first arc).", nameof(points));
+                }
+                if (points.Count % 2 == 0)
+                {
+                    throw new ArgumentException(
+                        "A CircularString must have an odd number of control points " +
+                        "(2n + 1 points encode n arcs).", nameof(points));
+                }
+            }
+            _points = points;
+        }
+
+        /// <summary>The control points of this <c>CircularString</c>.</summary>
+        public CoordinateSequence CoordinateSequence => _points;
+
+        /// <summary>The number of arc segments encoded by this <c>CircularString</c>.</summary>
+        public int NumArcs => _points.Count == 0 ? 0 : (_points.Count - 1) / 2;
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints => _points.Count;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _points.Count == 0;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => IsEmpty ? null : _points.GetCoordinate(0);
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates => _points.ToCoordinateArray();
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinateFlag = (Ordinates)(1 << (int)ordinate);
+            if ((_points.Ordinates & ordinateFlag) != ordinateFlag)
+            {
+                var nulls = new double[_points.Count];
+                for (int i = 0; i < nulls.Length; i++) nulls[i] = Coordinate.NullOrdinate;
+                return nulls;
+            }
+            var vals = new double[_points.Count];
+            for (int i = 0; i < _points.Count; i++) vals[i] = _points.GetOrdinate(i, (int)ordinate);
+            return vals;
+        }
+
+        /// <inheritdoc cref="Curve.StartPoint"/>
+        public override Point StartPoint =>
+            IsEmpty ? null : Factory.CreatePoint(_points.GetCoordinate(0));
+
+        /// <inheritdoc cref="Curve.EndPoint"/>
+        public override Point EndPoint =>
+            IsEmpty ? null : Factory.CreatePoint(_points.GetCoordinate(_points.Count - 1));
+
+        /// <inheritdoc cref="Curve.IsClosed"/>
+        public override bool IsClosed
+        {
+            get
+            {
+                if (IsEmpty) return false;
+                return _points.GetCoordinate(0).Equals2D(_points.GetCoordinate(_points.Count - 1));
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CircularString";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CircularString;
+
+        /// <summary>
+        /// Length approximated by summing arc-chord lengths.  Analytical arc-length
+        /// computation is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Length => Algorithm.Length.OfLine(_points);
+
+        /// <summary>
+        /// The boundary of a curve per the Mod-2 rule: empty when the curve is empty
+        /// or closed, otherwise the two end points.
+        /// </summary>
+        /// <remarks>
+        /// <c>BoundaryOp</c> only special-cases <see cref="LineString"/> and
+        /// <see cref="MultiLineString"/>; calling it for curve types recurses into
+        /// <see cref="Geometry.Boundary"/> and stack-overflows.  Mirror
+        /// <see cref="CompoundCurve.Boundary"/> until BoundaryOp learns about curves.
+        /// </remarks>
+        public override Geometry Boundary
+        {
+            get
+            {
+                if (IsEmpty || IsClosed)
+                {
+                    return Factory.CreateMultiPoint();
+                }
+                return Factory.CreateMultiPoint(new[] { StartPoint, EndPoint });
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            if (IsEmpty) return new Envelope();
+            // Conservative: enclose all control points. The true analytical
+            // envelope of an arc may extend beyond control points by up to the
+            // sagitta of the arc; a follow-up will tighten this.
+            var env = new Envelope();
+            for (int i = 0; i < _points.Count; i++)
+                env.ExpandToInclude(_points.GetCoordinate(i));
+            return env;
+        }
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CircularString)other;
+            if (_points.Count != o._points.Count) return false;
+            var cec = Factory.CoordinateEqualityComparer;
+            for (int i = 0; i < _points.Count; i++)
+            {
+                if (!cec.Equals(_points.GetCoordinate(i), o._points.GetCoordinate(i), tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            for (int i = 0; i < _points.Count; i++) filter.Filter(_points.GetCoordinate(i));
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            if (_points.Count == 0) return;
+            for (int i = 0; i < _points.Count; i++)
+            {
+                filter.Filter(_points, i);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            filter.Filter(_points);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal() => new CircularString(_points.Copy(), Factory);
+
+        /// <inheritdoc/>
+        public override void Normalize()
+        {
+            // Two normalization choices for an arc string: (a) keep direction,
+            // (b) flip endpoints when start > end in lex order. Mirror LineString:
+            if (IsEmpty) return;
+            var lex = _points.GetCoordinate(0).CompareTo(_points.GetCoordinate(_points.Count - 1));
+            if (lex > 0) CoordinateSequences.Reverse(_points);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal()
+        {
+            var rev = _points.Copy();
+            CoordinateSequences.Reverse(rev);
+            return new CircularString(rev, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CircularString;
+
+        /// <summary>
+        /// CompareTo for two CircularStrings uses coordinate-sequence lex order.
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CircularString)o;
+            int n = Math.Min(_points.Count, other._points.Count);
+            for (int i = 0; i < n; i++)
+            {
+                int c = _points.GetCoordinate(i).CompareTo(other._points.GetCoordinate(i));
+                if (c != 0) return c;
+            }
+            return _points.Count.CompareTo(other._points.Count);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            return comp.Compare(_points, ((CircularString)o)._points);
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.CircularString;
+
+        /// <summary>
+        /// Returns a chord approximation of this circular string as a
+        /// <see cref="LineString"/> through the control points.
+        /// </summary>
+        /// <remarks>
+        /// Arc-aware densification is deferred; this escape hatch lets algorithms
+        /// fall through to linear geometry without treating control polylines as
+        /// the only model of the type itself.
+        /// </remarks>
+        public LineString Linearize() => Linearize(double.NaN);
+
+        /// <summary>
+        /// Returns a chord approximation of this circular string as a
+        /// <see cref="LineString"/>.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Reserved for maximum chord length along each arc. Currently unused;
+        /// control-point chords are always returned.
+        /// </param>
+        public LineString Linearize(double arcSegmentLength)
+        {
+            if (IsEmpty)
+            {
+                return Factory.CreateLineString();
+            }
+            return Factory.CreateLineString(_points.Copy());
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -7,9 +7,10 @@
 //
 //   Assisted-by: Claude (Opus-4.7)
 //
-// Status: PRODUCTION -- SQL/MM / OGC CircularString first-class Geometry type
-// (structure + WKT/WKB foundation). Arc-aware Length / Distance / Envelope are
-// tracked by Category=Red oracle hooks (CurveOracleRedTests).
+// Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
+// Not GEOS-current metric parity: Length is control-polyline, Envelope is
+// control-bbox only, DistanceOp does not yet visit curves (see Category=Red
+// CurveOracleRedTests). Arc-aware Length/Envelope/Distance = later work.
 
 using System;
 using System.Collections.Generic;

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -7,10 +7,9 @@
 //
 //   Assisted-by: Claude (Opus-4.7)
 //
-// Status: PLAYGROUND -- prototype of OGC SFA-CA CircularString on top of the
-// foundational Curve/Surface abstractions already on enhancement/curved.
-// Not for merge into develop without further design discussion -- see the PR
-// description for scope, decisions, and open questions.
+// Status: PRODUCTION -- SQL/MM / OGC CircularString first-class Geometry type
+// (structure + WKT/WKB foundation). Arc-aware Length / Distance / Envelope are
+// tracked by Category=Red oracle hooks (CurveOracleRedTests).
 
 using System;
 using System.Collections.Generic;
@@ -27,10 +26,9 @@ namespace NetTopologySuite.Geometries.Curves
     /// with adjacent arcs sharing endpoints.  An empty <c>CircularString</c> has zero
     /// coordinates.
     /// <para/>
-    /// This is a prototype.  In particular, <c>Length</c> and <c>Boundary</c> currently
-    /// fall back to chord-based computations (treating the control points as a polyline)
-    /// rather than analytical arc geometry; the inherited <see cref="Curve.IsClosed"/>
-    /// semantics still apply (start equals end).
+    /// Foundation metrics: <c>Length</c> currently uses the control-point polyline
+    /// (not analytical arc length); arc-aware measure is gated by oracle RED tests.
+    /// The inherited <see cref="Curve.IsClosed"/> semantics apply (start equals end).
     /// </remarks>
     [Serializable]
     public class CircularString : Curve, ILinearizable<LineString>
@@ -131,7 +129,7 @@ namespace NetTopologySuite.Geometries.Curves
 
         /// <summary>
         /// Length approximated by summing arc-chord lengths.  Analytical arc-length
-        /// computation is tracked in the prototype roadmap.
+        /// is gated by oracle RED tests (arc-aware measure).
         /// </summary>
         public override double Length => Algorithm.Length.OfLine(_points);
 

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -8,13 +8,13 @@
 //   Assisted-by: Claude (Opus-4.7)
 //
 // Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
-// Not GEOS-current metric parity: Length is control-polyline, Envelope is
-// control-bbox only, DistanceOp does not yet visit curves (see Category=Red
-// CurveMetricsContractTests). Arc-aware Length/Envelope/Distance = later work.
+// Metrics and analytic ops (Length, Area, Envelope, IsSimple, Distance,
+// Centroid, InteriorPoint) fail closed with NotSupportedException until
+// arc-aware implementations land in a follow-up PR; Linearize() is the
+// explicit chord escape hatch.
 
 using System;
 using System.Collections.Generic;
-using NetTopologySuite.Algorithm;
 
 namespace NetTopologySuite.Geometries.Curves
 {
@@ -27,9 +27,10 @@ namespace NetTopologySuite.Geometries.Curves
     /// with adjacent arcs sharing endpoints.  An empty <c>CircularString</c> has zero
     /// coordinates.
     /// <para/>
-    /// Foundation metrics: <c>Length</c> currently uses the control-point polyline
-    /// (not analytical arc length); arc-aware measure is gated by Category=Red CurveMetricsContractTests.
-    /// The inherited <see cref="Curve.IsClosed"/> semantics apply (start equals end).
+    /// Metrics and analytic ops fail closed with <see cref="NotSupportedException"/>
+    /// until arc-aware implementations land; <see cref="Linearize()"/> is the explicit
+    /// chord escape hatch. The inherited <see cref="Curve.IsClosed"/> semantics apply
+    /// (start equals end).
     /// </remarks>
     [Serializable]
     public class CircularString : Curve, ILinearizable<LineString>
@@ -129,10 +130,14 @@ namespace NetTopologySuite.Geometries.Curves
         public override OgcGeometryType OgcGeometryType => OgcGeometryType.CircularString;
 
         /// <summary>
-        /// Length approximated by summing arc-chord lengths.  Analytical arc-length
-        /// is gated by Category=Red CurveMetricsContractTests (arc-aware measure).
+        /// Arc-aware length is not implemented yet. Empty is 0; otherwise throws.
         /// </summary>
-        public override double Length => Algorithm.Length.OfLine(_points);
+        /// <exception cref="NotSupportedException">
+        /// When this geometry is not empty. Call <see cref="Linearize()"/> to opt in
+        /// to an explicit chord approximation.
+        /// </exception>
+        public override double Length =>
+            IsEmpty ? 0d : throw CurvedGeometry.NotYetSupported(this, "Length");
 
         /// <summary>
         /// The boundary of a curve per the Mod-2 rule: empty when the curve is empty
@@ -160,14 +165,18 @@ namespace NetTopologySuite.Geometries.Curves
         protected override Envelope ComputeEnvelopeInternal()
         {
             if (IsEmpty) return new Envelope();
-            // Conservative: enclose all control points. The true analytical
-            // envelope of an arc may extend beyond control points by up to the
-            // sagitta of the arc; a follow-up will tighten this.
-            var env = new Envelope();
-            for (int i = 0; i < _points.Count; i++)
-                env.ExpandToInclude(_points.GetCoordinate(i));
-            return env;
+            throw CurvedGeometry.NotYetSupported(this, "Envelope");
         }
+
+        /// <summary>
+        /// Hashes a locally computed control-point envelope.
+        /// </summary>
+        /// <remarks>
+        /// Base <see cref="Geometry.GetHashCode"/> reads <c>EnvelopeInternal</c>,
+        /// which now throws for non-empty curve types. Hashing is identity, not a
+        /// geometric answer; control points are EqualsExact-consistent.
+        /// </remarks>
+        public override int GetHashCode() => CurvedGeometry.HashControlEnvelope(_points);
 
         /// <inheritdoc/>
         public override bool EqualsExact(Geometry other, double tolerance)
@@ -272,23 +281,28 @@ namespace NetTopologySuite.Geometries.Curves
         /// fall through to linear geometry without treating control polylines as
         /// the only model of the type itself.
         /// </remarks>
-        public LineString Linearize() => Linearize(double.NaN);
-
-        /// <summary>
-        /// Returns a chord approximation of this circular string as a
-        /// <see cref="LineString"/>.
-        /// </summary>
-        /// <param name="arcSegmentLength">
-        /// Reserved for maximum chord length along each arc. Currently unused;
-        /// control-point chords are always returned.
-        /// </param>
-        public LineString Linearize(double arcSegmentLength)
+        public LineString Linearize()
         {
             if (IsEmpty)
             {
                 return Factory.CreateLineString();
             }
             return Factory.CreateLineString(_points.Copy());
+        }
+
+        /// <summary>
+        /// Tolerance-driven linearization is not implemented yet.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Reserved for the maximum chord length along each arc.
+        /// </param>
+        /// <exception cref="NotSupportedException">
+        /// Always thrown until densification lands. Use <see cref="Linearize()"/>
+        /// for the explicit chord approximation.
+        /// </exception>
+        public LineString Linearize(double arcSegmentLength)
+        {
+            throw CurvedGeometry.ToleranceLinearizeNotSupported();
         }
     }
 }

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -10,7 +10,7 @@
 // Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
 // Not GEOS-current metric parity: Length is control-polyline, Envelope is
 // control-bbox only, DistanceOp does not yet visit curves (see Category=Red
-// CurveOracleRedTests). Arc-aware Length/Envelope/Distance = later work.
+// CurveMetricsContractTests). Arc-aware Length/Envelope/Distance = later work.
 
 using System;
 using System.Collections.Generic;
@@ -28,7 +28,7 @@ namespace NetTopologySuite.Geometries.Curves
     /// coordinates.
     /// <para/>
     /// Foundation metrics: <c>Length</c> currently uses the control-point polyline
-    /// (not analytical arc length); arc-aware measure is gated by oracle RED tests.
+    /// (not analytical arc length); arc-aware measure is gated by Category=Red CurveMetricsContractTests.
     /// The inherited <see cref="Curve.IsClosed"/> semantics apply (start equals end).
     /// </remarks>
     [Serializable]
@@ -130,7 +130,7 @@ namespace NetTopologySuite.Geometries.Curves
 
         /// <summary>
         /// Length approximated by summing arc-chord lengths.  Analytical arc-length
-        /// is gated by oracle RED tests (arc-aware measure).
+        /// is gated by Category=Red CurveMetricsContractTests (arc-aware measure).
         /// </summary>
         public override double Length => Algorithm.Length.OfLine(_points);
 

--- a/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
@@ -7,10 +7,8 @@
 //
 //   Assisted-by: Claude (Fable 5)
 //
-// Status: PLAYGROUND -- in-tree port of the SQL/MM CompoundCurve prototype from
-// the out-of-tree NetTopologySuite.Curve repository, following the maintainer
-// discussion on the PR ("in-tree is the way to go"). Not for merge into develop
-// without further design discussion -- see the PR description.
+// Status: PRODUCTION -- SQL/MM CompoundCurve first-class Geometry type
+// (structure + WKT/WKB foundation). Arc-aware metrics follow CircularString RED hooks.
 
 using System;
 using System.Collections.Generic;
@@ -19,17 +17,16 @@ namespace NetTopologySuite.Geometries.Curves
 {
     /// <summary>
     /// A SQL/MM Spatial (ISO/IEC 13249-3) <c>CompoundCurve</c>: a single, contiguous
-    /// curve composed of a sequence of <see cref="Curve"/> components -- in this
-    /// prototype either <see cref="LineString"/>s or <see cref="CircularString"/>s --
-    /// where each component starts at the end point of its predecessor.
+    /// curve composed of a sequence of <see cref="Curve"/> components -- either
+    /// <see cref="LineString"/>s or <see cref="CircularString"/>s -- where each
+    /// component starts at the end point of its predecessor.
     /// </summary>
     /// <remarks>
     /// Nested <c>CompoundCurve</c> components are rejected, keeping the component
     /// list flat (matching SQL/MM and common implementations).
     /// <para/>
-    /// This is a prototype.  Like <see cref="CircularString"/>, metric properties
-    /// (<c>Length</c>, envelopes) fall back to the chord-based computations of the
-    /// components rather than analytical arc geometry.
+    /// Like <see cref="CircularString"/>, foundation <c>Length</c> / envelopes use
+    /// component chord (control) geometry until arc-aware measure lands.
     /// </remarks>
     [Serializable]
     public class CompoundCurve : Curve, ILinearizable<LineString>
@@ -179,7 +176,7 @@ namespace NetTopologySuite.Geometries.Curves
         /// <summary>
         /// Length approximated by summing component lengths.  For
         /// <see cref="CircularString"/> components this is the chord-based fallback;
-        /// analytical arc-length computation is tracked in the prototype roadmap.
+        /// analytical arc-length is gated by oracle RED tests (arc-aware measure).
         /// </summary>
         public override double Length
         {

--- a/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
@@ -7,8 +7,9 @@
 //
 //   Assisted-by: Claude (Fable 5)
 //
-// Status: PRODUCTION -- SQL/MM CompoundCurve first-class Geometry type
-// (structure + WKT/WKB foundation). Arc-aware metrics follow CircularString RED hooks.
+// Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
+// Not GEOS-current metric parity (Length/Envelope/Distance); see CircularString
+// and Category=Red CurveOracleRedTests.
 
 using System;
 using System.Collections.Generic;

--- a/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
@@ -9,7 +9,7 @@
 //
 // Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
 // Not GEOS-current metric parity (Length/Envelope/Distance); see CircularString
-// and Category=Red CurveOracleRedTests.
+// and Category=Red CurveMetricsContractTests.
 
 using System;
 using System.Collections.Generic;
@@ -177,7 +177,7 @@ namespace NetTopologySuite.Geometries.Curves
         /// <summary>
         /// Length approximated by summing component lengths.  For
         /// <see cref="CircularString"/> components this is the chord-based fallback;
-        /// analytical arc-length is gated by oracle RED tests (arc-aware measure).
+        /// analytical arc-length is gated by Category=Red CurveMetricsContractTests (arc-aware measure).
         /// </summary>
         public override double Length
         {

--- a/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Fable 5)
+//
+// Status: PLAYGROUND -- in-tree port of the SQL/MM CompoundCurve prototype from
+// the out-of-tree NetTopologySuite.Curve repository, following the maintainer
+// discussion on the PR ("in-tree is the way to go"). Not for merge into develop
+// without further design discussion -- see the PR description.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// A SQL/MM Spatial (ISO/IEC 13249-3) <c>CompoundCurve</c>: a single, contiguous
+    /// curve composed of a sequence of <see cref="Curve"/> components -- in this
+    /// prototype either <see cref="LineString"/>s or <see cref="CircularString"/>s --
+    /// where each component starts at the end point of its predecessor.
+    /// </summary>
+    /// <remarks>
+    /// Nested <c>CompoundCurve</c> components are rejected, keeping the component
+    /// list flat (matching SQL/MM and common implementations).
+    /// <para/>
+    /// This is a prototype.  Like <see cref="CircularString"/>, metric properties
+    /// (<c>Length</c>, envelopes) fall back to the chord-based computations of the
+    /// components rather than analytical arc geometry.
+    /// </remarks>
+    [Serializable]
+    public class CompoundCurve : Curve, ILinearizable<LineString>
+    {
+        /// <summary>The component curves.</summary>
+        private readonly Curve[] _curves;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompoundCurve"/> class.
+        /// </summary>
+        /// <param name="curves">The component curves, in traversal order</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If a component is <c>null</c>, empty, or a <c>CompoundCurve</c> itself, or
+        /// if a component does not start at the end point of its predecessor.
+        /// </exception>
+        public CompoundCurve(Curve[] curves, GeometryFactory factory) : base(factory)
+        {
+            if (curves == null || curves.Length == 0)
+            {
+                _curves = new Curve[0];
+                return;
+            }
+            for (int i = 0; i < curves.Length; i++)
+            {
+                if (curves[i] == null)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain null components.", nameof(curves));
+                }
+                if (curves[i].IsEmpty)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain empty components.", nameof(curves));
+                }
+                if (curves[i] is CompoundCurve)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain nested CompoundCurve components.",
+                        nameof(curves));
+                }
+                if (i > 0)
+                {
+                    var previousEnd = curves[i - 1].EndPoint.Coordinate;
+                    var currentStart = curves[i].StartPoint.Coordinate;
+                    if (!previousEnd.Equals2D(currentStart))
+                    {
+                        throw new ArgumentException(
+                            "The components of a CompoundCurve must be contiguous: component " + i +
+                            " starts at " + currentStart + " but its predecessor ends at " + previousEnd + ".",
+                            nameof(curves));
+                    }
+                }
+            }
+            // Defensive copy: Normalize reverses and rewrites this array in place.
+            _curves = new Curve[curves.Length];
+            Array.Copy(curves, _curves, curves.Length);
+        }
+
+        /// <summary>
+        /// Gets the component curves of this <c>CompoundCurve</c>.
+        /// </summary>
+        public IReadOnlyList<Curve> Curves => _curves;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _curves.Length == 0;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => IsEmpty ? null : _curves[0].Coordinate;
+
+        /// <summary>
+        /// The coordinates of the components, concatenated in traversal order with
+        /// the shared join point of adjacent components emitted only once.
+        /// </summary>
+        public override Coordinate[] Coordinates
+        {
+            get
+            {
+                var coordinates = new List<Coordinate>();
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    var componentCoordinates = _curves[i].Coordinates;
+                    for (int j = i == 0 ? 0 : 1; j < componentCoordinates.Length; j++)
+                    {
+                        coordinates.Add(componentCoordinates[j]);
+                    }
+                }
+                return coordinates.ToArray();
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints
+        {
+            get
+            {
+                if (IsEmpty) return 0;
+                int numPoints = _curves[0].NumPoints;
+                for (int i = 1; i < _curves.Length; i++)
+                {
+                    numPoints += _curves[i].NumPoints - 1;
+                }
+                return numPoints;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinates = new List<double>();
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                double[] componentOrdinates = _curves[i].GetOrdinates(ordinate);
+                for (int j = i == 0 ? 0 : 1; j < componentOrdinates.Length; j++)
+                {
+                    ordinates.Add(componentOrdinates[j]);
+                }
+            }
+            return ordinates.ToArray();
+        }
+
+        /// <inheritdoc cref="Curve.StartPoint"/>
+        public override Point StartPoint =>
+            IsEmpty ? null : _curves[0].StartPoint;
+
+        /// <inheritdoc cref="Curve.EndPoint"/>
+        public override Point EndPoint =>
+            IsEmpty ? null : _curves[_curves.Length - 1].EndPoint;
+
+        /// <inheritdoc cref="Curve.IsClosed"/>
+        public override bool IsClosed
+        {
+            get
+            {
+                if (IsEmpty) return false;
+                return StartPoint.Coordinate.Equals2D(EndPoint.Coordinate);
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CompoundCurve";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CompoundCurve;
+
+        /// <summary>
+        /// Length approximated by summing component lengths.  For
+        /// <see cref="CircularString"/> components this is the chord-based fallback;
+        /// analytical arc-length computation is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Length
+        {
+            get
+            {
+                double length = 0d;
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    length += _curves[i].Length;
+                }
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The boundary of a curve per the Mod-2 rule: empty when the curve is empty
+        /// or closed, otherwise the two end points.
+        /// </summary>
+        public override Geometry Boundary
+        {
+            get
+            {
+                if (IsEmpty || IsClosed)
+                {
+                    return Factory.CreateMultiPoint();
+                }
+                return Factory.CreateMultiPoint(new[] { StartPoint, EndPoint });
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            var env = new Envelope();
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                env.ExpandToInclude(_curves[i].EnvelopeInternal);
+            }
+            return env;
+        }
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CompoundCurve)other;
+            if (_curves.Length != o._curves.Length) return false;
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                if (!_curves[i].EqualsExact(o._curves[i], tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++) _curves[i].Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                _curves[i].Apply(filter);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                _curves[i].Apply(filter);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            for (int i = 0; i < _curves.Length; i++) _curves[i].Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var curves = new Curve[_curves.Length];
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                curves[i] = (Curve)_curves[i].Copy();
+            }
+            return new CompoundCurve(curves, Factory);
+        }
+
+        /// <inheritdoc/>
+        public override void Normalize()
+        {
+            // Mirror the CircularString choice: flip traversal direction when the
+            // start point is lexicographically greater than the end point.
+            if (IsEmpty) return;
+            if (StartPoint.Coordinate.CompareTo(EndPoint.Coordinate) > 0)
+            {
+                Array.Reverse(_curves);
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    _curves[i] = (Curve)_curves[i].Reverse();
+                }
+                GeometryChanged();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal()
+        {
+            var curves = new Curve[_curves.Length];
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                curves[i] = (Curve)_curves[_curves.Length - 1 - i].Reverse();
+            }
+            return new CompoundCurve(curves, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CompoundCurve;
+
+        /// <summary>
+        /// CompareTo for two CompoundCurves uses lex order of the concatenated
+        /// coordinates (type-blind across component kinds).
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CompoundCurve)o;
+            var a = Coordinates;
+            var b = other.Coordinates;
+            int n = Math.Min(a.Length, b.Length);
+            for (int i = 0; i < n; i++)
+            {
+                int c = a[i].CompareTo(b[i]);
+                if (c != 0) return c;
+            }
+            return a.Length.CompareTo(b.Length);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            var other = (CompoundCurve)o;
+            var factory = Factory.CoordinateSequenceFactory;
+            return comp.Compare(factory.Create(Coordinates), factory.Create(other.Coordinates));
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.CompoundCurve;
+
+        /// <summary>
+        /// Returns a chord approximation of this compound curve as a single
+        /// <see cref="LineString"/>, concatenating linearized components and
+        /// collapsing shared join points.
+        /// </summary>
+        public LineString Linearize() => Linearize(double.NaN);
+
+        /// <summary>
+        /// Returns a chord approximation of this compound curve as a single
+        /// <see cref="LineString"/>.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Passed through to <see cref="CircularString"/> components when they
+        /// support densification; currently reserved (control chords).
+        /// </param>
+        public LineString Linearize(double arcSegmentLength)
+        {
+            if (IsEmpty)
+            {
+                return Factory.CreateLineString();
+            }
+
+            var coordinates = new List<Coordinate>();
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                LineString componentLine = LinearizeComponent(_curves[i], arcSegmentLength);
+                var componentCoordinates = componentLine.Coordinates;
+                for (int j = i == 0 ? 0 : 1; j < componentCoordinates.Length; j++)
+                {
+                    coordinates.Add(componentCoordinates[j]);
+                }
+            }
+            return Factory.CreateLineString(coordinates.ToArray());
+        }
+
+        private static LineString LinearizeComponent(Curve component, double arcSegmentLength)
+        {
+            switch (component)
+            {
+                case CircularString circularString:
+                    return circularString.Linearize(arcSegmentLength);
+                case LineString lineString:
+                    return lineString;
+                default:
+                    // Defensive: constructor rejects nested CompoundCurves; other
+                    // Curve subtypes should linearize via control coordinates.
+                    return component.Factory.CreateLineString(component.Coordinates);
+            }
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
@@ -8,8 +8,10 @@
 //   Assisted-by: Claude (Fable 5)
 //
 // Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
-// Not GEOS-current metric parity (Length/Envelope/Distance); see CircularString
-// and Category=Red CurveMetricsContractTests.
+// Metrics and analytic ops (Length, Area, Envelope, IsSimple, Distance,
+// Centroid, InteriorPoint) fail closed with NotSupportedException until
+// arc-aware implementations land in a follow-up PR; Linearize() is the
+// explicit chord escape hatch.
 
 using System;
 using System.Collections.Generic;
@@ -26,8 +28,9 @@ namespace NetTopologySuite.Geometries.Curves
     /// Nested <c>CompoundCurve</c> components are rejected, keeping the component
     /// list flat (matching SQL/MM and common implementations).
     /// <para/>
-    /// Like <see cref="CircularString"/>, foundation <c>Length</c> / envelopes use
-    /// component chord (control) geometry until arc-aware measure lands.
+    /// Metrics and analytic ops fail closed with <see cref="NotSupportedException"/>
+    /// until arc-aware implementations land; <see cref="Linearize()"/> is the explicit
+    /// chord escape hatch.
     /// </remarks>
     [Serializable]
     public class CompoundCurve : Curve, ILinearizable<LineString>
@@ -175,22 +178,15 @@ namespace NetTopologySuite.Geometries.Curves
         public override OgcGeometryType OgcGeometryType => OgcGeometryType.CompoundCurve;
 
         /// <summary>
-        /// Length approximated by summing component lengths.  For
-        /// <see cref="CircularString"/> components this is the chord-based fallback;
-        /// analytical arc-length is gated by Category=Red CurveMetricsContractTests (arc-aware measure).
+        /// Arc-aware length is not implemented yet. Empty is 0; otherwise throws,
+        /// including when every component is a <see cref="LineString"/>.
         /// </summary>
-        public override double Length
-        {
-            get
-            {
-                double length = 0d;
-                for (int i = 0; i < _curves.Length; i++)
-                {
-                    length += _curves[i].Length;
-                }
-                return length;
-            }
-        }
+        /// <exception cref="NotSupportedException">
+        /// When this geometry is not empty. Call <see cref="Linearize()"/> to opt in
+        /// to an explicit chord approximation.
+        /// </exception>
+        public override double Length =>
+            IsEmpty ? 0d : throw CurvedGeometry.NotYetSupported(this, "Length");
 
         /// <summary>
         /// The boundary of a curve per the Mod-2 rule: empty when the curve is empty
@@ -211,13 +207,19 @@ namespace NetTopologySuite.Geometries.Curves
         /// <inheritdoc/>
         protected override Envelope ComputeEnvelopeInternal()
         {
-            var env = new Envelope();
-            for (int i = 0; i < _curves.Length; i++)
-            {
-                env.ExpandToInclude(_curves[i].EnvelopeInternal);
-            }
-            return env;
+            if (IsEmpty) return new Envelope();
+            throw CurvedGeometry.NotYetSupported(this, "Envelope");
         }
+
+        /// <summary>
+        /// Hashes a locally computed control-point envelope.
+        /// </summary>
+        /// <remarks>
+        /// Base <see cref="Geometry.GetHashCode"/> reads <c>EnvelopeInternal</c>,
+        /// which now throws for non-empty curve types. Hashing is identity, not a
+        /// geometric answer; control points are EqualsExact-consistent.
+        /// </remarks>
+        public override int GetHashCode() => CurvedGeometry.HashControlEnvelope(Coordinates);
 
         /// <inheritdoc/>
         public override bool EqualsExact(Geometry other, double tolerance)
@@ -347,17 +349,7 @@ namespace NetTopologySuite.Geometries.Curves
         /// <see cref="LineString"/>, concatenating linearized components and
         /// collapsing shared join points.
         /// </summary>
-        public LineString Linearize() => Linearize(double.NaN);
-
-        /// <summary>
-        /// Returns a chord approximation of this compound curve as a single
-        /// <see cref="LineString"/>.
-        /// </summary>
-        /// <param name="arcSegmentLength">
-        /// Passed through to <see cref="CircularString"/> components when they
-        /// support densification; currently reserved (control chords).
-        /// </param>
-        public LineString Linearize(double arcSegmentLength)
+        public LineString Linearize()
         {
             if (IsEmpty)
             {
@@ -367,7 +359,7 @@ namespace NetTopologySuite.Geometries.Curves
             var coordinates = new List<Coordinate>();
             for (int i = 0; i < _curves.Length; i++)
             {
-                LineString componentLine = LinearizeComponent(_curves[i], arcSegmentLength);
+                LineString componentLine = LinearizeComponent(_curves[i]);
                 var componentCoordinates = componentLine.Coordinates;
                 for (int j = i == 0 ? 0 : 1; j < componentCoordinates.Length; j++)
                 {
@@ -377,12 +369,27 @@ namespace NetTopologySuite.Geometries.Curves
             return Factory.CreateLineString(coordinates.ToArray());
         }
 
-        private static LineString LinearizeComponent(Curve component, double arcSegmentLength)
+        /// <summary>
+        /// Tolerance-driven linearization is not implemented yet.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Reserved for the maximum chord length along each arc.
+        /// </param>
+        /// <exception cref="NotSupportedException">
+        /// Always thrown until densification lands. Use <see cref="Linearize()"/>
+        /// for the explicit chord approximation.
+        /// </exception>
+        public LineString Linearize(double arcSegmentLength)
+        {
+            throw CurvedGeometry.ToleranceLinearizeNotSupported();
+        }
+
+        private static LineString LinearizeComponent(Curve component)
         {
             switch (component)
             {
                 case CircularString circularString:
-                    return circularString.Linearize(arcSegmentLength);
+                    return circularString.Linearize();
                 case LineString lineString:
                     return lineString;
                 default:

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Fable 5)
+//
+// Status: PLAYGROUND -- in-tree port of the SQL/MM CurvePolygon prototype from
+// the out-of-tree NetTopologySuite.Curve repository, following the maintainer
+// discussion on the PR ("in-tree is the way to go"). This carries the F-CP
+// structural contract of the SFA Curve Awareness epic (locationtech/jts#1195,
+// Phase 1): rings are exposed as Curve, never collapsed to LinearRing.
+// Not for merge into develop without further design discussion -- see the PR
+// description.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// A SQL/MM Spatial (ISO/IEC 13249-3) <c>CurvePolygon</c>: a planar surface like
+    /// <see cref="Polygon"/>, but whose exterior and interior rings are
+    /// <see cref="Curve"/>s -- <see cref="LinearRing"/>s, closed
+    /// <see cref="CircularString"/>s or closed <see cref="CompoundCurve"/>s.
+    /// </summary>
+    /// <remarks>
+    /// Because <c>CurvePolygon</c> extends <c>Surface&lt;Curve&gt;</c> rather than
+    /// <c>Polygon</c>, the ring accessors are typed <see cref="Curve"/> and never
+    /// collapse a curved ring to a flat <see cref="LinearRing"/> (the F-CP
+    /// structural contract).
+    /// <para/>
+    /// This is a prototype.  <c>Area</c> and <c>Length</c> fall back to chord-based
+    /// computations that treat the control points of curved rings as polylines;
+    /// analytical arc geometry and linearization are tracked in the prototype
+    /// roadmap.
+    /// </remarks>
+    [Serializable]
+    public class CurvePolygon : Surface<Curve>, ILinearizable<Polygon>
+    {
+        /// <summary>The exterior ring.</summary>
+        private readonly Curve _shell;
+
+        /// <summary>The interior rings.</summary>
+        private readonly Curve[] _holes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurvePolygon"/> class with no
+        /// interior rings.
+        /// </summary>
+        /// <param name="shell">The exterior ring, a closed <c>Curve</c> (or null for an empty polygon)</param>
+        /// <param name="factory">The geometry factory</param>
+        public CurvePolygon(Curve shell, GeometryFactory factory)
+            : this(shell, null, factory)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurvePolygon"/> class.
+        /// </summary>
+        /// <param name="shell">The exterior ring, a closed <c>Curve</c> (or null for an empty polygon)</param>
+        /// <param name="holes">The interior rings, closed <c>Curve</c>s</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If a ring is not closed, a hole is <c>null</c>, or the shell is empty while
+        /// holes are not.
+        /// </exception>
+        public CurvePolygon(Curve shell, Curve[] holes, GeometryFactory factory) : base(factory)
+        {
+            if (shell == null)
+            {
+                shell = new CircularString(factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), factory);
+            }
+            if (holes == null || holes.Length == 0)
+            {
+                holes = new Curve[0];
+            }
+            else
+            {
+                // Defensive copy so callers cannot mutate the ring list after construction.
+                var holesCopy = new Curve[holes.Length];
+                Array.Copy(holes, holesCopy, holes.Length);
+                holes = holesCopy;
+            }
+            foreach (var hole in holes)
+            {
+                if (hole == null)
+                {
+                    throw new ArgumentException(
+                        "A CurvePolygon must not contain null holes.", nameof(holes));
+                }
+            }
+            if (shell.IsEmpty && HasNonEmptyElements(holes))
+            {
+                throw new ArgumentException("shell is empty but holes are not", nameof(holes));
+            }
+            if (!shell.IsEmpty && !shell.IsClosed)
+            {
+                throw new ArgumentException(
+                    "The shell of a CurvePolygon must be closed.", nameof(shell));
+            }
+            foreach (var hole in holes)
+            {
+                if (!hole.IsEmpty && !hole.IsClosed)
+                {
+                    throw new ArgumentException(
+                        "The holes of a CurvePolygon must be closed.", nameof(holes));
+                }
+            }
+            _shell = shell;
+            _holes = holes;
+        }
+
+        private static bool HasNonEmptyElements(Curve[] curves)
+        {
+            foreach (var curve in curves)
+            {
+                if (!curve.IsEmpty) return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc cref="Surface{T}.ExteriorRing"/>
+        public override Curve ExteriorRing => _shell;
+
+        /// <inheritdoc cref="Surface{T}.NumInteriorRings"/>
+        public override int NumInteriorRings => _holes.Length;
+
+        /// <inheritdoc cref="Surface{T}.GetInteriorRingN"/>
+        public override Curve GetInteriorRingN(int index) => _holes[index];
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CurvePolygon";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CurvePolygon;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _shell.IsEmpty;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => _shell.Coordinate;
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates
+        {
+            get
+            {
+                if (IsEmpty) return new Coordinate[0];
+                var coordinates = new List<Coordinate>(_shell.Coordinates);
+                foreach (var hole in _holes)
+                {
+                    coordinates.AddRange(hole.Coordinates);
+                }
+                return coordinates.ToArray();
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints
+        {
+            get
+            {
+                int numPoints = _shell.NumPoints;
+                foreach (var hole in _holes)
+                {
+                    numPoints += hole.NumPoints;
+                }
+                return numPoints;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinates = new List<double>(_shell.GetOrdinates(ordinate));
+            foreach (var hole in _holes)
+            {
+                ordinates.AddRange(hole.GetOrdinates(ordinate));
+            }
+            return ordinates.ToArray();
+        }
+
+        /// <summary>
+        /// Area approximated by treating the control points of the rings as polyline
+        /// rings (chord-based, consistent with <see cref="CircularString"/>'s
+        /// chord-based <c>Length</c>).  For curved rings the true area differs by the
+        /// circular segments; analytical arc area is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Area
+        {
+            get
+            {
+                if (IsEmpty) return 0d;
+                double area = Algorithm.Area.OfRing(_shell.Coordinates);
+                foreach (var hole in _holes)
+                {
+                    area -= Algorithm.Area.OfRing(hole.Coordinates);
+                }
+                return area;
+            }
+        }
+
+        /// <summary>
+        /// Perimeter approximated by summing ring lengths (chord-based for curved
+        /// rings).
+        /// </summary>
+        public override double Length
+        {
+            get
+            {
+                double length = _shell.Length;
+                foreach (var hole in _holes)
+                {
+                    length += hole.Length;
+                }
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The rings of this surface.  Returned as a <see cref="GeometryCollection"/>
+        /// of <see cref="Curve"/>s for now -- a dedicated <c>MultiCurve</c> type is
+        /// part of the prototype roadmap.
+        /// </summary>
+        public override Geometry Boundary
+        {
+            get
+            {
+                if (IsEmpty)
+                {
+                    return Factory.CreateGeometryCollection();
+                }
+                var rings = new Geometry[1 + _holes.Length];
+                rings[0] = _shell;
+                for (int i = 0; i < _holes.Length; i++)
+                {
+                    rings[i + 1] = _holes[i];
+                }
+                return Factory.CreateGeometryCollection(rings);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal() => _shell.EnvelopeInternal;
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CurvePolygon)other;
+            if (!_shell.EqualsExact(o._shell, tolerance)) return false;
+            if (_holes.Length != o._holes.Length) return false;
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                if (!_holes[i].EqualsExact(o._holes[i], tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            _shell.Apply(filter);
+            foreach (var hole in _holes) hole.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (!filter.Done)
+            {
+                foreach (var hole in _holes)
+                {
+                    hole.Apply(filter);
+                    if (filter.Done) break;
+                }
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (!filter.Done)
+            {
+                foreach (var hole in _holes)
+                {
+                    hole.Apply(filter);
+                    if (filter.Done) break;
+                }
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            _shell.Apply(filter);
+            foreach (var hole in _holes) hole.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var holes = new Curve[_holes.Length];
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                holes[i] = (Curve)_holes[i].Copy();
+            }
+            return new CurvePolygon((Curve)_shell.Copy(), holes, Factory);
+        }
+
+        /// <summary>
+        /// Normalization of ring orientation and hole ordering requires orientation
+        /// of curved rings, which is part of the prototype roadmap.  This prototype
+        /// implementation does nothing.
+        /// </summary>
+        public override void Normalize()
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal()
+        {
+            var holes = new Curve[_holes.Length];
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                holes[i] = (Curve)_holes[i].Reverse();
+            }
+            return new CurvePolygon((Curve)_shell.Reverse(), holes, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CurvePolygon;
+
+        /// <summary>
+        /// CompareTo for two CurvePolygons uses lex order of the shell coordinates,
+        /// then the hole count, then lex order of the hole coordinates (type-blind
+        /// across ring kinds).
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CurvePolygon)o;
+            int c = CompareCoordinates(_shell.Coordinates, other._shell.Coordinates);
+            if (c != 0) return c;
+            c = _holes.Length.CompareTo(other._holes.Length);
+            if (c != 0) return c;
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                c = CompareCoordinates(_holes[i].Coordinates, other._holes[i].Coordinates);
+                if (c != 0) return c;
+            }
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            var other = (CurvePolygon)o;
+            var factory = Factory.CoordinateSequenceFactory;
+            return comp.Compare(factory.Create(Coordinates), factory.Create(other.Coordinates));
+        }
+
+        private static int CompareCoordinates(Coordinate[] a, Coordinate[] b)
+        {
+            int n = Math.Min(a.Length, b.Length);
+            for (int i = 0; i < n; i++)
+            {
+                int c = a[i].CompareTo(b[i]);
+                if (c != 0) return c;
+            }
+            return a.Length.CompareTo(b.Length);
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.CurvePolygon;
+
+        /// <summary>
+        /// Returns a chord approximation of this curve polygon as a linear
+        /// <see cref="Polygon"/> whose rings are linearized control polylines.
+        /// </summary>
+        public Polygon Linearize() => Linearize(double.NaN);
+
+        /// <summary>
+        /// Returns a chord approximation of this curve polygon as a linear
+        /// <see cref="Polygon"/>.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Passed through to curved rings when they support densification;
+        /// currently reserved (control chords).
+        /// </param>
+        public Polygon Linearize(double arcSegmentLength)
+        {
+            if (IsEmpty)
+            {
+                return Factory.CreatePolygon();
+            }
+
+            var shell = LinearizeRing(_shell, arcSegmentLength);
+            LinearRing[] holes = null;
+            if (_holes.Length > 0)
+            {
+                holes = new LinearRing[_holes.Length];
+                for (int i = 0; i < _holes.Length; i++)
+                {
+                    holes[i] = LinearizeRing(_holes[i], arcSegmentLength);
+                }
+            }
+            return Factory.CreatePolygon(shell, holes);
+        }
+
+        private LinearRing LinearizeRing(Curve ring, double arcSegmentLength)
+        {
+            LineString line;
+            switch (ring)
+            {
+                case CircularString circularString:
+                    line = circularString.Linearize(arcSegmentLength);
+                    break;
+                case CompoundCurve compoundCurve:
+                    line = compoundCurve.Linearize(arcSegmentLength);
+                    break;
+                case LinearRing linearRing:
+                    return linearRing;
+                case LineString lineString:
+                    line = lineString;
+                    break;
+                default:
+                    line = Factory.CreateLineString(ring.Coordinates);
+                    break;
+            }
+            return Factory.CreateLinearRing(line.CoordinateSequence);
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -7,13 +7,9 @@
 //
 //   Assisted-by: Claude (Fable 5)
 //
-// Status: PLAYGROUND -- in-tree port of the SQL/MM CurvePolygon prototype from
-// the out-of-tree NetTopologySuite.Curve repository, following the maintainer
-// discussion on the PR ("in-tree is the way to go"). This carries the F-CP
-// structural contract of the SFA Curve Awareness epic (locationtech/jts#1195,
-// Phase 1): rings are exposed as Curve, never collapsed to LinearRing.
-// Not for merge into develop without further design discussion -- see the PR
-// description.
+// Status: PRODUCTION -- SQL/MM CurvePolygon first-class Geometry type
+// (structure + WKT/WKB foundation). Rings are Curve, never collapsed to LinearRing
+// (F-CP structural contract). Arc-aware Area/Length/Distance follow RED hooks.
 
 using System;
 using System.Collections.Generic;
@@ -32,10 +28,8 @@ namespace NetTopologySuite.Geometries.Curves
     /// collapse a curved ring to a flat <see cref="LinearRing"/> (the F-CP
     /// structural contract).
     /// <para/>
-    /// This is a prototype.  <c>Area</c> and <c>Length</c> fall back to chord-based
-    /// computations that treat the control points of curved rings as polylines;
-    /// analytical arc geometry and linearization are tracked in the prototype
-    /// roadmap.
+    /// Foundation <c>Area</c> / <c>Length</c> use control-polyline (chord) geometry
+    /// on curved rings; analytical arc measure is gated by oracle RED tests.
     /// </remarks>
     [Serializable]
     public class CurvePolygon : Surface<Curve>, ILinearizable<Polygon>
@@ -188,7 +182,7 @@ namespace NetTopologySuite.Geometries.Curves
         /// Area approximated by treating the control points of the rings as polyline
         /// rings (chord-based, consistent with <see cref="CircularString"/>'s
         /// chord-based <c>Length</c>).  For curved rings the true area differs by the
-        /// circular segments; analytical arc area is tracked in the prototype roadmap.
+        /// circular segments; analytical arc area is gated by oracle RED tests.
         /// </summary>
         public override double Area
         {
@@ -224,7 +218,7 @@ namespace NetTopologySuite.Geometries.Curves
         /// <summary>
         /// The rings of this surface.  Returned as a <see cref="GeometryCollection"/>
         /// of <see cref="Curve"/>s for now -- a dedicated <c>MultiCurve</c> type is
-        /// part of the prototype roadmap.
+        /// gated by oracle RED tests.
         /// </summary>
         public override Geometry Boundary
         {
@@ -323,7 +317,7 @@ namespace NetTopologySuite.Geometries.Curves
 
         /// <summary>
         /// Normalization of ring orientation and hole ordering requires orientation
-        /// of curved rings, which is part of the prototype roadmap.  This prototype
+        /// of curved rings, which is gated by oracle RED tests.  This prototype
         /// implementation does nothing.
         /// </summary>
         public override void Normalize()

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -8,8 +8,10 @@
 //   Assisted-by: Claude (Fable 5)
 //
 // Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
-// Rings are Curve, never collapsed to LinearRing (F-CP). Not GEOS-current metric
-// parity for Area/Length/Distance; see Category=Red CurveMetricsContractTests.
+// Rings are Curve, never collapsed to LinearRing (F-CP). Metrics and analytic
+// ops (Length, Area, Envelope, IsSimple, Distance, Centroid, InteriorPoint)
+// fail closed with NotSupportedException until arc-aware implementations land
+// in a follow-up PR; Linearize() is the explicit chord escape hatch.
 
 using System;
 using System.Collections.Generic;
@@ -28,8 +30,9 @@ namespace NetTopologySuite.Geometries.Curves
     /// collapse a curved ring to a flat <see cref="LinearRing"/> (the F-CP
     /// structural contract).
     /// <para/>
-    /// Foundation <c>Area</c> / <c>Length</c> use control-polyline (chord) geometry
-    /// on curved rings; analytical arc measure is gated by Category=Red CurveMetricsContractTests.
+    /// Metrics and analytic ops fail closed with <see cref="NotSupportedException"/>
+    /// until arc-aware implementations land; <see cref="Linearize()"/> is the explicit
+    /// chord escape hatch.
     /// </remarks>
     [Serializable]
     public class CurvePolygon : Surface<Curve>, ILinearizable<Polygon>
@@ -179,46 +182,30 @@ namespace NetTopologySuite.Geometries.Curves
         }
 
         /// <summary>
-        /// Area approximated by treating the control points of the rings as polyline
-        /// rings (chord-based, consistent with <see cref="CircularString"/>'s
-        /// chord-based <c>Length</c>).  For curved rings the true area differs by the
-        /// circular segments; analytical arc area is gated by Category=Red CurveMetricsContractTests.
+        /// Arc-aware area is not implemented yet. Empty is 0; otherwise throws,
+        /// including when every ring is linear.
         /// </summary>
-        public override double Area
-        {
-            get
-            {
-                if (IsEmpty) return 0d;
-                double area = Algorithm.Area.OfRing(_shell.Coordinates);
-                foreach (var hole in _holes)
-                {
-                    area -= Algorithm.Area.OfRing(hole.Coordinates);
-                }
-                return area;
-            }
-        }
+        /// <exception cref="NotSupportedException">
+        /// When this geometry is not empty. Call <see cref="Linearize()"/> to opt in
+        /// to an explicit chord approximation.
+        /// </exception>
+        public override double Area =>
+            IsEmpty ? 0d : throw CurvedGeometry.NotYetSupported(this, "Area");
 
         /// <summary>
-        /// Perimeter approximated by summing ring lengths (chord-based for curved
-        /// rings).
+        /// Arc-aware perimeter is not implemented yet. Empty is 0; otherwise throws.
         /// </summary>
-        public override double Length
-        {
-            get
-            {
-                double length = _shell.Length;
-                foreach (var hole in _holes)
-                {
-                    length += hole.Length;
-                }
-                return length;
-            }
-        }
+        /// <exception cref="NotSupportedException">
+        /// When this geometry is not empty. Call <see cref="Linearize()"/> to opt in
+        /// to an explicit chord approximation.
+        /// </exception>
+        public override double Length =>
+            IsEmpty ? 0d : throw CurvedGeometry.NotYetSupported(this, "Length");
 
         /// <summary>
-        /// The rings of this surface.  Returned as a <see cref="GeometryCollection"/>
-        /// of <see cref="Curve"/>s for now -- a dedicated <c>MultiCurve</c> type is
-        /// gated by Category=Red CurveMetricsContractTests.
+        /// The rings of this surface, returned as a <see cref="GeometryCollection"/>
+        /// of <see cref="Curve"/>s. Returning a dedicated <see cref="MultiCurve"/>
+        /// is a documented follow-up.
         /// </summary>
         public override Geometry Boundary
         {
@@ -239,7 +226,21 @@ namespace NetTopologySuite.Geometries.Curves
         }
 
         /// <inheritdoc/>
-        protected override Envelope ComputeEnvelopeInternal() => _shell.EnvelopeInternal;
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            if (IsEmpty) return new Envelope();
+            throw CurvedGeometry.NotYetSupported(this, "Envelope");
+        }
+
+        /// <summary>
+        /// Hashes a locally computed control-point envelope.
+        /// </summary>
+        /// <remarks>
+        /// Base <see cref="Geometry.GetHashCode"/> reads <c>EnvelopeInternal</c>,
+        /// which now throws for non-empty curve types. Hashing is identity, not a
+        /// geometric answer; control points are EqualsExact-consistent.
+        /// </remarks>
+        public override int GetHashCode() => CurvedGeometry.HashControlEnvelope(Coordinates);
 
         /// <inheritdoc/>
         public override bool EqualsExact(Geometry other, double tolerance)
@@ -316,12 +317,16 @@ namespace NetTopologySuite.Geometries.Curves
         }
 
         /// <summary>
-        /// Normalization of ring orientation and hole ordering requires orientation
-        /// of curved rings, which is gated by Category=Red CurveMetricsContractTests.  This type
-        /// implementation does nothing.
+        /// Normalization of ring orientation and hole ordering requires arc-aware
+        /// orientation. Empty is a no-op; otherwise throws.
         /// </summary>
+        /// <exception cref="NotSupportedException">
+        /// When this geometry is not empty.
+        /// </exception>
         public override void Normalize()
         {
+            if (IsEmpty) return;
+            throw CurvedGeometry.NotYetSupported(this, "Normalize");
         }
 
         /// <inheritdoc/>
@@ -384,46 +389,51 @@ namespace NetTopologySuite.Geometries.Curves
         /// Returns a chord approximation of this curve polygon as a linear
         /// <see cref="Polygon"/> whose rings are linearized control polylines.
         /// </summary>
-        public Polygon Linearize() => Linearize(double.NaN);
-
-        /// <summary>
-        /// Returns a chord approximation of this curve polygon as a linear
-        /// <see cref="Polygon"/>.
-        /// </summary>
-        /// <param name="arcSegmentLength">
-        /// Passed through to curved rings when they support densification;
-        /// currently reserved (control chords).
-        /// </param>
-        public Polygon Linearize(double arcSegmentLength)
+        public Polygon Linearize()
         {
             if (IsEmpty)
             {
                 return Factory.CreatePolygon();
             }
 
-            var shell = LinearizeRing(_shell, arcSegmentLength);
+            var shell = LinearizeRing(_shell);
             LinearRing[] holes = null;
             if (_holes.Length > 0)
             {
                 holes = new LinearRing[_holes.Length];
                 for (int i = 0; i < _holes.Length; i++)
                 {
-                    holes[i] = LinearizeRing(_holes[i], arcSegmentLength);
+                    holes[i] = LinearizeRing(_holes[i]);
                 }
             }
             return Factory.CreatePolygon(shell, holes);
         }
 
-        private LinearRing LinearizeRing(Curve ring, double arcSegmentLength)
+        /// <summary>
+        /// Tolerance-driven linearization is not implemented yet.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Reserved for the maximum chord length along each arc.
+        /// </param>
+        /// <exception cref="NotSupportedException">
+        /// Always thrown until densification lands. Use <see cref="Linearize()"/>
+        /// for the explicit chord approximation.
+        /// </exception>
+        public Polygon Linearize(double arcSegmentLength)
+        {
+            throw CurvedGeometry.ToleranceLinearizeNotSupported();
+        }
+
+        private LinearRing LinearizeRing(Curve ring)
         {
             LineString line;
             switch (ring)
             {
                 case CircularString circularString:
-                    line = circularString.Linearize(arcSegmentLength);
+                    line = circularString.Linearize();
                     break;
                 case CompoundCurve compoundCurve:
-                    line = compoundCurve.Linearize(arcSegmentLength);
+                    line = compoundCurve.Linearize();
                     break;
                 case LinearRing linearRing:
                     return linearRing;

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -7,9 +7,9 @@
 //
 //   Assisted-by: Claude (Fable 5)
 //
-// Status: PRODUCTION -- SQL/MM CurvePolygon first-class Geometry type
-// (structure + WKT/WKB foundation). Rings are Curve, never collapsed to LinearRing
-// (F-CP structural contract). Arc-aware Area/Length/Distance follow RED hooks.
+// Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
+// Rings are Curve, never collapsed to LinearRing (F-CP). Not GEOS-current metric
+// parity for Area/Length/Distance; see Category=Red CurveOracleRedTests.
 
 using System;
 using System.Collections.Generic;
@@ -317,7 +317,7 @@ namespace NetTopologySuite.Geometries.Curves
 
         /// <summary>
         /// Normalization of ring orientation and hole ordering requires orientation
-        /// of curved rings, which is gated by oracle RED tests.  This prototype
+        /// of curved rings, which is gated by oracle RED tests.  This type
         /// implementation does nothing.
         /// </summary>
         public override void Normalize()

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -9,7 +9,7 @@
 //
 // Status: PRODUCTION (structure + WKT/WKB) — GEOS 3.13-class foundation.
 // Rings are Curve, never collapsed to LinearRing (F-CP). Not GEOS-current metric
-// parity for Area/Length/Distance; see Category=Red CurveOracleRedTests.
+// parity for Area/Length/Distance; see Category=Red CurveMetricsContractTests.
 
 using System;
 using System.Collections.Generic;
@@ -29,7 +29,7 @@ namespace NetTopologySuite.Geometries.Curves
     /// structural contract).
     /// <para/>
     /// Foundation <c>Area</c> / <c>Length</c> use control-polyline (chord) geometry
-    /// on curved rings; analytical arc measure is gated by oracle RED tests.
+    /// on curved rings; analytical arc measure is gated by Category=Red CurveMetricsContractTests.
     /// </remarks>
     [Serializable]
     public class CurvePolygon : Surface<Curve>, ILinearizable<Polygon>
@@ -182,7 +182,7 @@ namespace NetTopologySuite.Geometries.Curves
         /// Area approximated by treating the control points of the rings as polyline
         /// rings (chord-based, consistent with <see cref="CircularString"/>'s
         /// chord-based <c>Length</c>).  For curved rings the true area differs by the
-        /// circular segments; analytical arc area is gated by oracle RED tests.
+        /// circular segments; analytical arc area is gated by Category=Red CurveMetricsContractTests.
         /// </summary>
         public override double Area
         {
@@ -218,7 +218,7 @@ namespace NetTopologySuite.Geometries.Curves
         /// <summary>
         /// The rings of this surface.  Returned as a <see cref="GeometryCollection"/>
         /// of <see cref="Curve"/>s for now -- a dedicated <c>MultiCurve</c> type is
-        /// gated by oracle RED tests.
+        /// gated by Category=Red CurveMetricsContractTests.
         /// </summary>
         public override Geometry Boundary
         {
@@ -317,7 +317,7 @@ namespace NetTopologySuite.Geometries.Curves
 
         /// <summary>
         /// Normalization of ring orientation and hole ordering requires orientation
-        /// of curved rings, which is gated by oracle RED tests.  This type
+        /// of curved rings, which is gated by Category=Red CurveMetricsContractTests.  This type
         /// implementation does nothing.
         /// </summary>
         public override void Normalize()

--- a/src/NetTopologySuite/Geometries/Curves/CurvedGeometry.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvedGeometry.cs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Assisted-by: xAI Grok
+
+using System;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// Shared fail-closed guards for SQL/MM curve types until arc-aware
+    /// metric and analytic implementations land.
+    /// </summary>
+    internal static class CurvedGeometry
+    {
+        /// <summary>
+        /// True for the five SQL/MM curve types. Excludes
+        /// <see cref="LineString"/>, <see cref="LinearRing"/>, <see cref="Polygon"/>,
+        /// and <see cref="Triangle"/>.
+        /// </summary>
+        public static bool IsCurvedType(Geometry g)
+        {
+            return g is CircularString
+                || g is CompoundCurve
+                || g is CurvePolygon
+                || g is MultiCurve
+                || g is MultiSurface;
+        }
+
+        /// <summary>
+        /// True if <paramref name="g"/> is a curved type or a
+        /// <see cref="GeometryCollection"/> that contains one.
+        /// </summary>
+        public static bool ContainsCurvedType(Geometry g)
+        {
+            if (IsCurvedType(g))
+                return true;
+            if (g is GeometryCollection gc)
+            {
+                for (int i = 0; i < gc.NumGeometries; i++)
+                {
+                    if (ContainsCurvedType(gc.GetGeometryN(i)))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        public static NotSupportedException NotYetSupported(Geometry g, string operation)
+        {
+            return new NotSupportedException(
+                $"Arc-aware {operation} is not implemented for {g.GeometryType} yet (planned follow-up PR). Call Linearize() to opt in to an explicit chord approximation.");
+        }
+
+        public static void CheckNotCurved(Geometry g, string operation)
+        {
+            if (ContainsCurvedType(g))
+                throw NotYetSupported(g, operation);
+        }
+
+        public static NotSupportedException ToleranceLinearizeNotSupported()
+        {
+            return new NotSupportedException(
+                "Tolerance-driven linearization is not implemented yet (planned follow-up PR). Call Linearize() for the explicit chord approximation.");
+        }
+
+        /// <summary>
+        /// Hash of a control-point envelope. Identity only — not a geometric answer.
+        /// </summary>
+        public static int HashControlEnvelope(CoordinateSequence points)
+        {
+            var env = new Envelope();
+            if (points != null)
+            {
+                for (int i = 0; i < points.Count; i++)
+                    env.ExpandToInclude(points.GetCoordinate(i));
+            }
+            return env.GetHashCode();
+        }
+
+        /// <summary>
+        /// Hash of a control-point envelope. Identity only — not a geometric answer.
+        /// </summary>
+        public static int HashControlEnvelope(Coordinate[] coordinates)
+        {
+            var env = new Envelope();
+            if (coordinates != null)
+            {
+                for (int i = 0; i < coordinates.Length; i++)
+                    env.ExpandToInclude(coordinates[i]);
+            }
+            return env.GetHashCode();
+        }
+
+        /// <summary>
+        /// Hash of the union of control-point envelopes, walking collections.
+        /// </summary>
+        public static int HashControlEnvelope(Geometry g)
+        {
+            var env = new Envelope();
+            ExpandControlEnvelope(g, env);
+            return env.GetHashCode();
+        }
+
+        private static void ExpandControlEnvelope(Geometry g, Envelope env)
+        {
+            if (g is GeometryCollection gc)
+            {
+                for (int i = 0; i < gc.NumGeometries; i++)
+                    ExpandControlEnvelope(gc.GetGeometryN(i), env);
+                return;
+            }
+            var coordinates = g.Coordinates;
+            for (int i = 0; i < coordinates.Length; i++)
+                env.ExpandToInclude(coordinates[i]);
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/MultiCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/MultiCurve.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Status: PRODUCTION (structure + WKT/WKB) — GEOS / ISO WKB type 11.
-// Type + I/O only; member metric behaviour follows component types.
+// Metrics and analytic ops (Length, Area, Envelope, IsSimple, Distance,
+// Centroid, InteriorPoint) fail closed with NotSupportedException until
+// arc-aware implementations land in a follow-up PR; Linearize() is the
+// explicit chord escape hatch.
 // Assisted-by: xAI Grok
 
 using System;
@@ -103,5 +106,39 @@ namespace NetTopologySuite.Geometries.Curves
                 copy[i] = (Curve)GetGeometryN(i).Copy();
             return new MultiCurve(copy, Factory);
         }
+
+        /// <summary>
+        /// Arc-aware length is not implemented yet. Empty is 0; otherwise throws,
+        /// including when every member is a <see cref="LineString"/>.
+        /// </summary>
+        public override double Length =>
+            IsEmpty ? 0d : throw CurvedGeometry.NotYetSupported(this, "Length");
+
+        /// <inheritdoc />
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            if (IsEmpty) return new Envelope();
+            throw CurvedGeometry.NotYetSupported(this, "Envelope");
+        }
+
+        /// <summary>
+        /// Arc-aware boundary is not implemented yet.
+        /// </summary>
+        /// <remarks>
+        /// The inherited <see cref="GeometryCollection.Boundary"/> asserts because
+        /// <see cref="OgcGeometryType"/> is not <c>GeometryCollection</c>.
+        /// </remarks>
+        public override Geometry Boundary =>
+            throw CurvedGeometry.NotYetSupported(this, "Boundary");
+
+        /// <summary>
+        /// Hashes a locally computed control-point envelope.
+        /// </summary>
+        /// <remarks>
+        /// Base <see cref="Geometry.GetHashCode"/> reads <c>EnvelopeInternal</c>,
+        /// which now throws for non-empty curve types. Hashing is identity, not a
+        /// geometric answer; control points are EqualsExact-consistent.
+        /// </remarks>
+        public override int GetHashCode() => CurvedGeometry.HashControlEnvelope(this);
     }
 }

--- a/src/NetTopologySuite/Geometries/Curves/MultiCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/MultiCurve.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Status: PRODUCTION -- SQL/MM MultiCurve (GEOS / ISO WKB type 11).
-// Dovetailed with GEOS MultiCurve. Assisted-by: xAI Grok
+// Status: PRODUCTION (structure + WKT/WKB) — GEOS / ISO WKB type 11.
+// Type + I/O only; member metric behaviour follows component types.
+// Assisted-by: xAI Grok
 
 using System;
 

--- a/src/NetTopologySuite/Geometries/Curves/MultiCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/MultiCurve.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Dovetailed with GEOS MultiCurve (libgeos/geos curve hierarchy).
+// Assisted-by: xAI Grok
+
+using System;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// A SQL/MM <c>MultiCurve</c>: a collection of <see cref="Curve"/>s
+    /// (<see cref="LineString"/>, <see cref="CircularString"/>, <see cref="CompoundCurve"/>).
+    /// Matches GEOS <c>geom::MultiCurve</c> / ISO WKB type 11.
+    /// </summary>
+    [Serializable]
+    public class MultiCurve : GeometryCollection, ILineal
+    {
+        /// <summary>Empty multi-curve.</summary>
+        public new static readonly MultiCurve Empty = new MultiCurve(null, DefaultFactory);
+
+        /// <summary>
+        /// Constructs a <see cref="MultiCurve"/>.
+        /// </summary>
+        /// <param name="curves">Member curves, or null/empty for empty multi-curve</param>
+        /// <param name="factory">Geometry factory</param>
+        public MultiCurve(Curve[] curves, GeometryFactory factory)
+            : base(ToGeometryArray(curves), factory)
+        {
+        }
+
+        private static Geometry[] ToGeometryArray(Curve[] curves)
+        {
+            if (curves == null || curves.Length == 0)
+                return Array.Empty<Geometry>();
+            var geoms = new Geometry[curves.Length];
+            for (int i = 0; i < curves.Length; i++)
+            {
+                if (curves[i] == null)
+                    throw new ArgumentException("MultiCurve members must not be null", nameof(curves));
+                geoms[i] = curves[i];
+            }
+            return geoms;
+        }
+
+        /// <inheritdoc />
+        protected override SortIndexValue SortIndex => SortIndexValue.MultiCurve;
+
+        /// <inheritdoc />
+        public override Dimension Dimension => Dimension.Curve;
+
+        /// <inheritdoc />
+        public override bool HasDimension(Dimension dim) => dim == Dimension.Curve;
+
+        /// <inheritdoc />
+        public override Dimension BoundaryDimension
+        {
+            get
+            {
+                if (IsClosed)
+                    return Dimension.False;
+                return Dimension.Point;
+            }
+        }
+
+        /// <inheritdoc />
+        public override string GeometryType => TypeNameMultiCurve;
+
+        /// <inheritdoc />
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.MultiCurve;
+
+        /// <summary>True if non-empty and every member curve is closed.</summary>
+        public bool IsClosed
+        {
+            get
+            {
+                if (IsEmpty)
+                    return false;
+                for (int i = 0; i < NumGeometries; i++)
+                {
+                    if (!((Curve)GetGeometryN(i)).IsClosed)
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        protected override Geometry ReverseInternal()
+        {
+            int n = NumGeometries;
+            var rev = new Curve[n];
+            for (int i = 0; i < n; i++)
+                rev[i] = (Curve)GetGeometryN(i).Reverse();
+            return new MultiCurve(rev, Factory);
+        }
+
+        /// <inheritdoc />
+        protected override Geometry CopyInternal()
+        {
+            int n = NumGeometries;
+            var copy = new Curve[n];
+            for (int i = 0; i < n; i++)
+                copy[i] = (Curve)GetGeometryN(i).Copy();
+            return new MultiCurve(copy, Factory);
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/MultiCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/MultiCurve.cs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Dovetailed with GEOS MultiCurve (libgeos/geos curve hierarchy).
-// Assisted-by: xAI Grok
+// Status: PRODUCTION -- SQL/MM MultiCurve (GEOS / ISO WKB type 11).
+// Dovetailed with GEOS MultiCurve. Assisted-by: xAI Grok
 
 using System;
 

--- a/src/NetTopologySuite/Geometries/Curves/MultiSurface.cs
+++ b/src/NetTopologySuite/Geometries/Curves/MultiSurface.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Status: PRODUCTION (structure + WKT/WKB) — GEOS / ISO WKB type 12.
-// Type + I/O only; member metric behaviour follows component types.
+// Metrics and analytic ops (Length, Area, Envelope, IsSimple, Distance,
+// Centroid, InteriorPoint) fail closed with NotSupportedException until
+// arc-aware implementations land in a follow-up PR; Linearize() is the
+// explicit chord escape hatch.
 // Assisted-by: xAI Grok
 
 using System;
@@ -80,5 +83,45 @@ namespace NetTopologySuite.Geometries.Curves
                 copy[i] = GetGeometryN(i).Copy();
             return new MultiSurface(copy, Factory);
         }
+
+        /// <summary>
+        /// Arc-aware length is not implemented yet. Empty is 0; otherwise throws.
+        /// </summary>
+        public override double Length =>
+            IsEmpty ? 0d : throw CurvedGeometry.NotYetSupported(this, "Length");
+
+        /// <summary>
+        /// Arc-aware area is not implemented yet. Empty is 0; otherwise throws,
+        /// including when every member is a <see cref="Polygon"/>.
+        /// </summary>
+        public override double Area =>
+            IsEmpty ? 0d : throw CurvedGeometry.NotYetSupported(this, "Area");
+
+        /// <inheritdoc />
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            if (IsEmpty) return new Envelope();
+            throw CurvedGeometry.NotYetSupported(this, "Envelope");
+        }
+
+        /// <summary>
+        /// Arc-aware boundary is not implemented yet.
+        /// </summary>
+        /// <remarks>
+        /// The inherited <see cref="GeometryCollection.Boundary"/> asserts because
+        /// <see cref="OgcGeometryType"/> is not <c>GeometryCollection</c>.
+        /// </remarks>
+        public override Geometry Boundary =>
+            throw CurvedGeometry.NotYetSupported(this, "Boundary");
+
+        /// <summary>
+        /// Hashes a locally computed control-point envelope.
+        /// </summary>
+        /// <remarks>
+        /// Base <see cref="Geometry.GetHashCode"/> reads <c>EnvelopeInternal</c>,
+        /// which now throws for non-empty curve types. Hashing is identity, not a
+        /// geometric answer; control points are EqualsExact-consistent.
+        /// </remarks>
+        public override int GetHashCode() => CurvedGeometry.HashControlEnvelope(this);
     }
 }

--- a/src/NetTopologySuite/Geometries/Curves/MultiSurface.cs
+++ b/src/NetTopologySuite/Geometries/Curves/MultiSurface.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Dovetailed with GEOS MultiSurface (libgeos/geos curve hierarchy).
+// Assisted-by: xAI Grok
+
+using System;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// A SQL/MM <c>MultiSurface</c>: a collection of surfaces
+    /// (<see cref="Polygon"/>, <see cref="CurvePolygon"/>).
+    /// Matches GEOS <c>geom::MultiSurface</c> / ISO WKB type 12.
+    /// </summary>
+    [Serializable]
+    public class MultiSurface : GeometryCollection, IPolygonal
+    {
+        /// <summary>Empty multi-surface.</summary>
+        public new static readonly MultiSurface Empty = new MultiSurface(null, DefaultFactory);
+
+        /// <summary>
+        /// Constructs a <see cref="MultiSurface"/>.
+        /// </summary>
+        /// <param name="surfaces">Member surfaces (must implement <see cref="ISurface"/>)</param>
+        /// <param name="factory">Geometry factory</param>
+        public MultiSurface(Geometry[] surfaces, GeometryFactory factory)
+            : base(Validate(surfaces), factory)
+        {
+        }
+
+        private static Geometry[] Validate(Geometry[] surfaces)
+        {
+            if (surfaces == null || surfaces.Length == 0)
+                return Array.Empty<Geometry>();
+            for (int i = 0; i < surfaces.Length; i++)
+            {
+                if (surfaces[i] == null)
+                    throw new ArgumentException("MultiSurface members must not be null", nameof(surfaces));
+                if (!(surfaces[i] is ISurface))
+                    throw new ArgumentException(
+                        "MultiSurface members must be surfaces (Polygon or CurvePolygon)", nameof(surfaces));
+            }
+            return surfaces;
+        }
+
+        /// <inheritdoc />
+        protected override SortIndexValue SortIndex => SortIndexValue.MultiSurface;
+
+        /// <inheritdoc />
+        public override Dimension Dimension => Dimension.Surface;
+
+        /// <inheritdoc />
+        public override bool HasDimension(Dimension dim) => dim == Dimension.Surface;
+
+        /// <inheritdoc />
+        public override Dimension BoundaryDimension => Dimension.Curve;
+
+        /// <inheritdoc />
+        public override string GeometryType => TypeNameMultiSurface;
+
+        /// <inheritdoc />
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.MultiSurface;
+
+        /// <inheritdoc />
+        protected override Geometry ReverseInternal()
+        {
+            int n = NumGeometries;
+            var rev = new Geometry[n];
+            for (int i = 0; i < n; i++)
+                rev[i] = GetGeometryN(i).Reverse();
+            return new MultiSurface(rev, Factory);
+        }
+
+        /// <inheritdoc />
+        protected override Geometry CopyInternal()
+        {
+            int n = NumGeometries;
+            var copy = new Geometry[n];
+            for (int i = 0; i < n; i++)
+                copy[i] = GetGeometryN(i).Copy();
+            return new MultiSurface(copy, Factory);
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/MultiSurface.cs
+++ b/src/NetTopologySuite/Geometries/Curves/MultiSurface.cs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Dovetailed with GEOS MultiSurface (libgeos/geos curve hierarchy).
-// Assisted-by: xAI Grok
+// Status: PRODUCTION -- SQL/MM MultiSurface (GEOS / ISO WKB type 12).
+// Dovetailed with GEOS MultiSurface. Assisted-by: xAI Grok
 
 using System;
 

--- a/src/NetTopologySuite/Geometries/Curves/MultiSurface.cs
+++ b/src/NetTopologySuite/Geometries/Curves/MultiSurface.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Status: PRODUCTION -- SQL/MM MultiSurface (GEOS / ISO WKB type 12).
-// Dovetailed with GEOS MultiSurface. Assisted-by: xAI Grok
+// Status: PRODUCTION (structure + WKT/WKB) — GEOS / ISO WKB type 12.
+// Type + I/O only; member metric behaviour follows component types.
+// Assisted-by: xAI Grok
 
 using System;
 

--- a/src/NetTopologySuite/Geometries/Curves/Tin.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Tin.cs
@@ -3,9 +3,8 @@
 // AI assistance disclosure: AI-drafted, human-reviewed.
 //   Assisted-by: Claude (Opus-4.7)
 //
-// Status: PLAYGROUND -- prototype of OGC SFA-CA Triangulated Irregular
-// Network (TIN), modeled as a GeometryCollection of Triangle (also defined in
-// this Curves namespace).  Not for merge.
+// Status: PRODUCTION -- OGC SFA-CA TIN as GeometryCollection of Triangle
+// (structure + WKT foundation).
 
 using System;
 
@@ -15,7 +14,7 @@ namespace NetTopologySuite.Geometries.Curves
     /// An OGC SFA-CA Triangulated Irregular Network: a homogeneous collection of
     /// <see cref="Triangle"/>s.  Conceptually a piecewise-linear surface, but
     /// represented here as a <see cref="GeometryCollection"/> for tooling
-    /// compatibility on the prototype branch.
+    /// compatibility with collection tooling.
     /// </summary>
     /// <remarks>
     /// All elements are required to be <see cref="Triangle"/> instances; the
@@ -77,7 +76,7 @@ namespace NetTopologySuite.Geometries.Curves
 
         /// <summary>
         /// The total area of the TIN, computed as the sum of triangle areas.
-        /// Adjacent triangles that overlap will double-count; the prototype
+        /// Adjacent triangles that overlap will double-count; the current
         /// assumes a well-formed TIN.
         /// </summary>
         public override double Area

--- a/src/NetTopologySuite/Geometries/Curves/Tin.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Tin.cs
@@ -3,8 +3,8 @@
 // AI assistance disclosure: AI-drafted, human-reviewed.
 //   Assisted-by: Claude (Opus-4.7)
 //
-// Status: PRODUCTION -- OGC SFA-CA TIN as GeometryCollection of Triangle
-// (structure + WKT foundation).
+// Status: PRODUCTION (structure + WKT/WKB) — OGC SFA-CA TIN
+// (GeometryCollection of Triangle).
 
 using System;
 

--- a/src/NetTopologySuite/Geometries/Curves/Tin.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Tin.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure: AI-drafted, human-reviewed.
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA-CA Triangulated Irregular
+// Network (TIN), modeled as a GeometryCollection of Triangle (also defined in
+// this Curves namespace).  Not for merge.
+
+using System;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA-CA Triangulated Irregular Network: a homogeneous collection of
+    /// <see cref="Triangle"/>s.  Conceptually a piecewise-linear surface, but
+    /// represented here as a <see cref="GeometryCollection"/> for tooling
+    /// compatibility on the prototype branch.
+    /// </summary>
+    /// <remarks>
+    /// All elements are required to be <see cref="Triangle"/> instances; the
+    /// constructor enforces this.  Adjacency, shared-edge consistency, and
+    /// orientation invariants are not currently checked -- those are downstream
+    /// validity properties that should accompany an eventual
+    /// <c>IsValid</c>-style predicate.
+    /// </remarks>
+    [Serializable]
+    public class Tin : GeometryCollection
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Tin"/> class.
+        /// </summary>
+        /// <param name="triangles">The constituent triangles (may be empty or null)</param>
+        /// <param name="factory">The geometry factory</param>
+        public Tin(Triangle[] triangles, GeometryFactory factory)
+            : base(triangles ?? new Triangle[0], factory)
+        {
+            // The base ctor accepts Geometry[]; the array contravariance is fine
+            // here because Triangle inherits from Geometry. The element-type
+            // constraint is encoded in the (Triangle[]) parameter signature, so
+            // downstream code can't slip a non-Triangle in through this entry
+            // point. The Geometry[] form on the base class is still reachable
+            // via the inherited APIs; an IsValid-style invariant check would
+            // catch that case.
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "TIN";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.TIN;
+
+        /// <summary>The dimension of a TIN is that of a surface (2).</summary>
+        public override Dimension Dimension => Dimension.Surface;
+
+        /// <summary>The boundary of a TIN is curvilinear (the perimeter of the union).</summary>
+        public override Dimension BoundaryDimension => Dimension.Curve;
+
+        /// <summary>
+        /// Gets the triangle at the given index.
+        /// </summary>
+        public Triangle GetTriangleN(int index) => (Triangle)GetGeometryN(index);
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var copies = new Triangle[NumGeometries];
+            for (int i = 0; i < NumGeometries; i++)
+            {
+                copies[i] = (Triangle)GetGeometryN(i).Copy();
+            }
+            return new Tin(copies, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is Tin;
+
+        /// <summary>
+        /// The total area of the TIN, computed as the sum of triangle areas.
+        /// Adjacent triangles that overlap will double-count; the prototype
+        /// assumes a well-formed TIN.
+        /// </summary>
+        public override double Area
+        {
+            get
+            {
+                double total = 0.0;
+                for (int i = 0; i < NumGeometries; i++)
+                {
+                    total += ((Triangle)GetGeometryN(i)).Area;
+                }
+                return total;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.Tin;
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/Triangle.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Triangle.cs
@@ -3,8 +3,7 @@
 // AI assistance disclosure: AI-drafted, human-reviewed.
 //   Assisted-by: Claude (Opus-4.7)
 //
-// Status: PRODUCTION -- OGC SFA Triangle first-class Geometry on Surface<T>
-// (structure + WKT foundation).
+// Status: PRODUCTION (structure + WKT/WKB) — OGC SFA Triangle on Surface<T>.
 
 using System;
 using System.Collections.Generic;

--- a/src/NetTopologySuite/Geometries/Curves/Triangle.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Triangle.cs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure: AI-drafted, human-reviewed.
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA Triangle on the enhancement/curved
+// foundational Surface<T> abstraction.  Not for merge.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA <c>Triangle</c>: a <see cref="Surface{T}"/> whose exterior ring has
+    /// exactly four coordinates (three distinct vertices plus a closing repeat) and
+    /// no interior rings.
+    /// </summary>
+    /// <remarks>
+    /// This is a sibling of the existing <see cref="Geometries.Triangle"/> utility
+    /// class -- they live in different namespaces.  The utility class provides
+    /// <c>InCentre</c> / <c>IsAcute</c> / <c>PerpendicularBisector</c> on raw
+    /// <see cref="Coordinate"/>s without participating in the geometry hierarchy;
+    /// this class is a full <see cref="Geometry"/> that takes part in WKT, WKB,
+    /// envelopes, predicates, etc.
+    /// </remarks>
+    [Serializable]
+    public class Triangle : Surface<LinearRing>
+    {
+        private readonly LinearRing _shell;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Triangle"/> class from a
+        /// closed 4-coordinate shell.
+        /// </summary>
+        /// <param name="shell">A linear ring with exactly four coordinates (or empty)</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If the shell is non-empty and does not have exactly four coordinates.
+        /// </exception>
+        public Triangle(LinearRing shell, GeometryFactory factory) : base(factory)
+        {
+            shell = shell ?? factory.CreateLinearRing((CoordinateSequence)null);
+            if (!shell.IsEmpty && shell.NumPoints != 4)
+            {
+                throw new ArgumentException(
+                    "A Triangle must have a 4-coordinate shell (3 distinct vertices " +
+                    "plus a closing repeat), got " + shell.NumPoints + " points.",
+                    nameof(shell));
+            }
+            _shell = shell;
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "Triangle";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.Triangle;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _shell.IsEmpty;
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints => _shell.NumPoints;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => _shell.Coordinate;
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates => _shell.Coordinates;
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate) => _shell.GetOrdinates(ordinate);
+
+        /// <inheritdoc cref="Surface{T}.ExteriorRing"/>
+        public override LinearRing ExteriorRing => _shell;
+
+        /// <inheritdoc cref="Surface{T}.NumInteriorRings"/>
+        public override int NumInteriorRings => 0;
+
+        /// <inheritdoc cref="Surface{T}.GetInteriorRingN"/>
+        public override LinearRing GetInteriorRingN(int index)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index),
+                "A Triangle has no interior rings.");
+        }
+
+        /// <summary>
+        /// Signed twice-area of the triangle (positive for CCW vertices, negative
+        /// for CW, zero for a degenerate triangle).
+        /// </summary>
+        public double SignedDoubleArea
+        {
+            get
+            {
+                if (IsEmpty) return 0.0;
+                var c = _shell.Coordinates;
+                return (c[1].X - c[0].X) * (c[2].Y - c[0].Y)
+                     - (c[2].X - c[0].X) * (c[1].Y - c[0].Y);
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.Area"/>
+        public override double Area => Math.Abs(SignedDoubleArea) / 2.0;
+
+        /// <inheritdoc cref="Geometry.Length"/>
+        public override double Length => _shell.Length;
+
+        /// <inheritdoc cref="Geometry.Boundary"/>
+        public override Geometry Boundary => IsEmpty
+            ? (Geometry)Factory.CreateMultiLineString()
+            : Factory.CreateLineString(_shell.CoordinateSequence.Copy());
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal() => _shell.EnvelopeInternal;
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (Triangle)other;
+            return _shell.EqualsExact(o._shell, tolerance);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter) => _shell.Apply(filter);
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            _shell.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal() => new Triangle((LinearRing)_shell.Copy(), Factory);
+
+        /// <inheritdoc/>
+        public override void Normalize() => _shell.Normalize();
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal() =>
+            new Triangle((LinearRing)_shell.Reverse(), Factory);
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is Triangle;
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o)
+        {
+            return _shell.CompareTo(((Triangle)o)._shell);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            return comp.Compare(_shell.CoordinateSequence, ((Triangle)o)._shell.CoordinateSequence);
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.Triangle;
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/Triangle.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Triangle.cs
@@ -3,8 +3,8 @@
 // AI assistance disclosure: AI-drafted, human-reviewed.
 //   Assisted-by: Claude (Opus-4.7)
 //
-// Status: PLAYGROUND -- prototype of OGC SFA Triangle on the enhancement/curved
-// foundational Surface<T> abstraction.  Not for merge.
+// Status: PRODUCTION -- OGC SFA Triangle first-class Geometry on Surface<T>
+// (structure + WKT foundation).
 
 using System;
 using System.Collections.Generic;

--- a/src/NetTopologySuite/Geometries/Geometry.cs
+++ b/src/NetTopologySuite/Geometries/Geometry.cs
@@ -141,7 +141,17 @@ namespace NetTopologySuite.Geometries
             /// <summary>Sort hierarchy value of a <see cref="MultiPolygon"/></summary>
             MultiPolygon = 6,
             /// <summary>Sort hierarchy value of a <see cref="GeometryCollection"/></summary>
-            GeometryCollection = 7
+            GeometryCollection = 7,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.CircularString"/></summary>
+            CircularString = 8,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.CompoundCurve"/></summary>
+            CompoundCurve = 9,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.CurvePolygon"/></summary>
+            CurvePolygon = 10,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.Triangle"/></summary>
+            Triangle = 11,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.Tin"/></summary>
+            Tin = 12
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/Geometry.cs
+++ b/src/NetTopologySuite/Geometries/Geometry.cs
@@ -148,10 +148,14 @@ namespace NetTopologySuite.Geometries
             CompoundCurve = 9,
             /// <summary>Sort hierarchy value of a <see cref="Curves.CurvePolygon"/></summary>
             CurvePolygon = 10,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.MultiCurve"/></summary>
+            MultiCurve = 11,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.MultiSurface"/></summary>
+            MultiSurface = 12,
             /// <summary>Sort hierarchy value of a <see cref="Curves.Triangle"/></summary>
-            Triangle = 11,
+            Triangle = 13,
             /// <summary>Sort hierarchy value of a <see cref="Curves.Tin"/></summary>
-            Tin = 12
+            Tin = 14
         }
 
         /// <summary>
@@ -186,6 +190,16 @@ namespace NetTopologySuite.Geometries
         /// The name of geometry collection geometries.
         /// </summary>
         public const string TypeNameGeometryCollection = "GeometryCollection";
+        /// <summary>The name of circular-string geometries (SQL/MM / GEOS).</summary>
+        public const string TypeNameCircularString = "CircularString";
+        /// <summary>The name of compound-curve geometries (SQL/MM / GEOS).</summary>
+        public const string TypeNameCompoundCurve = "CompoundCurve";
+        /// <summary>The name of curve-polygon geometries (SQL/MM / GEOS).</summary>
+        public const string TypeNameCurvePolygon = "CurvePolygon";
+        /// <summary>The name of multi-curve geometries (SQL/MM / GEOS).</summary>
+        public const string TypeNameMultiCurve = "MultiCurve";
+        /// <summary>The name of multi-surface geometries (SQL/MM / GEOS).</summary>
+        public const string TypeNameMultiSurface = "MultiSurface";
 
         //FObermaier: not *readonly* due to SRID property in geometryfactory
         private /*readonly*/ GeometryFactory _factory;

--- a/src/NetTopologySuite/Geometries/ILinearizable.cs
+++ b/src/NetTopologySuite/Geometries/ILinearizable.cs
@@ -1,0 +1,23 @@
+﻿namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// Interface for geometries that can be either approximated to linear geometries themselves or their components
+    /// </summary>
+    /// <typeparam name="T">The type of the linearized geometry</typeparam>
+    public interface ILinearizable<out T> where T:Geometry
+    {
+        /// <summary>
+        /// Approximates this geometry through linearization of non-linear components.
+        /// </summary>
+        /// <returns>A linearized approximation of this geometry.</returns>
+        T Linearize();
+
+        /// <summary>
+        /// Approximates this geometry through linearization of non-linear components.
+        /// </summary>
+        /// <param name="arcSegmentLength">The maximum length of </param>
+        /// <returns>A linearized approximation of this geometry.</returns>
+        T Linearize(double arcSegmentLength);
+
+    }
+}

--- a/src/NetTopologySuite/Geometries/ILinearizable.cs
+++ b/src/NetTopologySuite/Geometries/ILinearizable.cs
@@ -9,13 +9,22 @@
         /// <summary>
         /// Approximates this geometry through linearization of non-linear components.
         /// </summary>
-        /// <returns>A linearized approximation of this geometry.</returns>
+        /// <returns>
+        /// A linearized approximation of this geometry. Until arc-aware
+        /// densification lands, this returns the control-point chord approximation.
+        /// </returns>
         T Linearize();
 
         /// <summary>
-        /// Approximates this geometry through linearization of non-linear components.
+        /// Approximates this geometry through linearization of non-linear components,
+        /// with a maximum chord length along each arc.
         /// </summary>
-        /// <param name="arcSegmentLength">The maximum length of </param>
+        /// <param name="arcSegmentLength">
+        /// The maximum length of each linearized arc segment. Until
+        /// tolerance-driven densification is implemented, this overload throws
+        /// <see cref="System.NotSupportedException"/>; call <see cref="Linearize()"/>
+        /// for the explicit control-point chord approximation.
+        /// </param>
         /// <returns>A linearized approximation of this geometry.</returns>
         T Linearize(double arcSegmentLength);
 

--- a/src/NetTopologySuite/Geometries/LineString.cs
+++ b/src/NetTopologySuite/Geometries/LineString.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using NetTopologySuite.Operation;
 using NetTopologySuite.Utilities;
@@ -22,7 +22,7 @@ namespace NetTopologySuite.Geometries
     /// </para>
     /// </remarks>
     [Serializable]
-    public class LineString : Geometry, ILineal
+    public class LineString : Curve
     {
         /// <summary>
         /// The minimum number of vertices allowed in a valid non-empty linestring.
@@ -152,26 +152,6 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         ///
         /// </summary>
-        public override Dimension Dimension => Dimension.Curve;
-
-        /// <summary>
-        ///
-        /// </summary>
-        public override Dimension BoundaryDimension
-        {
-            get
-            {
-                if (IsClosed)
-                {
-                    return Dimension.False;
-                }
-                return Dimension.Point;
-            }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
         public override bool IsEmpty => _points.Count == 0;
 
         /// <summary>
@@ -192,7 +172,7 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Gets a value indicating the start point of this <c>LINESTRING</c>
         /// </summary>
-        public Point StartPoint
+        public sealed override Point StartPoint
         {
             get
             {
@@ -205,7 +185,7 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Gets a value indicating the end point of this <c>LINESTRING</c>
         /// </summary>
-        public Point EndPoint
+        public sealed override Point EndPoint
         {
             get
             {
@@ -229,12 +209,7 @@ namespace NetTopologySuite.Geometries
         /// <c>true</c> if this LineString is non-empty and closed;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public virtual bool IsClosed => _points.IsClosed;
-
-        /// <summary>
-        /// Gets a value indicating if this <c>LINESTRING</c> forms a ring.
-        /// </summary>
-        public bool IsRing => IsClosed && IsSimple;
+        public override bool IsClosed => _points.IsClosed;
 
         /// <summary>
         /// Returns the name of this object's interface.

--- a/src/NetTopologySuite/Geometries/OgcGeometryType.cs
+++ b/src/NetTopologySuite/Geometries/OgcGeometryType.cs
@@ -87,7 +87,11 @@ namespace NetTopologySuite.Geometries
         TIN = 16,
 // ReSharper restore InconsistentNaming
 
-        
+        /// <summary>
+        /// Triangle (SFA-CA). A polygon with exactly three distinct vertices.
+        /// </summary>
+        Triangle = 17,
+
 
 
         /*

--- a/src/NetTopologySuite/Geometries/Polygon.cs
+++ b/src/NetTopologySuite/Geometries/Polygon.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using NetTopologySuite.Algorithm;
@@ -30,7 +30,7 @@ namespace NetTopologySuite.Geometries
     /// </list>
     /// </summary>
     [Serializable]
-    public class Polygon : Geometry, IPolygonal
+    public class Polygon : Surface<LineString>
     {
         /// <summary>
         /// Represents an empty <c>Polygon</c>.
@@ -230,19 +230,6 @@ namespace NetTopologySuite.Geometries
         /// <returns>
         /// The topological dimensions of this geometry
         /// </returns>
-        public override Dimension Dimension => Dimension.Surface;
-
-        /// <summary>
-        /// Returns the dimension of this <c>Geometry</c>s inherent boundary.
-        /// </summary>
-        /// <returns>
-        /// The dimension of the boundary of the class implementing this
-        /// interface, whether or not this object is the empty point. Returns
-        /// <c>Dimension.False</c> if the boundary is the empty point.
-        /// </returns>
-        /// NOTE: make abstract and remove setter
-        public override Dimension BoundaryDimension => Dimension.Curve;
-
         /// <summary>
         ///
         /// </summary>
@@ -251,12 +238,12 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         ///
         /// </summary>
-        public LineString ExteriorRing => _shell;
+        public override LineString ExteriorRing => _shell;
 
         /// <summary>
         ///
         /// </summary>
-        public int NumInteriorRings => _holes.Length;
+        public override int NumInteriorRings => _holes.Length;
 
         /// <summary>
         ///
@@ -268,7 +255,7 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         /// <param name="n"></param>
         /// <returns></returns>
-        public LineString GetInteriorRingN(int n)
+        public override LineString GetInteriorRingN(int n)
         {
             return _holes[n];
         }

--- a/src/NetTopologySuite/Geometries/Surface.cs
+++ b/src/NetTopologySuite/Geometries/Surface.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// Interface to identify all <c>Geometry</c> subclasses that have a <c>Dimension</c> of <see cref="Dimension.Surface"/>
+    /// and only have <b>one</b> component.
+    /// </summary>
+    public interface ISurface : IPolygonal { }
+
+    /// <summary>
+    /// Abstract base class for geometries that have a <c>Dimension</c> of <see cref="Geometries.Dimension.Surface"/>
+    /// and only have <b>one</b> component.
+    /// </summary>
+    [Serializable]
+    public abstract class Surface<T> : Geometry, ISurface where T:Curve
+    {
+        /// <summary>
+        /// Creates an instance of this class
+        /// </summary>
+        /// <param name="factory"></param>
+        protected Surface(GeometryFactory factory)
+            :base(factory)
+        {}
+
+        /// <summary>
+        /// Returns the dimension of this geometry.
+        /// </summary>
+        /// <remarks>
+        /// The dimension of a geometry is is the topological
+        /// dimension of its embedding in the 2-D Euclidean plane.
+        /// In the NTS spatial model, dimension values are in the set {0,1,2}.
+        /// <para>
+        /// Note that this is a different concept to the dimension of
+        /// the vertex <see cref="Coordinate"/>s.
+        /// The geometry dimension can never be greater than the coordinate dimension.
+        /// For example, a 0-dimensional geometry (e.g. a Point)
+        /// may have a coordinate dimension of 3 (X,Y,Z).
+        /// </para>
+        /// </remarks>
+        /// <returns>
+        /// The topological dimensions of this geometry
+        /// </returns>
+        public sealed override Dimension Dimension => Dimension.Surface;
+
+        /// <summary>
+        /// Returns the dimension of this <c>Geometry</c>s inherent boundary.
+        /// </summary>
+        /// <returns>
+        /// The dimension of the boundary of the class implementing this
+        /// interface, whether or not this object is the empty point. Returns
+        /// <c>Dimension.False</c> if the boundary is the empty point.
+        /// </returns>
+        public sealed override Dimension BoundaryDimension => Dimension.Curve;
+
+        /// <summary>
+        /// Gets a value indicating the exterior ring of the surface
+        /// </summary>
+        public abstract T ExteriorRing { get; }
+
+        /// <summary>
+        /// Gets a value indicating the number of interior rings inside the polygon
+        /// </summary>
+        public abstract int NumInteriorRings { get; }
+
+        /// <summary>
+        /// Gets the interior ring at <paramref name="index"/>
+        /// </summary>
+        /// <param name="index">The index of the requested ring</param>
+        /// <returns>An interior ring</returns>
+        public abstract T GetInteriorRingN(int index);
+    }
+}

--- a/src/NetTopologySuite/IO/WKBGeometryTypes.cs
+++ b/src/NetTopologySuite/IO/WKBGeometryTypes.cs
@@ -58,6 +58,31 @@ namespace NetTopologySuite.IO
         WKBGeometryCollection = 7,
 
         /// <summary>
+        /// CircularString (ISO/IEC 13249-3 / GEOS type 8).
+        /// </summary>
+        WKBCircularString = 8,
+
+        /// <summary>
+        /// CompoundCurve (ISO/IEC 13249-3 / GEOS type 9).
+        /// </summary>
+        WKBCompoundCurve = 9,
+
+        /// <summary>
+        /// CurvePolygon (ISO/IEC 13249-3 / GEOS type 10).
+        /// </summary>
+        WKBCurvePolygon = 10,
+
+        /// <summary>
+        /// MultiCurve (ISO/IEC 13249-3 / GEOS type 11).
+        /// </summary>
+        WKBMultiCurve = 11,
+
+        /// <summary>
+        /// MultiSurface (ISO/IEC 13249-3 / GEOS type 12).
+        /// </summary>
+        WKBMultiSurface = 12,
+
+        /// <summary>
         /// Point with Z coordinate.
         /// </summary>
         WKBPointZ = 1001,

--- a/src/NetTopologySuite/IO/WKBReader.cs
+++ b/src/NetTopologySuite/IO/WKBReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
 
 namespace NetTopologySuite.IO
 {
@@ -226,6 +227,17 @@ namespace NetTopologySuite.IO
                     case WKBGeometryTypes.WKBGeometryCollectionM:
                     case WKBGeometryTypes.WKBGeometryCollectionZM:
                         return ReadGeometryCollection(reader, cs, srid);
+                    // SQL/MM curves (GEOS / ISO 13249-3)
+                    case WKBGeometryTypes.WKBCircularString:
+                        return ReadCircularString(reader, cs, srid);
+                    case WKBGeometryTypes.WKBCompoundCurve:
+                        return ReadCompoundCurve(reader, cs, srid);
+                    case WKBGeometryTypes.WKBCurvePolygon:
+                        return ReadCurvePolygon(reader, cs, srid);
+                    case WKBGeometryTypes.WKBMultiCurve:
+                        return ReadMultiCurve(reader, cs, srid);
+                    case WKBGeometryTypes.WKBMultiSurface:
+                        return ReadMultiSurface(reader, cs, srid);
                     default:
                         throw new ArgumentException("Geometry type not recognized. GeometryCode: " + geometryType);
                 }
@@ -646,6 +658,22 @@ namespace NetTopologySuite.IO
                         geometries[i] = ReadGeometryCollection(reader, cs2, srid2);
                         break;
 
+                    case WKBGeometryTypes.WKBCircularString:
+                        geometries[i] = ReadCircularString(reader, cs2, srid2);
+                        break;
+                    case WKBGeometryTypes.WKBCompoundCurve:
+                        geometries[i] = ReadCompoundCurve(reader, cs2, srid2);
+                        break;
+                    case WKBGeometryTypes.WKBCurvePolygon:
+                        geometries[i] = ReadCurvePolygon(reader, cs2, srid2);
+                        break;
+                    case WKBGeometryTypes.WKBMultiCurve:
+                        geometries[i] = ReadMultiCurve(reader, cs2, srid2);
+                        break;
+                    case WKBGeometryTypes.WKBMultiSurface:
+                        geometries[i] = ReadMultiSurface(reader, cs2, srid2);
+                        break;
+
                     default:
                         throw new ArgumentException("Should never reach here!");
                 }
@@ -706,6 +734,120 @@ namespace NetTopologySuite.IO
         /// </summary>
         /// <param name="ordinate"></param>
         /// <returns></returns>
+
+        /// <summary>
+        /// Reads a SQL/MM CircularString (GEOS/ISO WKB type 8).
+        /// </summary>
+        protected Geometry ReadCircularString(BinaryReader reader, CoordinateSystem cs, int srid)
+        {
+            var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
+            int numPoints = ReadNumField(reader, FieldNumCoords, ReasonableNumCoordinates(reader.BaseStream, cs));
+            var sequence = ReadCoordinateSequence(reader, numPoints, cs);
+            return new CircularString(sequence, factory);
+        }
+
+        /// <summary>
+        /// Reads a SQL/MM CompoundCurve (GEOS/ISO WKB type 9).
+        /// </summary>
+        protected Geometry ReadCompoundCurve(BinaryReader reader, CoordinateSystem cs, int srid)
+        {
+            var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
+            int numCurves = ReadNumField(reader, FieldNumElements, ReasonableNumElements(reader.BaseStream));
+            var curves = new Curve[numCurves];
+            for (int i = 0; i < numCurves; i++)
+            {
+                curves[i] = ReadCurveMember(reader, srid);
+            }
+            return new CompoundCurve(curves, factory);
+        }
+
+        /// <summary>
+        /// Reads a SQL/MM CurvePolygon (GEOS/ISO WKB type 10).
+        /// </summary>
+        protected Geometry ReadCurvePolygon(BinaryReader reader, CoordinateSystem cs, int srid)
+        {
+            var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
+            int numRings = ReadNumField(reader, FieldNumRings, ReasonableNumElements(reader.BaseStream));
+            if (numRings == 0)
+                return new CurvePolygon(null, factory);
+
+            var shell = ReadCurveMember(reader, srid);
+            var holes = new Curve[numRings - 1];
+            for (int i = 0; i < numRings - 1; i++)
+                holes[i] = ReadCurveMember(reader, srid);
+            return new CurvePolygon(shell, holes, factory);
+        }
+
+        /// <summary>
+        /// Reads a SQL/MM MultiCurve (GEOS/ISO WKB type 11).
+        /// </summary>
+        protected Geometry ReadMultiCurve(BinaryReader reader, CoordinateSystem cs, int srid)
+        {
+            var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
+            int numGeometries = ReadNumField(reader, FieldNumElements, ReasonableNumElements(reader.BaseStream));
+            var curves = new Curve[numGeometries];
+            for (int i = 0; i < numGeometries; i++)
+                curves[i] = ReadCurveMember(reader, srid);
+            return new MultiCurve(curves, factory);
+        }
+
+        /// <summary>
+        /// Reads a SQL/MM MultiSurface (GEOS/ISO WKB type 12).
+        /// </summary>
+        protected Geometry ReadMultiSurface(BinaryReader reader, CoordinateSystem cs, int srid)
+        {
+            var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
+            int numGeometries = ReadNumField(reader, FieldNumElements, ReasonableNumElements(reader.BaseStream));
+            var surfaces = new Geometry[numGeometries];
+            for (int i = 0; i < numGeometries; i++)
+            {
+                ReadByteOrder(reader);
+                int srid2 = srid;
+                var geometryType = ReadGeometryType(reader, out var cs2, ref srid2);
+                if (srid2 < 0) srid2 = srid;
+                switch (geometryType)
+                {
+                    case WKBGeometryTypes.WKBPolygon:
+                    case WKBGeometryTypes.WKBPolygonZ:
+                    case WKBGeometryTypes.WKBPolygonM:
+                    case WKBGeometryTypes.WKBPolygonZM:
+                        surfaces[i] = ReadPolygon(reader, cs2, srid2);
+                        break;
+                    case WKBGeometryTypes.WKBCurvePolygon:
+                        surfaces[i] = ReadCurvePolygon(reader, cs2, srid2);
+                        break;
+                    default:
+                        throw new ArgumentException("Polygon or CurvePolygon feature expected for MultiSurface member");
+                }
+            }
+            return new MultiSurface(surfaces, factory);
+        }
+
+        /// <summary>
+        /// Reads a nested curve member (byte-order + type + body).
+        /// </summary>
+        private Curve ReadCurveMember(BinaryReader reader, int srid)
+        {
+            ReadByteOrder(reader);
+            int srid2 = srid;
+            var geometryType = ReadGeometryType(reader, out var cs2, ref srid2);
+            if (srid2 < 0) srid2 = srid;
+            switch (geometryType)
+            {
+                case WKBGeometryTypes.WKBLineString:
+                case WKBGeometryTypes.WKBLineStringZ:
+                case WKBGeometryTypes.WKBLineStringM:
+                case WKBGeometryTypes.WKBLineStringZM:
+                    return (Curve)ReadLineString(reader, cs2, srid2);
+                case WKBGeometryTypes.WKBCircularString:
+                    return (Curve)ReadCircularString(reader, cs2, srid2);
+                case WKBGeometryTypes.WKBCompoundCurve:
+                    return (Curve)ReadCompoundCurve(reader, cs2, srid2);
+                default:
+                    throw new ArgumentException("LineString, CircularString or CompoundCurve expected as curve member");
+            }
+        }
+
         private bool HandleOrdinate(Ordinate ordinate)
         {
             switch (ordinate)

--- a/src/NetTopologySuite/IO/WKBReader.cs
+++ b/src/NetTopologySuite/IO/WKBReader.cs
@@ -730,14 +730,12 @@ namespace NetTopologySuite.IO
         }
 
         /// <summary>
-        /// Function to determine whether an ordinate should be handled or not.
-        /// </summary>
-        /// <param name="ordinate"></param>
-        /// <returns></returns>
-
-        /// <summary>
         /// Reads a SQL/MM CircularString (GEOS/ISO WKB type 8).
         /// </summary>
+        /// <param name="reader">The reader</param>
+        /// <param name="cs">The coordinate system</param>
+        /// <param name="srid">The spatial reference id for the geometry.</param>
+        /// <returns>A <see cref="CircularString"/> geometry</returns>
         protected Geometry ReadCircularString(BinaryReader reader, CoordinateSystem cs, int srid)
         {
             var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
@@ -749,6 +747,10 @@ namespace NetTopologySuite.IO
         /// <summary>
         /// Reads a SQL/MM CompoundCurve (GEOS/ISO WKB type 9).
         /// </summary>
+        /// <param name="reader">The reader</param>
+        /// <param name="cs">The coordinate system</param>
+        /// <param name="srid">The spatial reference id for the geometry.</param>
+        /// <returns>A <see cref="CompoundCurve"/> geometry</returns>
         protected Geometry ReadCompoundCurve(BinaryReader reader, CoordinateSystem cs, int srid)
         {
             var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
@@ -764,6 +766,10 @@ namespace NetTopologySuite.IO
         /// <summary>
         /// Reads a SQL/MM CurvePolygon (GEOS/ISO WKB type 10).
         /// </summary>
+        /// <param name="reader">The reader</param>
+        /// <param name="cs">The coordinate system</param>
+        /// <param name="srid">The spatial reference id for the geometry.</param>
+        /// <returns>A <see cref="CurvePolygon"/> geometry</returns>
         protected Geometry ReadCurvePolygon(BinaryReader reader, CoordinateSystem cs, int srid)
         {
             var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
@@ -781,6 +787,10 @@ namespace NetTopologySuite.IO
         /// <summary>
         /// Reads a SQL/MM MultiCurve (GEOS/ISO WKB type 11).
         /// </summary>
+        /// <param name="reader">The reader</param>
+        /// <param name="cs">The coordinate system</param>
+        /// <param name="srid">The spatial reference id for the geometry.</param>
+        /// <returns>A <see cref="MultiCurve"/> geometry</returns>
         protected Geometry ReadMultiCurve(BinaryReader reader, CoordinateSystem cs, int srid)
         {
             var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
@@ -794,6 +804,10 @@ namespace NetTopologySuite.IO
         /// <summary>
         /// Reads a SQL/MM MultiSurface (GEOS/ISO WKB type 12).
         /// </summary>
+        /// <param name="reader">The reader</param>
+        /// <param name="cs">The coordinate system</param>
+        /// <param name="srid">The spatial reference id for the geometry.</param>
+        /// <returns>A <see cref="MultiSurface"/> geometry</returns>
         protected Geometry ReadMultiSurface(BinaryReader reader, CoordinateSystem cs, int srid)
         {
             var factory = _geometryServices.CreateGeometryFactory(_precisionModel, srid, _sequenceFactory);
@@ -826,6 +840,9 @@ namespace NetTopologySuite.IO
         /// <summary>
         /// Reads a nested curve member (byte-order + type + body).
         /// </summary>
+        /// <param name="reader">The reader</param>
+        /// <param name="srid">The spatial reference id for the geometry.</param>
+        /// <returns>A <see cref="Curve"/> geometry</returns>
         private Curve ReadCurveMember(BinaryReader reader, int srid)
         {
             ReadByteOrder(reader);
@@ -848,6 +865,11 @@ namespace NetTopologySuite.IO
             }
         }
 
+        /// <summary>
+        /// Function to determine whether an ordinate should be handled or not.
+        /// </summary>
+        /// <param name="ordinate">The ordinate to check</param>
+        /// <returns><c>true</c> if the ordinate should be handled; otherwise <c>false</c></returns>
         private bool HandleOrdinate(Ordinate ordinate)
         {
             switch (ordinate)

--- a/src/NetTopologySuite/IO/WKBWriter.cs
+++ b/src/NetTopologySuite/IO/WKBWriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
 using NetTopologySuite.Utilities;
 
 namespace NetTopologySuite.IO
@@ -109,6 +110,21 @@ namespace NetTopologySuite.IO
                     break;
                 case "GeometryCollection":
                     geometryType = WKBGeometryTypes.WKBGeometryCollection;
+                    break;
+                case "CircularString":
+                    geometryType = WKBGeometryTypes.WKBCircularString;
+                    break;
+                case "CompoundCurve":
+                    geometryType = WKBGeometryTypes.WKBCompoundCurve;
+                    break;
+                case "CurvePolygon":
+                    geometryType = WKBGeometryTypes.WKBCurvePolygon;
+                    break;
+                case "MultiCurve":
+                    geometryType = WKBGeometryTypes.WKBMultiCurve;
+                    break;
+                case "MultiSurface":
+                    geometryType = WKBGeometryTypes.WKBMultiSurface;
                     break;
                 default:
                     Assert.ShouldNeverReachHere("Unknown geometry type:" + geom.GeometryType);
@@ -288,14 +304,24 @@ namespace NetTopologySuite.IO
         {
             if (geometry is Point point)
                 Write(point, writer, includeSRID);
+            else if (geometry is CircularString circularString)
+                WriteCircularString(circularString, writer, includeSRID);
+            else if (geometry is CompoundCurve compoundCurve)
+                WriteCompoundCurve(compoundCurve, writer, includeSRID);
             else if (geometry is LineString lineString)
                 Write(lineString, writer, includeSRID);
+            else if (geometry is CurvePolygon curvePolygon)
+                WriteCurvePolygon(curvePolygon, writer, includeSRID);
             else if (geometry is Polygon polygon)
                 Write(polygon, writer, includeSRID);
             else if (geometry is MultiPoint multiPoint)
                 Write(multiPoint, writer, includeSRID);
+            else if (geometry is MultiCurve multiCurve)
+                WriteMultiCurve(multiCurve, writer, includeSRID);
             else if (geometry is MultiLineString multiLineString)
                 Write(multiLineString, writer, includeSRID);
+            else if (geometry is MultiSurface multiSurface)
+                WriteMultiSurface(multiSurface, writer, includeSRID);
             else if (geometry is MultiPolygon multiPolygon)
                 Write(multiPolygon, writer, includeSRID);
             else if (geometry is GeometryCollection geometryCollection)
@@ -611,14 +637,24 @@ namespace NetTopologySuite.IO
         {
             if (geometry is Point point)
                 return new byte[GetRequiredBufferSize(point, includeSRID)];
+            if (geometry is CircularString circularString)
+                return new byte[GetRequiredBufferSizeCurve(circularString, includeSRID)];
+            if (geometry is CompoundCurve compoundCurve)
+                return new byte[GetRequiredBufferSizeCurve(compoundCurve, includeSRID)];
             if (geometry is LineString lineString)
                 return new byte[GetRequiredBufferSize(lineString, includeSRID)];
+            if (geometry is CurvePolygon curvePolygon)
+                return new byte[GetRequiredBufferSizeCurve(curvePolygon, includeSRID)];
             if (geometry is Polygon polygon)
                 return new byte[GetRequiredBufferSize(polygon, includeSRID)];
             if (geometry is MultiPoint multiPoint)
                 return new byte[GetRequiredBufferSize(multiPoint, includeSRID)];
+            if (geometry is MultiCurve multiCurve)
+                return new byte[GetRequiredBufferSize(multiCurve, includeSRID)];
             if (geometry is MultiLineString multiLineString)
                 return new byte[GetRequiredBufferSize(multiLineString, includeSRID)];
+            if (geometry is MultiSurface multiSurface)
+                return new byte[GetRequiredBufferSize(multiSurface, includeSRID)];
             if (geometry is MultiPolygon multiPolygon)
                 return new byte[GetRequiredBufferSize(multiPolygon, includeSRID)];
             if (geometry is GeometryCollection geometryCollection)
@@ -666,14 +702,24 @@ namespace NetTopologySuite.IO
         {
             if (geometry is Point point)
                 return GetRequiredBufferSize(point, includeSRID);
+            if (geometry is CircularString circularString)
+                return GetRequiredBufferSizeCurve(circularString, includeSRID);
+            if (geometry is CompoundCurve compoundCurve)
+                return GetRequiredBufferSizeCurve(compoundCurve, includeSRID);
             if (geometry is LineString lineString)
                 return GetRequiredBufferSize(lineString, includeSRID);
+            if (geometry is CurvePolygon curvePolygon)
+                return GetRequiredBufferSizeCurve(curvePolygon, includeSRID);
             if (geometry is Polygon polygon)
                 return GetRequiredBufferSize(polygon, includeSRID);
             if (geometry is MultiPoint multiPoint)
                 return GetRequiredBufferSize(multiPoint, includeSRID);
+            if (geometry is MultiCurve multiCurve)
+                return GetRequiredBufferSize(multiCurve, includeSRID);
             if (geometry is MultiLineString multiLineString)
                 return GetRequiredBufferSize(multiLineString, includeSRID);
+            if (geometry is MultiSurface multiSurface)
+                return GetRequiredBufferSize(multiSurface, includeSRID);
             if (geometry is MultiPolygon multiPolygon)
                 return GetRequiredBufferSize(multiPolygon, includeSRID);
             if (geometry is GeometryCollection geometryCollection)
@@ -868,6 +914,92 @@ namespace NetTopologySuite.IO
         /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
         /// </param>
         /// <returns>The number of bytes required to store <paramref name="geometry"/> in its WKB format.</returns>
+
+        private void WriteCircularString(CircularString circularString, BinaryWriter writer, bool includeSRID)
+        {
+            WriteHeader(writer, circularString, includeSRID);
+#pragma warning disable 618
+            Write(circularString.CoordinateSequence, true, writer);
+#pragma warning restore 618
+        }
+
+        private void WriteCompoundCurve(CompoundCurve compoundCurve, BinaryWriter writer, bool includeSRID)
+        {
+            WriteHeader(writer, compoundCurve, includeSRID);
+            writer.Write(compoundCurve.IsEmpty ? 0 : compoundCurve.Curves.Count);
+            if (compoundCurve.IsEmpty)
+                return;
+            foreach (var curve in compoundCurve.Curves)
+                Write(curve, writer, curve.SRID != compoundCurve.SRID);
+        }
+
+        private void WriteCurvePolygon(CurvePolygon curvePolygon, BinaryWriter writer, bool includeSRID)
+        {
+            WriteHeader(writer, curvePolygon, includeSRID);
+            if (curvePolygon.IsEmpty)
+            {
+                writer.Write(0);
+                return;
+            }
+            writer.Write(curvePolygon.NumInteriorRings + 1);
+            Write(curvePolygon.ExteriorRing, writer, curvePolygon.ExteriorRing.SRID != curvePolygon.SRID);
+            for (int i = 0; i < curvePolygon.NumInteriorRings; i++)
+            {
+                var hole = curvePolygon.GetInteriorRingN(i);
+                Write(hole, writer, hole.SRID != curvePolygon.SRID);
+            }
+        }
+
+        private void WriteMultiCurve(MultiCurve multiCurve, BinaryWriter writer, bool includeSRID)
+        {
+            WriteHeader(writer, multiCurve, includeSRID);
+            writer.Write(multiCurve.NumGeometries);
+            for (int i = 0; i < multiCurve.NumGeometries; i++)
+            {
+                var curve = multiCurve.GetGeometryN(i);
+                Write(curve, writer, curve.SRID != multiCurve.SRID);
+            }
+        }
+
+        private void WriteMultiSurface(MultiSurface multiSurface, BinaryWriter writer, bool includeSRID)
+        {
+            WriteHeader(writer, multiSurface, includeSRID);
+            writer.Write(multiSurface.NumGeometries);
+            for (int i = 0; i < multiSurface.NumGeometries; i++)
+            {
+                var surface = multiSurface.GetGeometryN(i);
+                Write(surface, writer, surface.SRID != multiSurface.SRID);
+            }
+        }
+
+        private int GetRequiredBufferSizeCurve(CircularString circularString, bool includeSRID)
+        {
+            return GetHeaderSize(includeSRID) + 4 + circularString.NumPoints * _coordinateSize;
+        }
+
+        private int GetRequiredBufferSizeCurve(CompoundCurve compoundCurve, bool includeSRID)
+        {
+            int count = GetHeaderSize(includeSRID) + 4;
+            if (compoundCurve.IsEmpty)
+                return count;
+            foreach (var curve in compoundCurve.Curves)
+                count += GetRequiredBufferSize(curve, curve.SRID != compoundCurve.SRID);
+            return count;
+        }
+
+        private int GetRequiredBufferSizeCurve(CurvePolygon curvePolygon, bool includeSRID)
+        {
+            int count = GetHeaderSize(includeSRID) + 4;
+            if (curvePolygon.IsEmpty)
+                return count;
+            count += GetRequiredBufferSize(curvePolygon.ExteriorRing, curvePolygon.ExteriorRing.SRID != curvePolygon.SRID);
+            for (int i = 0; i < curvePolygon.NumInteriorRings; i++)
+            {
+                var hole = curvePolygon.GetInteriorRingN(i);
+                count += GetRequiredBufferSize(hole, hole.SRID != curvePolygon.SRID);
+            }
+            return count;
+        }
         private int GetRequiredBufferSize(Point geometry, bool includeSRID)
         {
             return GetHeaderSize(includeSRID) + _coordinateSize;

--- a/src/NetTopologySuite/IO/WKBWriter.cs
+++ b/src/NetTopologySuite/IO/WKBWriter.cs
@@ -906,15 +906,14 @@ namespace NetTopologySuite.IO
             => GetRequiredBufferSize(geometry, true);
 
         /// <summary>
-        /// Computes the length of a buffer to write the <see cref="Point"/> <paramref name="geometry"/> in its WKB format.
+        /// Write a CircularString in its WKB format.
         /// </summary>
-        /// <param name="geometry">The geometry</param>
+        /// <param name="circularString">The CircularString</param>
+        /// <param name="writer">The writer</param>
         /// <param name="includeSRID">
         /// A flag indicting if SRID value is of possible interest.
         /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
         /// </param>
-        /// <returns>The number of bytes required to store <paramref name="geometry"/> in its WKB format.</returns>
-
         private void WriteCircularString(CircularString circularString, BinaryWriter writer, bool includeSRID)
         {
             WriteHeader(writer, circularString, includeSRID);
@@ -923,6 +922,15 @@ namespace NetTopologySuite.IO
 #pragma warning restore 618
         }
 
+        /// <summary>
+        /// Write a CompoundCurve in its WKB format.
+        /// </summary>
+        /// <param name="compoundCurve">The CompoundCurve</param>
+        /// <param name="writer">The writer</param>
+        /// <param name="includeSRID">
+        /// A flag indicting if SRID value is of possible interest.
+        /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
+        /// </param>
         private void WriteCompoundCurve(CompoundCurve compoundCurve, BinaryWriter writer, bool includeSRID)
         {
             WriteHeader(writer, compoundCurve, includeSRID);
@@ -933,6 +941,15 @@ namespace NetTopologySuite.IO
                 Write(curve, writer, curve.SRID != compoundCurve.SRID);
         }
 
+        /// <summary>
+        /// Write a CurvePolygon in its WKB format.
+        /// </summary>
+        /// <param name="curvePolygon">The CurvePolygon</param>
+        /// <param name="writer">The writer</param>
+        /// <param name="includeSRID">
+        /// A flag indicting if SRID value is of possible interest.
+        /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
+        /// </param>
         private void WriteCurvePolygon(CurvePolygon curvePolygon, BinaryWriter writer, bool includeSRID)
         {
             WriteHeader(writer, curvePolygon, includeSRID);
@@ -950,6 +967,15 @@ namespace NetTopologySuite.IO
             }
         }
 
+        /// <summary>
+        /// Write a MultiCurve in its WKB format.
+        /// </summary>
+        /// <param name="multiCurve">The MultiCurve</param>
+        /// <param name="writer">The writer</param>
+        /// <param name="includeSRID">
+        /// A flag indicting if SRID value is of possible interest.
+        /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
+        /// </param>
         private void WriteMultiCurve(MultiCurve multiCurve, BinaryWriter writer, bool includeSRID)
         {
             WriteHeader(writer, multiCurve, includeSRID);
@@ -961,6 +987,15 @@ namespace NetTopologySuite.IO
             }
         }
 
+        /// <summary>
+        /// Write a MultiSurface in its WKB format.
+        /// </summary>
+        /// <param name="multiSurface">The MultiSurface</param>
+        /// <param name="writer">The writer</param>
+        /// <param name="includeSRID">
+        /// A flag indicting if SRID value is of possible interest.
+        /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
+        /// </param>
         private void WriteMultiSurface(MultiSurface multiSurface, BinaryWriter writer, bool includeSRID)
         {
             WriteHeader(writer, multiSurface, includeSRID);
@@ -972,11 +1007,31 @@ namespace NetTopologySuite.IO
             }
         }
 
+        /// <summary>
+        /// Computes the length of a buffer to write the <see cref="CircularString"/>
+        /// <paramref name="circularString"/> in its WKB format.
+        /// </summary>
+        /// <param name="circularString">The CircularString</param>
+        /// <param name="includeSRID">
+        /// A flag indicting if SRID value is of possible interest.
+        /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
+        /// </param>
+        /// <returns>The number of bytes required to store the geometry in its WKB format.</returns>
         private int GetRequiredBufferSizeCurve(CircularString circularString, bool includeSRID)
         {
             return GetHeaderSize(includeSRID) + 4 + circularString.NumPoints * _coordinateSize;
         }
 
+        /// <summary>
+        /// Computes the length of a buffer to write the <see cref="CompoundCurve"/>
+        /// <paramref name="compoundCurve"/> in its WKB format.
+        /// </summary>
+        /// <param name="compoundCurve">The CompoundCurve</param>
+        /// <param name="includeSRID">
+        /// A flag indicting if SRID value is of possible interest.
+        /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
+        /// </param>
+        /// <returns>The number of bytes required to store the geometry in its WKB format.</returns>
         private int GetRequiredBufferSizeCurve(CompoundCurve compoundCurve, bool includeSRID)
         {
             int count = GetHeaderSize(includeSRID) + 4;
@@ -987,6 +1042,16 @@ namespace NetTopologySuite.IO
             return count;
         }
 
+        /// <summary>
+        /// Computes the length of a buffer to write the <see cref="CurvePolygon"/>
+        /// <paramref name="curvePolygon"/> in its WKB format.
+        /// </summary>
+        /// <param name="curvePolygon">The CurvePolygon</param>
+        /// <param name="includeSRID">
+        /// A flag indicting if SRID value is of possible interest.
+        /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
+        /// </param>
+        /// <returns>The number of bytes required to store the geometry in its WKB format.</returns>
         private int GetRequiredBufferSizeCurve(CurvePolygon curvePolygon, bool includeSRID)
         {
             int count = GetHeaderSize(includeSRID) + 4;
@@ -1000,6 +1065,16 @@ namespace NetTopologySuite.IO
             }
             return count;
         }
+
+        /// <summary>
+        /// Computes the length of a buffer to write the <see cref="Point"/> <paramref name="geometry"/> in its WKB format.
+        /// </summary>
+        /// <param name="geometry">The geometry</param>
+        /// <param name="includeSRID">
+        /// A flag indicting if SRID value is of possible interest.
+        /// The value is <c>&amp;&amp;</c>-combineed with <c>HandleSRID</c>.
+        /// </param>
+        /// <returns>The number of bytes required to store <paramref name="geometry"/> in its WKB format.</returns>
         private int GetRequiredBufferSize(Point geometry, bool includeSRID)
         {
             return GetHeaderSize(includeSRID) + _coordinateSize;

--- a/src/NetTopologySuite/IO/WKTConstants.cs
+++ b/src/NetTopologySuite/IO/WKTConstants.cs
@@ -54,6 +54,14 @@ namespace NetTopologySuite.IO
         /// </summary>
         public const string CURVEPOLYGON = "CURVEPOLYGON";
         /// <summary>
+        /// Token text for <see cref="Geometries.Curves.MultiCurve"/> geometries (SQL/MM / GEOS)
+        /// </summary>
+        public const string MULTICURVE = "MULTICURVE";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.MultiSurface"/> geometries (SQL/MM / GEOS)
+        /// </summary>
+        public const string MULTISURFACE = "MULTISURFACE";
+        /// <summary>
         /// Token text for <see cref="Geometries.Curves.Triangle"/> geometries
         /// </summary>
         public const string TRIANGLE = "TRIANGLE";

--- a/src/NetTopologySuite/IO/WKTConstants.cs
+++ b/src/NetTopologySuite/IO/WKTConstants.cs
@@ -42,6 +42,27 @@ namespace NetTopologySuite.IO
         public const string POLYGON = "POLYGON";
 
         /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CircularString"/> geometries
+        /// </summary>
+        public const string CIRCULARSTRING = "CIRCULARSTRING";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CompoundCurve"/> geometries
+        /// </summary>
+        public const string COMPOUNDCURVE = "COMPOUNDCURVE";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CurvePolygon"/> geometries
+        /// </summary>
+        public const string CURVEPOLYGON = "CURVEPOLYGON";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.Triangle"/> geometries
+        /// </summary>
+        public const string TRIANGLE = "TRIANGLE";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.Tin"/> geometries
+        /// </summary>
+        public const string TIN = "TIN";
+
+        /// <summary>
         /// Token text for empty geometries
         /// </summary>
         public const string EMPTY = "EMPTY";

--- a/src/NetTopologySuite/IO/WKTReader.cs
+++ b/src/NetTopologySuite/IO/WKTReader.cs
@@ -771,6 +771,10 @@ namespace NetTopologySuite.IO
                 returned = ReadCompoundCurveText(tokens, factory, ordinateFlags);
             else if (IsTypeName(tokens, type, WKTConstants.CURVEPOLYGON))
                 returned = ReadCurvePolygonText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.MULTICURVE))
+                returned = ReadMultiCurveText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.MULTISURFACE))
+                returned = ReadMultiSurfaceText(tokens, factory, ordinateFlags);
             else if (IsTypeName(tokens, type, WKTConstants.TRIANGLE))
                 returned = ReadTriangleText(tokens, factory, ordinateFlags);
             else if (IsTypeName(tokens, type, WKTConstants.TIN))
@@ -1064,6 +1068,13 @@ private Point ReadPointText(TokenStream tokens, GeometryFactory factory, Ordinat
                 return factory.CreateLineString(sequence);
             }
 
+            // GEOS / PostGIS accept tagged LINESTRING inside COMPOUNDCURVE / CURVEPOLYGON
+            if (current.StartsWith(WKTConstants.LINESTRING, StringComparison.OrdinalIgnoreCase))
+            {
+                GetNextWord(tokens);
+                return ReadLineStringText(tokens, factory, ordinateFlags);
+            }
+
             if (current.StartsWith(WKTConstants.CIRCULARSTRING, StringComparison.OrdinalIgnoreCase))
             {
                 GetNextWord(tokens);
@@ -1079,6 +1090,61 @@ private Point ReadPointText(TokenStream tokens, GeometryFactory factory, Ordinat
             }
 
             throw new ParseException("Unexpected token: " + current);
+        }
+
+        /// <summary>
+        /// Creates a <c>MultiCurve</c> (GEOS / SQL/MM) using the next token in the stream.
+        /// </summary>
+        private Geometries.Curves.MultiCurve ReadMultiCurveText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.MultiCurve(null, factory);
+
+            var curves = new List<Curve>();
+            do
+            {
+                curves.Add(ReadCurveText(tokens, factory, ordinateFlags, true));
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            while (nextToken.Equals(","));
+
+            return new Geometries.Curves.MultiCurve(curves.ToArray(), factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>MultiSurface</c> (GEOS / SQL/MM) using the next token in the stream.
+        /// </summary>
+        private Geometries.Curves.MultiSurface ReadMultiSurfaceText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.MultiSurface(null, factory);
+
+            var surfaces = new List<Geometry>();
+            do
+            {
+                string current = LookAheadWord(tokens);
+                if (current.StartsWith(WKTConstants.CURVEPOLYGON, StringComparison.OrdinalIgnoreCase))
+                {
+                    GetNextWord(tokens);
+                    surfaces.Add(ReadCurvePolygonText(tokens, factory, ordinateFlags));
+                }
+                else if (current.StartsWith(WKTConstants.POLYGON, StringComparison.OrdinalIgnoreCase)
+                         || current.Equals(WKTConstants.EMPTY) || current.Equals("("))
+                {
+                    if (current.StartsWith(WKTConstants.POLYGON, StringComparison.OrdinalIgnoreCase))
+                        GetNextWord(tokens);
+                    surfaces.Add(ReadPolygonText(tokens, factory, ordinateFlags));
+                }
+                else
+                    throw new ParseException("Expected POLYGON or CURVEPOLYGON in MULTISURFACE, got: " + current);
+
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            while (nextToken.Equals(","));
+
+            return new Geometries.Curves.MultiSurface(surfaces.ToArray(), factory);
         }
 
         /// <summary>

--- a/src/NetTopologySuite/IO/WKTReader.cs
+++ b/src/NetTopologySuite/IO/WKTReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -765,6 +765,16 @@ namespace NetTopologySuite.IO
                 returned = ReadMultiPolygonText(tokens, factory, ordinateFlags);
             else if (IsTypeName(tokens, type, WKTConstants.GEOMETRYCOLLECTION))
                 returned = ReadGeometryCollectionText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.CIRCULARSTRING))
+                returned = ReadCircularStringText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.COMPOUNDCURVE))
+                returned = ReadCompoundCurveText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.CURVEPOLYGON))
+                returned = ReadCurvePolygonText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.TRIANGLE))
+                returned = ReadTriangleText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.TIN))
+                returned = ReadTinText(tokens, factory, ordinateFlags);
             else throw new ParseException("Unknown type: " + type);
 
             if (returned == null)
@@ -1013,6 +1023,169 @@ private Point ReadPointText(TokenStream tokens, GeometryFactory factory, Ordinat
             while (nextToken.Equals(","));
 
             return factory.CreateGeometryCollection(geometries.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a <c>CircularString</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CircularString Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CircularString</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CircularString ReadCircularStringText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            var sequence = GetCoordinateSequence(factory, tokens, ordinateFlags, 0, false);
+            return new Geometries.Curves.CircularString(sequence, factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Curve</c> using the next token in the stream: either a bare
+        /// coordinate list (a <c>LineString</c>), a tagged <c>CIRCULARSTRING</c>, or -- where
+        /// allowed -- a tagged <c>COMPOUNDCURVE</c>.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a curve component.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <param name="allowCompoundCurve">Whether a <c>COMPOUNDCURVE</c> is allowed at this position</param>
+        /// <returns>A <c>Curve</c> specified by the next token in the stream.</returns>
+        private Curve ReadCurveText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags, bool allowCompoundCurve)
+        {
+            string current = LookAheadWord(tokens);
+
+            if (current.Equals(WKTConstants.EMPTY) || current.Equals("("))
+            {
+                var sequence = GetCoordinateSequence(factory, tokens, ordinateFlags, 0, false);
+                return factory.CreateLineString(sequence);
+            }
+
+            if (current.StartsWith(WKTConstants.CIRCULARSTRING, StringComparison.OrdinalIgnoreCase))
+            {
+                GetNextWord(tokens);
+                return ReadCircularStringText(tokens, factory, ordinateFlags);
+            }
+
+            if (current.StartsWith(WKTConstants.COMPOUNDCURVE, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!allowCompoundCurve)
+                    throw new ParseException("A COMPOUNDCURVE is not allowed as a component of another COMPOUNDCURVE");
+                GetNextWord(tokens);
+                return ReadCompoundCurveText(tokens, factory, ordinateFlags);
+            }
+
+            throw new ParseException("Unexpected token: " + current);
+        }
+
+        /// <summary>
+        /// Creates a <c>CompoundCurve</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CompoundCurve Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CompoundCurve</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CompoundCurve ReadCompoundCurveText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.CompoundCurve(null, factory);
+
+            var curves = new List<Curve>();
+            do
+            {
+                var curve = ReadCurveText(tokens, factory, ordinateFlags, false);
+                curves.Add(curve);
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            while (nextToken.Equals(","));
+
+            return new Geometries.Curves.CompoundCurve(curves.ToArray(), factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>CurvePolygon</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CurvePolygon Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CurvePolygon</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CurvePolygon ReadCurvePolygonText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.CurvePolygon(null, factory);
+
+            var shell = ReadCurveText(tokens, factory, ordinateFlags, true);
+            var holes = new List<Curve>();
+            nextToken = GetNextCloserOrComma(tokens);
+            while (nextToken.Equals(","))
+            {
+                var hole = ReadCurveText(tokens, factory, ordinateFlags, true);
+                holes.Add(hole);
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            return new Geometries.Curves.CurvePolygon(shell, holes.ToArray(), factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Triangle</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a Triangle Text (a Polygon Text without holes).
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>Triangle</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.Triangle ReadTriangleText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            var polygon = ReadPolygonText(tokens, factory, ordinateFlags);
+            if (polygon.IsEmpty)
+                return new Geometries.Curves.Triangle(null, factory);
+            if (polygon.NumInteriorRings != 0)
+                throw new ParseException("A TRIANGLE must not contain interior rings");
+            return new Geometries.Curves.Triangle((LinearRing)polygon.ExteriorRing, factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Tin</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a Tin Text (a MultiPolygon Text whose
+        ///   elements are hole-free triangles).
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>Tin</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.Tin ReadTinText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.Tin(null, factory);
+
+            var triangles = new List<Geometries.Curves.Triangle>();
+            do
+            {
+                var polygon = ReadPolygonText(tokens, factory, ordinateFlags);
+                if (polygon.NumInteriorRings != 0)
+                    throw new ParseException("A TRIANGLE within a TIN must not contain interior rings");
+                triangles.Add(new Geometries.Curves.Triangle((LinearRing)polygon.ExteriorRing, factory));
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            while (nextToken.Equals(","));
+
+            return new Geometries.Curves.Tin(triangles.ToArray(), factory);
         }
     }
 }

--- a/src/NetTopologySuite/IO/WKTWriter.cs
+++ b/src/NetTopologySuite/IO/WKTWriter.cs
@@ -546,9 +546,17 @@ namespace NetTopologySuite.IO
                     AppendTriangleTaggedText(triangle, outputOrdinates, useFormatting, level, writer, ordinateFormat);
                     break;
 
-                // NB: Tin extends GeometryCollection, so this case must come first.
+                // NB: Tin / MultiCurve / MultiSurface extend GeometryCollection — must come first.
                 case Geometries.Curves.Tin tin:
                     AppendTinTaggedText(tin, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.MultiCurve multiCurve:
+                    AppendMultiCurveTaggedText(multiCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.MultiSurface multiSurface:
+                    AppendMultiSurfaceTaggedText(multiSurface, outputOrdinates, useFormatting, level, writer, ordinateFormat);
                     break;
 
                 case GeometryCollection geometryCollection:
@@ -1122,6 +1130,48 @@ namespace NetTopologySuite.IO
                     AppendSequenceText(((LineString)ring).CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
                     break;
             }
+        }
+
+        /// <summary>
+        /// Converts a <c>MultiCurve</c> to MultiCurve Tagged Text (GEOS / SQL/MM).
+        /// </summary>
+        private void AppendMultiCurveTaggedText(Geometries.Curves.MultiCurve multiCurve, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.MULTICURVE} ");
+            AppendOrdinateText(outputOrdinates, writer);
+            if (multiCurve.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+            writer.Write("(");
+            for (int i = 0; i < multiCurve.NumGeometries; i++)
+            {
+                if (i > 0) writer.Write(", ");
+                AppendGeometryTaggedText(multiCurve.GetGeometryN(i), outputOrdinates, useFormatting, level + 1, writer, ordinateFormat);
+            }
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a <c>MultiSurface</c> to MultiSurface Tagged Text (GEOS / SQL/MM).
+        /// </summary>
+        private void AppendMultiSurfaceTaggedText(Geometries.Curves.MultiSurface multiSurface, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.MULTISURFACE} ");
+            AppendOrdinateText(outputOrdinates, writer);
+            if (multiSurface.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+            writer.Write("(");
+            for (int i = 0; i < multiSurface.NumGeometries; i++)
+            {
+                if (i > 0) writer.Write(", ");
+                AppendGeometryTaggedText(multiSurface.GetGeometryN(i), outputOrdinates, useFormatting, level + 1, writer, ordinateFormat);
+            }
+            writer.Write(")");
         }
 
         /// <summary>

--- a/src/NetTopologySuite/IO/WKTWriter.cs
+++ b/src/NetTopologySuite/IO/WKTWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -530,6 +530,27 @@ namespace NetTopologySuite.IO
                     AppendMultiPolygonTaggedText(multiPolygon, outputOrdinates, useFormatting, level, writer, ordinateFormat);
                     break;
 
+                case Geometries.Curves.CircularString circularString:
+                    AppendCircularStringTaggedText(circularString, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CompoundCurve compoundCurve:
+                    AppendCompoundCurveTaggedText(compoundCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CurvePolygon curvePolygon:
+                    AppendCurvePolygonTaggedText(curvePolygon, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.Triangle triangle:
+                    AppendTriangleTaggedText(triangle, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                // NB: Tin extends GeometryCollection, so this case must come first.
+                case Geometries.Curves.Tin tin:
+                    AppendTinTaggedText(tin, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
                 case GeometryCollection geometryCollection:
                     AppendGeometryCollectionTaggedText(geometryCollection, outputOrdinates, useFormatting, level, writer, ordinateFormat);
                     break;
@@ -967,6 +988,220 @@ namespace NetTopologySuite.IO
                 }
                 writer.Write(")");
             }
+        }
+
+        /// <summary>
+        /// Converts a <c>CircularString</c> to CircularString Tagged Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="circularString">The <c>CircularString</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCircularStringTaggedText(Geometries.Curves.CircularString circularString, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>CompoundCurve</c> to CompoundCurve Tagged Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="compoundCurve">The <c>CompoundCurve</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCompoundCurveTaggedText(Geometries.Curves.CompoundCurve compoundCurve, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.COMPOUNDCURVE} ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendCompoundCurveText(compoundCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>CompoundCurve</c> to CompoundCurve Text format, then appends
+        /// it to the writer. <c>LineString</c> components are written as bare
+        /// coordinate lists, <c>CircularString</c> components with their tag.
+        /// </summary>
+        /// <param name="compoundCurve">The <c>CompoundCurve</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCompoundCurveText(Geometries.Curves.CompoundCurve compoundCurve, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (compoundCurve.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            writer.Write("(");
+            for (int i = 0; i < compoundCurve.Curves.Count; i++)
+            {
+                if (i > 0) writer.Write(", ");
+                var component = compoundCurve.Curves[i];
+                if (component is Geometries.Curves.CircularString circularString)
+                {
+                    writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+                    AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                }
+                else
+                {
+                    AppendSequenceText(((LineString)component).CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                }
+            }
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a <c>CurvePolygon</c> to CurvePolygon Tagged Text format, then
+        /// appends it to the writer. <c>LineString</c> rings are written as bare
+        /// coordinate lists, <c>CircularString</c> and <c>CompoundCurve</c> rings
+        /// with their tags.
+        /// </summary>
+        /// <param name="curvePolygon">The <c>CurvePolygon</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCurvePolygonTaggedText(Geometries.Curves.CurvePolygon curvePolygon, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.CURVEPOLYGON} ");
+            AppendOrdinateText(outputOrdinates, writer);
+
+            if (curvePolygon.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            writer.Write("(");
+            AppendCurveRingText(curvePolygon.ExteriorRing, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+            for (int i = 0; i < curvePolygon.NumInteriorRings; i++)
+            {
+                writer.Write(", ");
+                AppendCurveRingText(curvePolygon.GetInteriorRingN(i), outputOrdinates, useFormatting, level + 1, writer, ordinateFormat);
+            }
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a single ring of a <c>CurvePolygon</c> to Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="ring">The ring to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCurveRingText(Curve ring, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            switch (ring)
+            {
+                case Geometries.Curves.CircularString circularString:
+                    writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+                    AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CompoundCurve compoundCurve:
+                    writer.Write($"{WKTConstants.COMPOUNDCURVE} ");
+                    AppendCompoundCurveText(compoundCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                default:
+                    AppendSequenceText(((LineString)ring).CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>Triangle</c> to Triangle Tagged Text format, then appends it
+        /// to the writer.
+        /// </summary>
+        /// <param name="triangle">The <c>Triangle</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTriangleTaggedText(Geometries.Curves.Triangle triangle, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.TRIANGLE} ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendTriangleText(triangle, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>Triangle</c> to Triangle Text format (a Polygon Text without
+        /// holes), then appends it to the writer.
+        /// </summary>
+        /// <param name="triangle">The <c>Triangle</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="indentFirst">flag indicating that the first <see cref="Coordinate"/> of the sequence should be indented for better visibility.</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTriangleText(Geometries.Curves.Triangle triangle, Ordinates outputOrdinates, bool useFormatting, int level, bool indentFirst, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (triangle.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            if (indentFirst) Indent(useFormatting, level, writer);
+            writer.Write("(");
+            AppendSequenceText(triangle.ExteriorRing.CoordinateSequence, outputOrdinates,
+                useFormatting, level, false, writer, ordinateFormat);
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a <c>Tin</c> to Tin Tagged Text format, then appends it to the
+        /// writer.
+        /// </summary>
+        /// <param name="tin">The <c>Tin</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTinTaggedText(Geometries.Curves.Tin tin, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.TIN} ");
+            AppendOrdinateText(outputOrdinates, writer);
+
+            if (tin.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            int level2 = level;
+            bool doIndent = false;
+            writer.Write("(");
+            for (int i = 0; i < tin.NumGeometries; i++)
+            {
+                if (i > 0)
+                {
+                    writer.Write(", ");
+                    level2 = level + 1;
+                    doIndent = true;
+                }
+                AppendTriangleText((Geometries.Curves.Triangle)tin.GetGeometryN(i), outputOrdinates, useFormatting, level2, doIndent, writer, ordinateFormat);
+            }
+            writer.Write(")");
         }
 
         private void IndentCoords(bool useFormatting, int coordIndex, int level, TextWriter writer)

--- a/src/NetTopologySuite/Operation/Distance/DistanceOp.cs
+++ b/src/NetTopologySuite/Operation/Distance/DistanceOp.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
 using NetTopologySuite.Geometries.Utilities;
 
 namespace NetTopologySuite.Operation.Distance
@@ -94,6 +95,8 @@ namespace NetTopologySuite.Operation.Distance
         /// <param name="terminateDistance">The distance on which to terminate the search.</param>
         public DistanceOp(Geometry g0, Geometry g1, double terminateDistance)
         {
+            CurvedGeometry.CheckNotCurved(g0, "Distance");
+            CurvedGeometry.CheckNotCurved(g1, "Distance");
             _geom = new[] { g0, g1 };
             _terminateDistance = terminateDistance;
         }

--- a/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
+++ b/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
 using NetTopologySuite.Geometries.Utilities;
 using NetTopologySuite.Noding;
 
@@ -160,6 +161,8 @@ namespace NetTopologySuite.Operation.Valid
         private bool ComputeSimple(Geometry geom)
         {
             if (geom.IsEmpty) return true;
+            if (CurvedGeometry.IsCurvedType(geom))
+                throw CurvedGeometry.NotYetSupported(geom, "IsSimple");
             switch (geom)
             {
                 case Point _:
@@ -273,10 +276,7 @@ namespace NetTopologySuite.Operation.Valid
             var segStrings = new List<ISegmentString>();
             for (int i = 0; i < geom.NumGeometries; i++)
             {
-                // Use Geometry (not LineString) so ILineal curve types such as
-                // CircularString / CompoundCurve can use the chord-based path
-                // without an InvalidCastException.
-                var line = geom.GetGeometryN(i);
+                var line = (LineString)geom.GetGeometryN(i);
                 var trimPts = TrimRepeatedPoints(line.Coordinates);
                 if (trimPts != null)
                 {

--- a/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
+++ b/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
@@ -273,7 +273,10 @@ namespace NetTopologySuite.Operation.Valid
             var segStrings = new List<ISegmentString>();
             for (int i = 0; i < geom.NumGeometries; i++)
             {
-                var line = (LineString)geom.GetGeometryN(i);
+                // Use Geometry (not LineString) so ILineal curve types such as
+                // CircularString / CompoundCurve can use the chord-based path
+                // without an InvalidCastException.
+                var line = geom.GetGeometryN(i);
                 var trimPts = TrimRepeatedPoints(line.Coordinates);
                 if (trimPts != null)
                 {

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularStringTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularStringTest.cs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Opus-4.7)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class CircularStringTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Make(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            var seq = _factory.CoordinateSequenceFactory.Create(coords);
+            return new CircularString(seq, _factory);
+        }
+
+        [Test]
+        public void EmptyCircularStringHasZeroPoints()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.IsEmpty, Is.True);
+            Assert.That(cs.NumPoints, Is.EqualTo(0));
+            Assert.That(cs.NumArcs, Is.EqualTo(0));
+            Assert.That(cs.IsClosed, Is.False);
+        }
+
+        [Test]
+        public void SingleArcHasThreePoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            Assert.That(cs.NumPoints, Is.EqualTo(3));
+            Assert.That(cs.NumArcs, Is.EqualTo(1));
+            Assert.That(cs.IsEmpty, Is.False);
+            Assert.That(cs.GeometryType, Is.EqualTo("CircularString"));
+            Assert.That(cs.OgcGeometryType, Is.EqualTo(OgcGeometryType.CircularString));
+        }
+
+        [Test]
+        public void TwoArcsHaveFivePoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0), (0, -1), (1, 0));
+            Assert.That(cs.NumPoints, Is.EqualTo(5));
+            Assert.That(cs.NumArcs, Is.EqualTo(2));
+            // The endpoint equals the startpoint, so it's closed.
+            Assert.That(cs.IsClosed, Is.True);
+        }
+
+        [Test]
+        public void NonEmptyMustHaveAtLeastThreePoints()
+        {
+            var seq = _factory.CoordinateSequenceFactory.Create(new[] {
+                new Coordinate(0, 0), new Coordinate(1, 1)
+            });
+            Assert.Throws<ArgumentException>(() => new CircularString(seq, _factory));
+        }
+
+        [Test]
+        public void PointCountMustBeOdd()
+        {
+            var seq = _factory.CoordinateSequenceFactory.Create(new[] {
+                new Coordinate(0, 0), new Coordinate(1, 1),
+                new Coordinate(2, 0), new Coordinate(3, 1)
+            });
+            Assert.Throws<ArgumentException>(() => new CircularString(seq, _factory));
+        }
+
+        [Test]
+        public void StartAndEndPointsAreFirstAndLast()
+        {
+            var cs = Make((1, 2), (3, 4), (5, 6));
+            Assert.That(cs.StartPoint.X, Is.EqualTo(1));
+            Assert.That(cs.StartPoint.Y, Is.EqualTo(2));
+            Assert.That(cs.EndPoint.X, Is.EqualTo(5));
+            Assert.That(cs.EndPoint.Y, Is.EqualTo(6));
+        }
+
+        [Test]
+        public void EnvelopeEnclosesAllControlPoints()
+        {
+            var cs = Make((0, 0), (5, 10), (10, 0));
+            var env = cs.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(10));
+            Assert.That(env.MinY, Is.EqualTo(0));
+            Assert.That(env.MaxY, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void CopyProducesEqualButDistinctObject()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var copy = (CircularString)cs.Copy();
+            Assert.That(copy.EqualsExact(cs), Is.True);
+            Assert.That(ReferenceEquals(copy, cs), Is.False);
+        }
+
+        [Test]
+        public void ReverseFlipsCoordinateOrder()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var rev = (CircularString)cs.Reverse();
+            Assert.That(rev.StartPoint.X, Is.EqualTo(-1));
+            Assert.That(rev.EndPoint.X, Is.EqualTo(1));
+            // Double reverse is identity.
+            var revrev = (CircularString)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cs), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCircularStringFromLineString()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var ls = _factory.CreateLineString(cs.Coordinates);
+            Assert.That(cs.EqualsExact(ls), Is.False,
+                "CircularString and LineString with the same coordinates should not be EqualsExact.");
+        }
+
+        [Test]
+        public void EmptyStartAndEndPointsAreNullLikeLineString()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.StartPoint, Is.Null);
+            Assert.That(cs.EndPoint, Is.Null);
+        }
+
+        [Test]
+        public void OpenBoundaryIsEndpoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var boundary = cs.Boundary;
+            Assert.That(boundary.NumGeometries, Is.EqualTo(2));
+            Assert.That(boundary.GetGeometryN(0).Coordinate, Is.EqualTo(new Coordinate(1, 0)));
+            Assert.That(boundary.GetGeometryN(1).Coordinate, Is.EqualTo(new Coordinate(-1, 0)));
+        }
+
+        [Test]
+        public void ClosedBoundaryIsEmpty()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0), (0, -1), (1, 0));
+            Assert.That(cs.IsClosed, Is.True);
+            Assert.That(cs.Boundary.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void EmptyBoundaryIsEmpty()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.Boundary.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void IsSimpleAndIsRingDoNotThrow()
+        {
+            var open = Make((1, 0), (0, 1), (-1, 0));
+            Assert.That(() => open.IsSimple, Throws.Nothing);
+            Assert.That(() => open.IsRing, Throws.Nothing);
+            Assert.That(open.IsSimple, Is.True);
+            Assert.That(open.IsRing, Is.False);
+
+            var closed = Make((1, 0), (0, 1), (-1, 0), (0, -1), (1, 0));
+            Assert.That(() => closed.IsSimple, Throws.Nothing);
+            Assert.That(() => closed.IsRing, Throws.Nothing);
+            Assert.That(closed.IsSimple, Is.True);
+            Assert.That(closed.IsRing, Is.True);
+        }
+
+        [Test]
+        public void LinearizeReturnsLineStringThroughControlPoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            ILinearizable<LineString> linearizable = cs;
+            var line = linearizable.Linearize();
+
+            Assert.That(line, Is.InstanceOf<LineString>());
+            Assert.That(line, Is.Not.InstanceOf<CircularString>());
+            Assert.That(line.NumPoints, Is.EqualTo(3));
+            Assert.That(line.Coordinates, Is.EqualTo(cs.Coordinates));
+            Assert.That(cs.Linearize(1.0).NumPoints, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void LinearizeEmptyReturnsEmptyLineString()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.Linearize().IsEmpty, Is.True);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularStringTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularStringTest.cs
@@ -81,14 +81,24 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
         }
 
         [Test]
-        public void EnvelopeEnclosesAllControlPoints()
+        public void EnvelopeFailsClosedUntilArcAware()
         {
             var cs = Make((0, 0), (5, 10), (10, 0));
-            var env = cs.EnvelopeInternal;
-            Assert.That(env.MinX, Is.EqualTo(0));
-            Assert.That(env.MaxX, Is.EqualTo(10));
-            Assert.That(env.MinY, Is.EqualTo(0));
-            Assert.That(env.MaxY, Is.EqualTo(10));
+            Assert.That(() => cs.EnvelopeInternal, Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void LengthFailsClosed()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            Assert.That(() => cs.Length, Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void EmptyLengthIsZero()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.Length, Is.EqualTo(0d));
         }
 
         [Test]
@@ -155,19 +165,15 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
         }
 
         [Test]
-        public void IsSimpleAndIsRingDoNotThrow()
+        public void IsSimpleAndIsRingFailClosed()
         {
             var open = Make((1, 0), (0, 1), (-1, 0));
-            Assert.That(() => open.IsSimple, Throws.Nothing);
-            Assert.That(() => open.IsRing, Throws.Nothing);
-            Assert.That(open.IsSimple, Is.True);
-            Assert.That(open.IsRing, Is.False);
+            Assert.That(() => open.IsSimple, Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => open.IsRing, Throws.TypeOf<NotSupportedException>());
 
             var closed = Make((1, 0), (0, 1), (-1, 0), (0, -1), (1, 0));
-            Assert.That(() => closed.IsSimple, Throws.Nothing);
-            Assert.That(() => closed.IsRing, Throws.Nothing);
-            Assert.That(closed.IsSimple, Is.True);
-            Assert.That(closed.IsRing, Is.True);
+            Assert.That(() => closed.IsSimple, Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => closed.IsRing, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]
@@ -181,7 +187,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
             Assert.That(line, Is.Not.InstanceOf<CircularString>());
             Assert.That(line.NumPoints, Is.EqualTo(3));
             Assert.That(line.Coordinates, Is.EqualTo(cs.Coordinates));
-            Assert.That(cs.Linearize(1.0).NumPoints, Is.EqualTo(3));
+            Assert.That(() => cs.Linearize(1.0), Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CompoundCurveTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CompoundCurveTest.cs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class CompoundCurveTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Arc(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private LineString Line(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLineString(coords);
+        }
+
+        [Test]
+        public void EmptyCompoundCurveHasZeroPoints()
+        {
+            var cc = new CompoundCurve(null, _factory);
+            Assert.That(cc.IsEmpty, Is.True);
+            Assert.That(cc.NumPoints, Is.EqualTo(0));
+            Assert.That(cc.Curves.Count, Is.EqualTo(0));
+            Assert.That(cc.IsClosed, Is.False);
+            Assert.That(cc.GeometryType, Is.EqualTo("CompoundCurve"));
+            Assert.That(cc.OgcGeometryType, Is.EqualTo(OgcGeometryType.CompoundCurve));
+        }
+
+        [Test]
+        public void LineArcLineSharesJoinPoints()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)), Line((3, 0), (4, 0)) },
+                _factory);
+
+            Assert.That(cc.Curves.Count, Is.EqualTo(3));
+            // 2 + 3 + 2 control points, with the two join points emitted once.
+            Assert.That(cc.NumPoints, Is.EqualTo(5));
+            Assert.That(cc.Coordinates.Length, Is.EqualTo(5));
+            Assert.That(cc.StartPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+            Assert.That(cc.EndPoint.Coordinate, Is.EqualTo(new Coordinate(4, 0)));
+            Assert.That(cc.IsClosed, Is.False);
+        }
+
+        [Test]
+        public void MembersRetainSubtypes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+
+            Assert.That(cc.Curves[0], Is.InstanceOf<CircularString>());
+            Assert.That(cc.Curves[1], Is.InstanceOf<LineString>());
+        }
+
+        [Test]
+        public void ClosedCompoundCurveIsClosedAndHasEmptyBoundary()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (0, 0)) },
+                _factory);
+
+            Assert.That(cc.IsClosed, Is.True);
+            Assert.That(cc.Boundary.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void OpenCompoundCurveBoundaryIsEndpoints()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) },
+                _factory);
+
+            var boundary = cc.Boundary;
+            Assert.That(boundary.NumGeometries, Is.EqualTo(2));
+            Assert.That(boundary.GetGeometryN(0).Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+            Assert.That(boundary.GetGeometryN(1).Coordinate, Is.EqualTo(new Coordinate(3, 0)));
+        }
+
+        [Test]
+        public void LengthIsSumOfComponentLengths()
+        {
+            var line = Line((0, 0), (1, 0));
+            var arc = Arc((1, 0), (2, 1), (3, 0));
+            var cc = new CompoundCurve(new Curve[] { line, arc }, _factory);
+
+            Assert.That(cc.Length, Is.EqualTo(line.Length + arc.Length).Within(1e-12));
+        }
+
+        [Test]
+        public void EnvelopeIsUnionOfComponentEnvelopes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 5), (3, 0)) },
+                _factory);
+
+            var env = cc.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(3));
+            Assert.That(env.MinY, Is.EqualTo(0));
+            Assert.That(env.MaxY, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void RejectsNullComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { null }, _factory));
+        }
+
+        [Test]
+        public void RejectsEmptyComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { _factory.CreateLineString() }, _factory));
+        }
+
+        [Test]
+        public void RejectsNonContiguousComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(
+                    new Curve[] { Line((0, 0), (1, 0)), Line((2, 0), (3, 0)) },
+                    _factory));
+        }
+
+        [Test]
+        public void RejectsNestedCompoundCurves()
+        {
+            var inner = new CompoundCurve(new Curve[] { Line((0, 0), (1, 0)) }, _factory);
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { inner }, _factory));
+        }
+
+        [Test]
+        public void EmptyStartAndEndPointsAreNullLikeLineString()
+        {
+            var cc = new CompoundCurve(null, _factory);
+            Assert.That(cc.StartPoint, Is.Null);
+            Assert.That(cc.EndPoint, Is.Null);
+        }
+
+        [Test]
+        public void NormalizeDoesNotMutateCallerComponentArray()
+        {
+            var components = new Curve[]
+            {
+                Line((4, 0), (3, 0)),
+                Arc((3, 0), (2, 1), (1, 0))
+            };
+            var originalFirstStart = components[0].StartPoint.Coordinate.Copy();
+
+            var cc = new CompoundCurve(components, _factory);
+            cc.Normalize();
+
+            Assert.That(components[0].StartPoint.Coordinate, Is.EqualTo(originalFirstStart),
+                "Normalize must not reverse the caller's component array in place.");
+            Assert.That(cc.StartPoint.Coordinate.CompareTo(cc.EndPoint.Coordinate) <= 0);
+        }
+
+        [Test]
+        public void IsSimpleAndIsRingDoNotThrow()
+        {
+            var open = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) },
+                _factory);
+            Assert.That(() => open.IsSimple, Throws.Nothing);
+            Assert.That(() => open.IsRing, Throws.Nothing);
+            Assert.That(open.IsRing, Is.False);
+
+            var closed = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (0, 0)) },
+                _factory);
+            Assert.That(() => closed.IsSimple, Throws.Nothing);
+            Assert.That(() => closed.IsRing, Throws.Nothing);
+            Assert.That(closed.IsClosed, Is.True);
+        }
+
+        [Test]
+        public void CopyProducesEqualButDistinctObjectAndPreservesSubtypes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+            var copy = (CompoundCurve)cc.Copy();
+
+            Assert.That(copy.EqualsExact(cc), Is.True);
+            Assert.That(ReferenceEquals(copy, cc), Is.False);
+            Assert.That(copy.Curves[0], Is.InstanceOf<CircularString>());
+            Assert.That(ReferenceEquals(copy.Curves[0], cc.Curves[0]), Is.False);
+        }
+
+        [Test]
+        public void ReverseFlipsComponentOrderAndDirection()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+            var rev = (CompoundCurve)cc.Reverse();
+
+            Assert.That(rev.Curves[0], Is.InstanceOf<LineString>());
+            Assert.That(rev.Curves[1], Is.InstanceOf<CircularString>());
+            Assert.That(rev.StartPoint.Coordinate, Is.EqualTo(new Coordinate(3, 0)));
+            Assert.That(rev.EndPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+
+            // Double reverse is identity.
+            var revrev = (CompoundCurve)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cc), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCompoundCurveFromLineString()
+        {
+            var cc = new CompoundCurve(new Curve[] { Line((0, 0), (1, 0), (2, 0)) }, _factory);
+            var ls = Line((0, 0), (1, 0), (2, 0));
+            Assert.That(cc.EqualsExact(ls), Is.False,
+                "CompoundCurve and LineString with the same coordinates should not be EqualsExact.");
+        }
+
+        [Test]
+        public void LinearizeReturnsLineStringCollapsingJoinPoints()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)), Line((3, 0), (4, 0)) },
+                _factory);
+            ILinearizable<LineString> linearizable = cc;
+            var line = linearizable.Linearize();
+
+            Assert.That(line, Is.InstanceOf<LineString>());
+            Assert.That(line, Is.Not.InstanceOf<CompoundCurve>());
+            Assert.That(line.NumPoints, Is.EqualTo(5));
+            Assert.That(line.StartPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+            Assert.That(line.EndPoint.Coordinate, Is.EqualTo(new Coordinate(4, 0)));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CompoundCurveTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CompoundCurveTest.cs
@@ -90,27 +90,26 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
         }
 
         [Test]
-        public void LengthIsSumOfComponentLengths()
+        public void LengthFailsClosed()
         {
             var line = Line((0, 0), (1, 0));
             var arc = Arc((1, 0), (2, 1), (3, 0));
-            var cc = new CompoundCurve(new Curve[] { line, arc }, _factory);
+            var mixed = new CompoundCurve(new Curve[] { line, arc }, _factory);
+            Assert.That(() => mixed.Length, Throws.TypeOf<NotSupportedException>());
 
-            Assert.That(cc.Length, Is.EqualTo(line.Length + arc.Length).Within(1e-12));
+            var allLinear = new CompoundCurve(new Curve[] { Line((0, 0), (1, 0)), Line((1, 0), (2, 0)) }, _factory);
+            Assert.That(() => allLinear.Length, Throws.TypeOf<NotSupportedException>(),
+                "Unconditional cut: all-LineString CompoundCurve still throws.");
         }
 
         [Test]
-        public void EnvelopeIsUnionOfComponentEnvelopes()
+        public void EnvelopeFailsClosedUntilArcAware()
         {
             var cc = new CompoundCurve(
                 new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 5), (3, 0)) },
                 _factory);
 
-            var env = cc.EnvelopeInternal;
-            Assert.That(env.MinX, Is.EqualTo(0));
-            Assert.That(env.MaxX, Is.EqualTo(3));
-            Assert.That(env.MinY, Is.EqualTo(0));
-            Assert.That(env.MaxY, Is.EqualTo(5));
+            Assert.That(() => cc.EnvelopeInternal, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]
@@ -171,20 +170,19 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
         }
 
         [Test]
-        public void IsSimpleAndIsRingDoNotThrow()
+        public void IsSimpleAndIsRingFailClosed()
         {
             var open = new CompoundCurve(
                 new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) },
                 _factory);
-            Assert.That(() => open.IsSimple, Throws.Nothing);
-            Assert.That(() => open.IsRing, Throws.Nothing);
-            Assert.That(open.IsRing, Is.False);
+            Assert.That(() => open.IsSimple, Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => open.IsRing, Throws.TypeOf<NotSupportedException>());
 
             var closed = new CompoundCurve(
                 new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (0, 0)) },
                 _factory);
-            Assert.That(() => closed.IsSimple, Throws.Nothing);
-            Assert.That(() => closed.IsRing, Throws.Nothing);
+            Assert.That(() => closed.IsSimple, Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => closed.IsRing, Throws.TypeOf<NotSupportedException>());
             Assert.That(closed.IsClosed, Is.True);
         }
 
@@ -243,6 +241,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
             Assert.That(line.NumPoints, Is.EqualTo(5));
             Assert.That(line.StartPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
             Assert.That(line.EndPoint.Coordinate, Is.EqualTo(new Coordinate(4, 0)));
+            Assert.That(() => cc.Linearize(1.0), Throws.TypeOf<NotSupportedException>());
         }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveCompareToTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveCompareToTest.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+// The OGC Triangle geometry, not the coordinate utility class.
+using Triangle = NetTopologySuite.Geometries.Curves.Triangle;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// Mixed-type <see cref="Geometry.CompareTo(Geometry)"/> must order by
+    /// dedicated sort indices and never enter a wrong CompareToSameClass cast.
+    /// </summary>
+    public class CurveCompareToTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Arc(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private LineString Line(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLineString(coords);
+        }
+
+        private LinearRing Ring(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLinearRing(coords);
+        }
+
+        [Test]
+        public void CircularStringCompareToLineStringDoesNotThrow()
+        {
+            var circularString = Arc((0, 0), (1, 1), (2, 0));
+            var lineString = Line((0, 0), (1, 1), (2, 0));
+
+            Assert.That(() => circularString.CompareTo(lineString), Throws.Nothing);
+            Assert.That(() => lineString.CompareTo(circularString), Throws.Nothing);
+            Assert.That(circularString.CompareTo(lineString), Is.Not.EqualTo(0));
+            Assert.That(circularString.CompareTo(lineString),
+                Is.EqualTo(-lineString.CompareTo(circularString)));
+        }
+
+        [Test]
+        public void CompoundCurveCompareToLineStringDoesNotThrow()
+        {
+            var compoundCurve = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) },
+                _factory);
+            var lineString = Line((0, 0), (1, 0), (2, 1), (3, 0));
+
+            Assert.That(() => compoundCurve.CompareTo(lineString), Throws.Nothing);
+            Assert.That(() => lineString.CompareTo(compoundCurve), Throws.Nothing);
+            Assert.That(compoundCurve.CompareTo(lineString), Is.Not.EqualTo(0));
+        }
+
+        [Test]
+        public void CurvePolygonCompareToPolygonDoesNotThrow()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            var curvePolygon = new CurvePolygon(shell, _factory);
+            var polygon = _factory.CreatePolygon(shell);
+
+            Assert.That(() => curvePolygon.CompareTo(polygon), Throws.Nothing);
+            Assert.That(() => polygon.CompareTo(curvePolygon), Throws.Nothing);
+            Assert.That(curvePolygon.CompareTo(polygon), Is.Not.EqualTo(0));
+            Assert.That(curvePolygon.CompareTo(polygon),
+                Is.EqualTo(-polygon.CompareTo(curvePolygon)));
+        }
+
+        [Test]
+        public void TriangleCompareToPolygonDoesNotThrow()
+        {
+            var shell = Ring((0, 0), (1, 0), (0, 1), (0, 0));
+            var triangle = new Triangle(shell, _factory);
+            var polygon = _factory.CreatePolygon(shell);
+
+            Assert.That(() => triangle.CompareTo(polygon), Throws.Nothing);
+            Assert.That(() => polygon.CompareTo(triangle), Throws.Nothing);
+            Assert.That(triangle.CompareTo(polygon), Is.Not.EqualTo(0));
+        }
+
+        [Test]
+        public void TinCompareToMultiPolygonDoesNotThrow()
+        {
+            var t1 = new Triangle(Ring((0, 0), (1, 0), (0, 1), (0, 0)), _factory);
+            var t2 = new Triangle(Ring((1, 0), (1, 1), (0, 1), (1, 0)), _factory);
+            var tin = new Tin(new[] { t1, t2 }, _factory);
+            var multiPolygon = _factory.CreateMultiPolygon(new[]
+            {
+                _factory.CreatePolygon(Ring((0, 0), (1, 0), (0, 1), (0, 0))),
+                _factory.CreatePolygon(Ring((1, 0), (1, 1), (0, 1), (1, 0)))
+            });
+
+            Assert.That(() => tin.CompareTo(multiPolygon), Throws.Nothing);
+            Assert.That(() => multiPolygon.CompareTo(tin), Throws.Nothing);
+            Assert.That(tin.CompareTo(multiPolygon), Is.Not.EqualTo(0));
+        }
+
+        [Test]
+        public void ArraySortOfMixedLinearAndCurveTypesDoesNotThrow()
+        {
+            Geometry[] geometries =
+            {
+                Line((0, 0), (1, 0)),
+                Arc((0, 0), (1, 1), (2, 0)),
+                new CompoundCurve(new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) }, _factory),
+                _factory.CreatePolygon(Ring((0, 0), (1, 0), (1, 1), (0, 1), (0, 0))),
+                new CurvePolygon(Arc((0, 0), (2, 2), (4, 0), (2, -2), (0, 0)), _factory),
+                new Triangle(Ring((0, 0), (1, 0), (0, 1), (0, 0)), _factory)
+            };
+
+            Assert.That(() => Array.Sort(geometries), Throws.Nothing);
+
+            // Sorted order must be stable under a second pass and anti-symmetric.
+            for (int i = 0; i < geometries.Length - 1; i++)
+            {
+                Assert.That(geometries[i].CompareTo(geometries[i + 1]), Is.LessThanOrEqualTo(0));
+            }
+        }
+
+        [Test]
+        public void SameTypeCompareToUsesStructuralOrderNotOnlySortIndex()
+        {
+            var a = Arc((0, 0), (1, 1), (2, 0));
+            var b = Arc((0, 0), (1, 2), (2, 0));
+            Assert.That(a.CompareTo(b), Is.Not.EqualTo(0));
+            Assert.That(a.CompareTo(a.Copy()), Is.EqualTo(0));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveFailClosedTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveFailClosedTest.cs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Fail-closed contract for curve metrics/analytics. Assisted-by: xAI Grok
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.Operation.Distance;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// Pins the fail-closed contract: metric and analytic members on the five
+    /// SQL/MM curve types throw <see cref="NotSupportedException"/> until
+    /// arc-aware implementations land. Empty geometries keep trivial exact
+    /// values; <c>GetHashCode</c> stays identity-safe.
+    /// </summary>
+    public class CurveFailClosedTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Semicircle()
+        {
+            var seq = _factory.CoordinateSequenceFactory.Create(new[]
+            {
+                new Coordinate(1, 0),
+                new Coordinate(0, 1),
+                new Coordinate(-1, 0)
+            });
+            return new CircularString(seq, _factory);
+        }
+
+        private CompoundCurve Compound()
+        {
+            var line = _factory.CreateLineString(new[] { new Coordinate(-2, 0), new Coordinate(1, 0) });
+            return new CompoundCurve(new Curve[] { line, Semicircle() }, _factory);
+        }
+
+        private CurvePolygon CurvePoly()
+        {
+            var shell = new CircularString(_factory.CoordinateSequenceFactory.Create(new[]
+            {
+                new Coordinate(0, 0),
+                new Coordinate(2, 2),
+                new Coordinate(4, 0),
+                new Coordinate(2, -2),
+                new Coordinate(0, 0)
+            }), _factory);
+            return new CurvePolygon(shell, _factory);
+        }
+
+        private MultiCurve MultiC() => new MultiCurve(new Curve[] { Semicircle() }, _factory);
+
+        private MultiSurface MultiS() => new MultiSurface(new Geometry[] { CurvePoly() }, _factory);
+
+        private Geometry[] AllFive() => new Geometry[]
+        {
+            Semicircle(), Compound(), CurvePoly(), MultiC(), MultiS()
+        };
+
+        [Test]
+        public void DistanceThrowsFromBothOperandPositions()
+        {
+            var arc = Semicircle();
+            var point = _factory.CreatePoint(new Coordinate(0, 0));
+
+            Assert.That(() => arc.Distance(point), Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => point.Distance(arc), Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => DistanceOp.NearestPoints(point, arc), Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => DistanceOp.IsWithinDistance(point, arc, 1.0), Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void CentroidAndInteriorPointThrowForEachCurveType()
+        {
+            foreach (var g in AllFive())
+            {
+                Assert.That(() => g.Centroid, Throws.TypeOf<NotSupportedException>(), g.GeometryType + ".Centroid");
+                Assert.That(() => g.InteriorPoint, Throws.TypeOf<NotSupportedException>(), g.GeometryType + ".InteriorPoint");
+            }
+        }
+
+        [Test]
+        public void CentroidAndInteriorPointThrowForCollectionWrappingCircularString()
+        {
+            var gc = _factory.CreateGeometryCollection(new Geometry[] { Semicircle() });
+            Assert.That(() => gc.Centroid, Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => gc.InteriorPoint, Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void MultiCurveAndMultiSurfaceBoundaryThrowNotSupported()
+        {
+            Assert.That(() => MultiC().Boundary, Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => MultiS().Boundary, Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void MultiCurveLengthAndMultiSurfaceAreaThrow()
+        {
+            Assert.That(() => MultiC().Length, Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => MultiS().Area, Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void GetHashCodeDoesNotThrowForAnyCurveType()
+        {
+            foreach (var g in AllFive())
+            {
+                Assert.That(() => g.GetHashCode(), Throws.Nothing, g.GeometryType + ".GetHashCode");
+            }
+        }
+
+        [Test]
+        public void IntersectsThrowsViaEnvelopeGuard()
+        {
+            var point = _factory.CreatePoint(new Coordinate(0, 0));
+            Assert.That(() => point.Intersects(Semicircle()), Throws.TypeOf<NotSupportedException>());
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveMetricsContractTests.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveMetricsContractTests.cs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // Intentional-fail hooks for arc-aware Distance / Length / Envelope on the
-// SQL/MM curve foundation. These pin expected contracts and fail until the
-// metrics work leaves the control-polyline / control-bbox stubs.
+// SQL/MM curve foundation. These pin expected contracts and stay red until
+// arc-aware metrics land; today the members throw NotSupportedException
+// instead of returning control-polyline / control-bbox stubs.
 //
 // Assisted-by: xAI Grok
 
@@ -17,7 +18,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
     /// <summary>
     /// Intentional-fail contract tests for arc-aware curve metrics.
     /// Assert SQL/MM / GEOS-quality Distance, Length, and Envelope behaviour;
-    /// they fail on the current control-polyline stubs and mark the Phase-2 hook.
+    /// they stay red until arc-aware metrics land (today they fail with
+    /// <see cref="NotSupportedException"/> rather than wrong chord values).
     /// Excluded from default CI via <c>FailureCase</c> (same pattern as other known-fail fixtures).
     /// </summary>
     [Category("FailureCase")]
@@ -59,8 +61,8 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
 
         /// <summary>
         /// P0 — Distance to a curve must be finite and arc-correct.
-        /// Today <see cref="DistanceOp"/> never visits CircularString segments and
-        /// returns <see cref="double.MaxValue"/> (expected distance at centre is 1).
+        /// Today <see cref="DistanceOp"/> fails closed with
+        /// <see cref="NotSupportedException"/> (expected distance at centre is 1).
         /// </summary>
         [Test]
         public void Red_Distance_PointToCircularString_CentreOfUnitSemicircle_IsRadius()

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveMetricsContractTests.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveMetricsContractTests.cs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// RED hooks for arc-aware behaviour on the SQL/MM curve foundation.
-// Intentional fails until Distance / Length / Envelope leave the chord-stub path.
-//
-// Ground truth: NetTopologySuite.Proofs oracle modes ARC_DISTANCE / ARC_LENGTH
-// (docs/nts857-oracle-bug-hunt-2026-08.md). Keep this file small — one pin per gap.
+// Intentional-fail hooks for arc-aware Distance / Length / Envelope on the
+// SQL/MM curve foundation. These pin expected contracts and fail until the
+// metrics work leaves the control-polyline / control-bbox stubs.
 //
 // Assisted-by: xAI Grok
 
@@ -17,13 +15,15 @@ using NUnit.Framework;
 namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
 {
     /// <summary>
-    /// Oracle-backed RED tests for curve metrics.
-    /// These assert the SQL/MM / GEOS-quality contracts; they fail on the
-    /// current control-polyline stubs and are the product hook for Phase-2 work.
+    /// Intentional-fail contract tests for arc-aware curve metrics.
+    /// Assert SQL/MM / GEOS-quality Distance, Length, and Envelope behaviour;
+    /// they fail on the current control-polyline stubs and mark the Phase-2 hook.
+    /// Excluded from default CI via <c>FailureCase</c> (same pattern as other known-fail fixtures).
     /// </summary>
+    [Category("FailureCase")]
     [Category("Red")]
-    [Category("Curves.Oracle")]
-    public class CurveOracleRedTests
+    [Category("Curves.MetricsContract")]
+    public class CurveMetricsContractTests
     {
         private readonly GeometryFactory _factory = new GeometryFactory();
 
@@ -60,7 +60,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
         /// <summary>
         /// P0 — Distance to a curve must be finite and arc-correct.
         /// Today <see cref="DistanceOp"/> never visits CircularString segments and
-        /// returns <see cref="double.MaxValue"/> (oracle ARC_DISTANCE = 1 at centre).
+        /// returns <see cref="double.MaxValue"/> (expected distance at centre is 1).
         /// </summary>
         [Test]
         public void Red_Distance_PointToCircularString_CentreOfUnitSemicircle_IsRadius()
@@ -73,7 +73,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
             Assert.That(double.IsFinite(d), Is.True,
                 "Distance must not leave the MaxValue sentinel for curve inputs.");
             Assert.That(d, Is.EqualTo(1.0).Within(1e-9),
-                "Oracle ARC_DISTANCE: centre of unit semicircle is at distance r = 1.");
+                "Expected arc-aware distance: centre of unit semicircle is at distance r = 1.");
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
 
         /// <summary>
         /// P1 — Length is arc measure r·θ, not the control-polyline.
-        /// Unit semicircle: oracle ARC_LENGTH = π.
+        /// Unit semicircle: expected length is π.
         /// </summary>
         [Test]
         public void Red_Length_UnitSemicircle_IsPi()
@@ -101,7 +101,7 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
             var arc = UnitSemicircle();
 
             Assert.That(arc.Length, Is.EqualTo(Math.PI).Within(1e-9),
-                "Oracle ARC_LENGTH: unit semicircle length is π, not 2√2 control chords.");
+                "Expected arc-aware length: unit semicircle is π, not 2√2 control chords.");
         }
 
         /// <summary>

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveOracleRedTests.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveOracleRedTests.cs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// RED hooks for arc-aware behaviour on the SQL/MM curve foundation.
+// Intentional fails until Distance / Length / Envelope leave the chord-stub path.
+//
+// Ground truth: NetTopologySuite.Proofs oracle modes ARC_DISTANCE / ARC_LENGTH
+// (docs/nts857-oracle-bug-hunt-2026-08.md). Keep this file small — one pin per gap.
+//
+// Assisted-by: xAI Grok
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.Operation.Distance;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// Oracle-backed RED tests for curve metrics.
+    /// These assert the SQL/MM / GEOS-quality contracts; they fail on the
+    /// current control-polyline stubs and are the product hook for Phase-2 work.
+    /// </summary>
+    [Category("Red")]
+    [Category("Curves.Oracle")]
+    public class CurveOracleRedTests
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        /// <summary>
+        /// Unit upper semicircle: controls (1,0), (0,1), (-1,0). Radius 1, centre origin.
+        /// </summary>
+        private CircularString UnitSemicircle()
+        {
+            var seq = _factory.CoordinateSequenceFactory.Create(new[]
+            {
+                new Coordinate(1, 0),
+                new Coordinate(0, 1),
+                new Coordinate(-1, 0)
+            });
+            return new CircularString(seq, _factory);
+        }
+
+        /// <summary>
+        /// Unit circle arc through angles −30°, 10°, 50° (radians via cos/sin).
+        /// True max X on the arc is 1 (angle 0°), which is not a control point.
+        /// </summary>
+        private CircularString UnitArcPastAxis()
+        {
+            static double Rad(double deg) => deg * Math.PI / 180.0;
+            var seq = _factory.CoordinateSequenceFactory.Create(new[]
+            {
+                new Coordinate(Math.Cos(Rad(-30)), Math.Sin(Rad(-30))),
+                new Coordinate(Math.Cos(Rad(10)), Math.Sin(Rad(10))),
+                new Coordinate(Math.Cos(Rad(50)), Math.Sin(Rad(50)))
+            });
+            return new CircularString(seq, _factory);
+        }
+
+        /// <summary>
+        /// P0 — Distance to a curve must be finite and arc-correct.
+        /// Today <see cref="DistanceOp"/> never visits CircularString segments and
+        /// returns <see cref="double.MaxValue"/> (oracle ARC_DISTANCE = 1 at centre).
+        /// </summary>
+        [Test]
+        public void Red_Distance_PointToCircularString_CentreOfUnitSemicircle_IsRadius()
+        {
+            var arc = UnitSemicircle();
+            var centre = _factory.CreatePoint(new Coordinate(0, 0));
+
+            double d = DistanceOp.Distance(centre, arc);
+
+            Assert.That(double.IsFinite(d), Is.True,
+                "Distance must not leave the MaxValue sentinel for curve inputs.");
+            Assert.That(d, Is.EqualTo(1.0).Within(1e-9),
+                "Oracle ARC_DISTANCE: centre of unit semicircle is at distance r = 1.");
+        }
+
+        /// <summary>
+        /// P0 companion — endpoint query is zero on the true arc.
+        /// </summary>
+        [Test]
+        public void Red_Distance_PointToCircularString_Endpoint_IsZero()
+        {
+            var arc = UnitSemicircle();
+            var end = _factory.CreatePoint(new Coordinate(1, 0));
+
+            double d = DistanceOp.Distance(end, arc);
+
+            Assert.That(double.IsFinite(d), Is.True);
+            Assert.That(d, Is.EqualTo(0.0).Within(1e-12));
+        }
+
+        /// <summary>
+        /// P1 — Length is arc measure r·θ, not the control-polyline.
+        /// Unit semicircle: oracle ARC_LENGTH = π.
+        /// </summary>
+        [Test]
+        public void Red_Length_UnitSemicircle_IsPi()
+        {
+            var arc = UnitSemicircle();
+
+            Assert.That(arc.Length, Is.EqualTo(Math.PI).Within(1e-9),
+                "Oracle ARC_LENGTH: unit semicircle length is π, not 2√2 control chords.");
+        }
+
+        /// <summary>
+        /// P1 — Envelope must cover the true arc, not only control points.
+        /// </summary>
+        [Test]
+        public void Red_Envelope_IncludesAxisExtremeBeyondControls()
+        {
+            var arc = UnitArcPastAxis();
+            var env = arc.EnvelopeInternal;
+
+            Assert.That(env.MaxX, Is.GreaterThanOrEqualTo(1.0 - 1e-12),
+                "Unit arc spanning −30°…50° reaches x=1 at angle 0°; " +
+                "control-only bbox stops at cos(10°) ≈ 0.985.");
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+//
+// The "FCP_*" tests are the in-tree port of CurvePolygonStructuralSpec from the
+// out-of-tree NetTopologySuite.Curve repository. They pin the F-CP (Structural
+// CurvePolygon) contract of the SFA Curve Awareness epic (locationtech/jts#1195,
+// Phase 1): rings are exposed as Curve and never collapse to LinearRing on
+// access, copy, or WKT round-trip. Per NTS convention these stay in the
+// codebase indefinitely as a regression net. The out-of-tree sub-TAG FCP-TL
+// (linearization) depends on facilities this prototype does not carry yet; it
+// comes back with the linearization follow-up.
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    [Category("CurveAwareness")]
+    public class CurvePolygonTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Arc(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private LinearRing Ring(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLinearRing(coords);
+        }
+
+        private LineString Line(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLineString(coords);
+        }
+
+        /// <summary>A compound shell made of two semi-circles, plus one linear hole.</summary>
+        private CurvePolygon CompoundShellWithLinearHole()
+        {
+            var shell = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (5, 5), (10, 0)), Arc((10, 0), (5, -5), (0, 0)) },
+                _factory);
+            var hole = Ring((2, -1), (8, -1), (8, 1), (2, 1), (2, -1));
+            return new CurvePolygon(shell, new Curve[] { hole }, _factory);
+        }
+
+        /// <summary>A CurvePolygon with a CircularString hole inside a flat shell.</summary>
+        private CurvePolygon FlatShellWithArcHole()
+        {
+            var shell = Ring((0, 0), (100, 0), (100, 100), (0, 100), (0, 0));
+            var hole = Arc((40, 50), (50, 60), (60, 50), (50, 40), (40, 50));
+            return new CurvePolygon(shell, new Curve[] { hole }, _factory);
+        }
+
+        // ============================================================
+        // F-CP structural contract (ported from CurvePolygonStructuralSpec)
+        // ============================================================
+
+        [Test]
+        public void FCP_S_compound_shell_exposed_as_CompoundCurve()
+        {
+            var cp = CompoundShellWithLinearHole();
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-S: compound shell should be exposed as CompoundCurve, got "
+                + cp.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_S_arc_shell_exposed_as_CircularString()
+        {
+            var cp = new CurvePolygon(Arc((0, 0), (10, 0), (5, 5), (0, 5), (0, 0)), _factory);
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<CircularString>(),
+                "FCP-S: arc shell should be exposed as CircularString, got "
+                + cp.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_MEM_compound_shell_members_retain_subtypes()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var cc = (CompoundCurve)cp.ExteriorRing;
+            Assert.That(cc.Curves.Count, Is.EqualTo(2),
+                "FCP-MEM: compound shell should have two members");
+            Assert.That(cc.Curves[0], Is.InstanceOf<CircularString>(),
+                "FCP-MEM: member 0 should be a CircularString");
+            Assert.That(cc.Curves[1], Is.InstanceOf<CircularString>(),
+                "FCP-MEM: member 1 should be a CircularString");
+        }
+
+        [Test]
+        public void FCP_H_arc_hole_exposed_as_CircularString()
+        {
+            var cp = FlatShellWithArcHole();
+            Assert.That(cp.NumInteriorRings, Is.EqualTo(1),
+                "FCP-H: CurvePolygon has one interior ring");
+            Assert.That(cp.GetInteriorRingN(0), Is.InstanceOf<CircularString>(),
+                "FCP-H: arc hole should be a CircularString, got "
+                + cp.GetInteriorRingN(0).GetType().Name);
+        }
+
+        [Test]
+        public void FCP_CP_copy_preserves_shell_subtype()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var copy = (CurvePolygon)cp.Copy();
+
+            Assert.That(copy.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-CP: copied shell must also be a CompoundCurve, got "
+                + copy.ExteriorRing.GetType().Name);
+            Assert.That(copy.ExteriorRing, Is.Not.SameAs(cp.ExteriorRing),
+                "FCP-CP: copy must be a deep copy of the shell");
+            Assert.That(copy.EqualsExact(cp), Is.True);
+        }
+
+        [Test]
+        public void FCP_CP_copy_preserves_arc_hole_subtype()
+        {
+            var cp = FlatShellWithArcHole();
+            var copy = (CurvePolygon)cp.Copy();
+
+            Assert.That(copy.GetInteriorRingN(0), Is.InstanceOf<CircularString>(),
+                "FCP-CP: copied hole must remain a CircularString, got "
+                + copy.GetInteriorRingN(0).GetType().Name);
+        }
+
+        [Test]
+        public void FCP_WKT_roundtrip_preserves_compound_shell()
+        {
+            var cp = CompoundShellWithLinearHole();
+            string emitted = new WKTWriter().Write(cp);
+
+            Assert.That(emitted.ToUpperInvariant(), Does.Contain("COMPOUNDCURVE"),
+                "FCP-WKT: emitted WKT must contain the COMPOUNDCURVE tag, got: " + emitted);
+
+            var roundTripped = (CurvePolygon)new WKTReader().Read(emitted);
+            Assert.That(roundTripped.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-WKT: round-tripped shell must remain a CompoundCurve, got "
+                + roundTripped.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_WKT_roundtrip_preserves_arc_shell()
+        {
+            var cp = new CurvePolygon(Arc((0, 0), (10, 0), (5, 5), (0, 5), (0, 0)), _factory);
+            string emitted = new WKTWriter().Write(cp);
+
+            Assert.That(emitted.ToUpperInvariant(), Does.Contain("CIRCULARSTRING"),
+                "FCP-WKT: emitted WKT must contain the CIRCULARSTRING tag, got: " + emitted);
+
+            var roundTripped = (CurvePolygon)new WKTReader().Read(emitted);
+            Assert.That(roundTripped.ExteriorRing, Is.InstanceOf<CircularString>(),
+                "FCP-WKT: round-tripped shell must remain a CircularString, got "
+                + roundTripped.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_DOVE_ring_accessors_are_typed_Curve()
+        {
+            var exteriorRingType = typeof(CurvePolygon).GetProperty(nameof(CurvePolygon.ExteriorRing))?.PropertyType;
+            Assert.That(exteriorRingType, Is.Not.Null,
+                "FCP-DOVE: CurvePolygon must expose an ExteriorRing accessor");
+            Assert.That(exteriorRingType, Is.EqualTo(typeof(Curve)),
+                "FCP-DOVE: CurvePolygon.ExteriorRing must be typed as Curve "
+                + "(the polymorphic base of LinearRing / LineString / CircularString / "
+                + "CompoundCurve). If this returns LinearRing again, the JTS-side "
+                + "FCP-DOVE A/B/C dovetail decision needs to be made here too.");
+        }
+
+        // ============================================================
+        // Construction and basic behavior
+        // ============================================================
+
+        [Test]
+        public void EmptyCurvePolygonHasZeroPoints()
+        {
+            var cp = new CurvePolygon(null, _factory);
+            Assert.That(cp.IsEmpty, Is.True);
+            Assert.That(cp.NumPoints, Is.EqualTo(0));
+            Assert.That(cp.NumInteriorRings, Is.EqualTo(0));
+            Assert.That(cp.Area, Is.EqualTo(0));
+            Assert.That(cp.GeometryType, Is.EqualTo("CurvePolygon"));
+            Assert.That(cp.OgcGeometryType, Is.EqualTo(OgcGeometryType.CurvePolygon));
+        }
+
+        [Test]
+        public void RejectsUnclosedShell()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(Arc((0, 0), (1, 1), (2, 0)), _factory));
+        }
+
+        [Test]
+        public void RejectsUnclosedHole()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(shell, new Curve[] { Line((1, 1), (2, 2)) }, _factory));
+        }
+
+        [Test]
+        public void RejectsEmptyShellWithHoles()
+        {
+            var hole = Ring((2, 2), (4, 2), (4, 4), (2, 4), (2, 2));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(null, new Curve[] { hole }, _factory));
+        }
+
+        [Test]
+        public void RejectsNullHoles()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(shell, new Curve[] { null }, _factory));
+        }
+
+        [Test]
+        public void ChordBasedAreaSubtractsHoles()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            var hole = Ring((2, 2), (4, 2), (4, 4), (2, 4), (2, 2));
+            var cp = new CurvePolygon(shell, new Curve[] { hole }, _factory);
+
+            Assert.That(cp.Area, Is.EqualTo(96).Within(1e-12));
+            Assert.That(cp.Length, Is.EqualTo(40 + 8).Within(1e-12));
+        }
+
+        [Test]
+        public void EnvelopeIsShellEnvelope()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var env = cp.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(10));
+            Assert.That(env.MinY, Is.EqualTo(-5));
+            Assert.That(env.MaxY, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void BoundaryExposesAllRings()
+        {
+            var cp = FlatShellWithArcHole();
+            var boundary = cp.Boundary;
+            Assert.That(boundary.NumGeometries, Is.EqualTo(2));
+            Assert.That(boundary.GetGeometryN(0), Is.InstanceOf<LinearRing>());
+            Assert.That(boundary.GetGeometryN(1), Is.InstanceOf<CircularString>());
+        }
+
+        [Test]
+        public void ReversePreservesRingSubtypes()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var rev = (CurvePolygon)cp.Reverse();
+
+            Assert.That(rev.ExteriorRing, Is.InstanceOf<CompoundCurve>());
+            Assert.That(rev.NumInteriorRings, Is.EqualTo(1));
+
+            // Double reverse is identity.
+            var revrev = (CurvePolygon)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cp), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCurvePolygonFromPolygon()
+        {
+            var shellCoords = new[] { (0d, 0d), (10d, 0d), (10d, 10d), (0d, 10d), (0d, 0d) };
+            var cp = new CurvePolygon(Ring(shellCoords), _factory);
+            var polygon = _factory.CreatePolygon(Ring(shellCoords));
+            Assert.That(cp.EqualsExact(polygon), Is.False,
+                "CurvePolygon and Polygon with the same shell should not be EqualsExact.");
+        }
+
+        [Test]
+        public void LinearizeReturnsLinearPolygonWithLinearRings()
+        {
+            var cp = FlatShellWithArcHole();
+            ILinearizable<Polygon> linearizable = cp;
+            var polygon = linearizable.Linearize();
+
+            Assert.That(polygon, Is.InstanceOf<Polygon>());
+            Assert.That(polygon, Is.Not.InstanceOf<CurvePolygon>());
+            Assert.That(polygon.ExteriorRing, Is.InstanceOf<LinearRing>());
+            Assert.That(polygon.NumInteriorRings, Is.EqualTo(1));
+            Assert.That(polygon.GetInteriorRingN(0), Is.InstanceOf<LinearRing>());
+            Assert.That(polygon.GetInteriorRingN(0).NumPoints, Is.EqualTo(5));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
@@ -224,25 +224,36 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
         }
 
         [Test]
-        public void ChordBasedAreaSubtractsHoles()
+        public void AreaAndLengthFailClosed()
         {
             var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
             var hole = Ring((2, 2), (4, 2), (4, 4), (2, 4), (2, 2));
             var cp = new CurvePolygon(shell, new Curve[] { hole }, _factory);
 
-            Assert.That(cp.Area, Is.EqualTo(96).Within(1e-12));
-            Assert.That(cp.Length, Is.EqualTo(40 + 8).Within(1e-12));
+            Assert.That(() => cp.Area, Throws.TypeOf<NotSupportedException>(),
+                "Unconditional cut: all-linear CurvePolygon still throws.");
+            Assert.That(() => cp.Length, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]
-        public void EnvelopeIsShellEnvelope()
+        public void EnvelopeFailsClosedUntilArcAware()
         {
             var cp = CompoundShellWithLinearHole();
-            var env = cp.EnvelopeInternal;
-            Assert.That(env.MinX, Is.EqualTo(0));
-            Assert.That(env.MaxX, Is.EqualTo(10));
-            Assert.That(env.MinY, Is.EqualTo(-5));
-            Assert.That(env.MaxY, Is.EqualTo(5));
+            Assert.That(() => cp.EnvelopeInternal, Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void NormalizeFailsClosedWhenNotEmpty()
+        {
+            var cp = new CurvePolygon(Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0)), _factory);
+            Assert.That(() => cp.Normalize(), Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void LinearizeWithToleranceFailsClosed()
+        {
+            var cp = FlatShellWithArcHole();
+            Assert.That(() => cp.Linearize(1.0), Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWkbWktGeosTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWkbWktGeosTest.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// GEOS-aligned WKT/WKB curve I/O tests. Assisted-by: xAI Grok
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// WKT/WKB import dovetailed with GEOS SQL/MM curve types (8–12).
+    /// </summary>
+    public class CurveWkbWktGeosTest
+    {
+        [TestCase("CIRCULARSTRING (0 0, 1 1, 2 0)")]
+        [TestCase("CIRCULARSTRING EMPTY")]
+        [TestCase("COMPOUNDCURVE ((0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0))")]
+        [TestCase("COMPOUNDCURVE (LINESTRING (0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0))")]
+        [TestCase("CURVEPOLYGON (CIRCULARSTRING (0 0, 2 2, 4 0, 2 -2, 0 0))")]
+        [TestCase("MULTICURVE (CIRCULARSTRING (0 0, 1 1, 2 0), (3 0, 4 0))")]
+        [TestCase("MULTICURVE EMPTY")]
+        [TestCase("MULTISURFACE (CURVEPOLYGON (CIRCULARSTRING (0 0, 2 2, 4 0, 2 -2, 0 0)), POLYGON ((10 10, 20 10, 20 20, 10 20, 10 10)))")]
+        [TestCase("MULTISURFACE EMPTY")]
+        public void WktRoundTrip(string wkt)
+        {
+            var g = new WKTReader().Read(wkt);
+            string written = g.AsText();
+            var again = new WKTReader().Read(written);
+            Assert.That(again.EqualsExact(g), Is.True, written);
+        }
+
+        [Test]
+        public void GeosStyleLineStringTagInCompoundCurve()
+        {
+            var g = new WKTReader().Read(
+                "COMPOUNDCURVE (LINESTRING (0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0))");
+            var cc = (CompoundCurve)g;
+            Assert.That(cc.Curves[0], Is.InstanceOf<LineString>());
+            Assert.That(cc.Curves[1], Is.InstanceOf<CircularString>());
+        }
+
+        [TestCase("CIRCULARSTRING (0 0, 1 1, 2 0)")]
+        [TestCase("CIRCULARSTRING EMPTY")]
+        [TestCase("COMPOUNDCURVE ((0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0))")]
+        [TestCase("CURVEPOLYGON (CIRCULARSTRING (0 0, 2 2, 4 0, 2 -2, 0 0))")]
+        [TestCase("CURVEPOLYGON EMPTY")]
+        [TestCase("MULTICURVE (CIRCULARSTRING (0 0, 1 1, 2 0), (3 0, 4 0))")]
+        [TestCase("MULTICURVE EMPTY")]
+        [TestCase("MULTISURFACE (CURVEPOLYGON (CIRCULARSTRING (0 0, 2 2, 4 0, 2 -2, 0 0)))")]
+        [TestCase("MULTISURFACE EMPTY")]
+        public void WkbRoundTrip(string wkt)
+        {
+            var g = new WKTReader().Read(wkt);
+            var writer = new WKBWriter();
+            byte[] bytes = writer.Write(g);
+            var reader = new WKBReader();
+            var again = reader.Read(bytes);
+            Assert.That(again.GetType(), Is.EqualTo(g.GetType()), g.GeometryType);
+            Assert.That(again.EqualsExact(g), Is.True, WKBWriter.ToHex(bytes));
+        }
+
+        [Test]
+        public void WkbTypeCodesMatchGeosIso()
+        {
+            Assert.That((int)WKBGeometryTypes.WKBCircularString, Is.EqualTo(8));
+            Assert.That((int)WKBGeometryTypes.WKBCompoundCurve, Is.EqualTo(9));
+            Assert.That((int)WKBGeometryTypes.WKBCurvePolygon, Is.EqualTo(10));
+            Assert.That((int)WKBGeometryTypes.WKBMultiCurve, Is.EqualTo(11));
+            Assert.That((int)WKBGeometryTypes.WKBMultiSurface, Is.EqualTo(12));
+        }
+
+        [Test]
+        public void MultiSurfacePreservesMemberSubtypes()
+        {
+            var g = (MultiSurface)new WKTReader().Read(
+                "MULTISURFACE (CURVEPOLYGON (CIRCULARSTRING (0 0, 2 2, 4 0, 2 -2, 0 0)), POLYGON ((10 10, 20 10, 20 20, 10 20, 10 10)))");
+            Assert.That(g.GetGeometryN(0), Is.InstanceOf<CurvePolygon>());
+            Assert.That(g.GetGeometryN(1), Is.InstanceOf<Polygon>());
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWktTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWktTest.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+// The OGC Triangle geometry, not the coordinate utility class.
+using Triangle = NetTopologySuite.Geometries.Curves.Triangle;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// WKT round-trip tests for the curve prototype types (CIRCULARSTRING,
+    /// COMPOUNDCURVE, CURVEPOLYGON, TRIANGLE, TIN).
+    /// </summary>
+    public class CurveWktTest
+    {
+        [TestCase("CIRCULARSTRING (0 0, 1 1, 2 0)", typeof(CircularString))]
+        [TestCase("CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0)", typeof(CircularString))]
+        [TestCase("CIRCULARSTRING EMPTY", typeof(CircularString))]
+        [TestCase("COMPOUNDCURVE ((0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0), (3 0, 4 0))", typeof(CompoundCurve))]
+        [TestCase("COMPOUNDCURVE (CIRCULARSTRING (0 0, 1 1, 2 0), (2 0, 3 0))", typeof(CompoundCurve))]
+        [TestCase("COMPOUNDCURVE EMPTY", typeof(CompoundCurve))]
+        [TestCase("CURVEPOLYGON (CIRCULARSTRING (0 0, 2 2, 4 0, 2 -2, 0 0))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON (COMPOUNDCURVE (CIRCULARSTRING (0 0, 5 5, 10 0), (10 0, 0 0)), (2 1, 8 1, 8 2, 2 2, 2 1))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON ((0 0, 100 0, 100 100, 0 100, 0 0), CIRCULARSTRING (40 50, 50 60, 60 50, 50 40, 40 50))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON EMPTY", typeof(CurvePolygon))]
+        [TestCase("TRIANGLE ((0 0, 1 0, 0 1, 0 0))", typeof(Triangle))]
+        [TestCase("TRIANGLE EMPTY", typeof(Triangle))]
+        [TestCase("TIN (((0 0, 1 0, 0 1, 0 0)), ((1 0, 1 1, 0 1, 1 0)))", typeof(Tin))]
+        [TestCase("TIN EMPTY", typeof(Tin))]
+        [TestCase("GEOMETRYCOLLECTION (CIRCULARSTRING (0 0, 1 1, 2 0), POINT (5 5))", typeof(GeometryCollection))]
+        public void WktRoundTripIsStable(string wkt, Type expectedType)
+        {
+            var reader = new WKTReader();
+
+            var geometry = reader.Read(wkt);
+            Assert.That(geometry, Is.InstanceOf(expectedType));
+
+            string written = geometry.AsText();
+            Assert.That(written, Is.EqualTo(wkt));
+
+            var reparsed = reader.Read(written);
+            Assert.That(reparsed.EqualsExact(geometry), Is.True,
+                "Round-tripped geometry should be EqualsExact to the original.");
+        }
+
+        [Test]
+        public void ReadPreservesComponentAndRingSubtypes()
+        {
+            var reader = new WKTReader();
+
+            var cc = (CompoundCurve)reader.Read("COMPOUNDCURVE ((0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0))");
+            Assert.That(cc.Curves[0], Is.InstanceOf<LineString>());
+            Assert.That(cc.Curves[1], Is.InstanceOf<CircularString>());
+
+            var cp = (CurvePolygon)reader.Read(
+                "CURVEPOLYGON ((0 0, 100 0, 100 100, 0 100, 0 0), CIRCULARSTRING (40 50, 50 60, 60 50, 50 40, 40 50))");
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<LineString>());
+            Assert.That(cp.GetInteriorRingN(0), Is.InstanceOf<CircularString>());
+        }
+
+        [Test]
+        public void ReadSupportsZOrdinates()
+        {
+            var geometry = new WKTReader().Read("CIRCULARSTRING Z(0 0 5, 1 1 5, 2 0 5)");
+
+            var circularString = (CircularString)geometry;
+            Assert.That(circularString.CoordinateSequence.GetZ(0), Is.EqualTo(5));
+            Assert.That(new WKTWriter(3).Write(geometry), Is.EqualTo("CIRCULARSTRING Z(0 0 5, 1 1 5, 2 0 5)"));
+        }
+
+        [Test]
+        public void ReadRejectsNestedCompoundCurves()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("COMPOUNDCURVE (COMPOUNDCURVE ((0 0, 1 0)))"));
+        }
+
+        [Test]
+        public void ReadRejectsTriangleWithInteriorRing()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("TRIANGLE ((0 0, 10 0, 0 10, 0 0), (1 1, 2 1, 1 2, 1 1))"));
+        }
+
+        [Test]
+        public void ReadRejectsUnexpectedCurveComponent()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("CURVEPOLYGON (POINT (0 0))"));
+        }
+
+        [Test]
+        public void ReadRejectsEvenCircularStringPointCount()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new WKTReader().Read("CIRCULARSTRING (0 0, 1 1)"));
+        }
+
+        [Test]
+        public void ReadRejectsNonContiguousCompoundCurve()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new WKTReader().Read("COMPOUNDCURVE ((0 0, 1 0), (2 0, 3 0))"));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/TriangleAndTinTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/TriangleAndTinTest.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Opus-4.7)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+using Triangle = NetTopologySuite.Geometries.Curves.Triangle;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class TriangleAndTinTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private LinearRing TriRing(double ax, double ay, double bx, double by, double cx, double cy)
+        {
+            var coords = new[]
+            {
+                new Coordinate(ax, ay),
+                new Coordinate(bx, by),
+                new Coordinate(cx, cy),
+                new Coordinate(ax, ay),
+            };
+            return _factory.CreateLinearRing(coords);
+        }
+
+        [Test]
+        public void TriangleAcceptsFourCoordRing()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.That(t.NumPoints, Is.EqualTo(4));
+            Assert.That(t.GeometryType, Is.EqualTo("Triangle"));
+            Assert.That(t.OgcGeometryType, Is.EqualTo(OgcGeometryType.Triangle));
+            Assert.That(t.NumInteriorRings, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TriangleAreaIsHalfBaseTimesHeight()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 0, 8), _factory);
+            Assert.That(t.Area, Is.EqualTo(40.0).Within(1e-9));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsPositiveForCCW()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.That(t.SignedDoubleArea, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsNegativeForCW()
+        {
+            var t = new Triangle(TriRing(0, 0, 5, 8, 10, 0), _factory);
+            Assert.That(t.SignedDoubleArea, Is.LessThan(0));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsZeroForCollinear()
+        {
+            var t = new Triangle(TriRing(0, 0, 1, 1, 2, 2), _factory);
+            Assert.That(t.SignedDoubleArea, Is.EqualTo(0).Within(1e-9));
+            Assert.That(t.Area, Is.EqualTo(0).Within(1e-9));
+        }
+
+        [Test]
+        public void TriangleRejectsNon4PointRing()
+        {
+            var ring = _factory.CreateLinearRing(new[]
+            {
+                new Coordinate(0, 0), new Coordinate(10, 0),
+                new Coordinate(10, 10), new Coordinate(0, 10),
+                new Coordinate(0, 0)
+            });
+            Assert.Throws<ArgumentException>(() => new Triangle(ring, _factory));
+        }
+
+        [Test]
+        public void TriangleHasNoInteriorRings()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.Throws<ArgumentOutOfRangeException>(() => t.GetInteriorRingN(0));
+        }
+
+        [Test]
+        public void TriangleCopyIsEqualButDistinct()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var copy = (Triangle)t.Copy();
+            Assert.That(copy.EqualsExact(t), Is.True);
+            Assert.That(ReferenceEquals(copy, t), Is.False);
+        }
+
+        [Test]
+        public void TriangleReverseFlipsVertexOrder()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var rev = (Triangle)t.Reverse();
+            Assert.That(rev.SignedDoubleArea, Is.EqualTo(-t.SignedDoubleArea).Within(1e-9));
+        }
+
+        [Test]
+        public void TinHoldsTriangles()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var t2 = new Triangle(TriRing(10, 0, 20, 0, 15, 8), _factory);
+            var tin = new Tin(new[] { t1, t2 }, _factory);
+            Assert.That(tin.NumGeometries, Is.EqualTo(2));
+            Assert.That(tin.GeometryType, Is.EqualTo("TIN"));
+            Assert.That(tin.OgcGeometryType, Is.EqualTo(OgcGeometryType.TIN));
+        }
+
+        [Test]
+        public void TinAreaIsSumOfTriangleAreas()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 0, 8), _factory);
+            var t2 = new Triangle(TriRing(10, 0, 20, 0, 10, 4), _factory);
+            var tin = new Tin(new[] { t1, t2 }, _factory);
+            Assert.That(tin.Area, Is.EqualTo(40.0 + 20.0).Within(1e-9));
+        }
+
+        [Test]
+        public void EmptyTinHasZeroGeometries()
+        {
+            var tin = new Tin(new Triangle[0], _factory);
+            Assert.That(tin.NumGeometries, Is.EqualTo(0));
+            Assert.That(tin.Area, Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void TinGetTriangleNReturnsTypedElement()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var tin = new Tin(new[] { t1 }, _factory);
+            var got = tin.GetTriangleN(0);
+            Assert.That(got, Is.SameAs(t1));
+        }
+
+        [Test]
+        public void TinCopyDeepCopiesTriangles()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var tin = new Tin(new[] { t1 }, _factory);
+            var copy = (Tin)tin.Copy();
+            Assert.That(copy.NumGeometries, Is.EqualTo(1));
+            Assert.That(copy.GetTriangleN(0).EqualsExact(t1), Is.True);
+            Assert.That(ReferenceEquals(copy.GetTriangleN(0), t1), Is.False);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Land the SQL/MM curve and surface types as first-class `Geometry` subtypes in the **main** NetTopologySuite library, on new `Curve` / `Surface<T>` bases — not in the retired `NetTopologySuite.Curve` package or submodule.

**Seven geometry types**, all in `NetTopologySuite.Geometries.Curves`:

| Type | Base |
|---|---|
| `CircularString` | `Curve` |
| `CompoundCurve` | `Curve` |
| `CurvePolygon` | `Surface<Curve>` |
| `MultiCurve` | `GeometryCollection` |
| `MultiSurface` | `GeometryCollection` |
| `Triangle` | `Surface<LinearRing>` |
| `Tin` | `GeometryCollection` |

```mermaid
classDiagram
    class Geometry
    class Curve
    class Surface
    class GeometryCollection

    Geometry <|-- Curve
    Geometry <|-- Surface
    Geometry <|-- GeometryCollection

    Curve <|-- LineString
    Curve <|-- CircularString
    Curve <|-- CompoundCurve
    LineString <|-- LinearRing

    Surface <|-- Polygon
    Surface <|-- CurvePolygon
    Surface <|-- Triangle

    GeometryCollection <|-- MultiCurve
    GeometryCollection <|-- MultiSurface
    GeometryCollection <|-- Tin

    class LineString {
      existing - reparented
    }
    class Polygon {
      existing - reparented
    }
    class CircularString
    class CompoundCurve
    class CurvePolygon
    class Triangle
    class MultiCurve
    class MultiSurface
    class Tin
```

**Both I/O paths.** WKT read and write for `CIRCULARSTRING`, `COMPOUNDCURVE`, `CURVEPOLYGON`, `TRIANGLE` and `TIN`, covering EMPTY, multi-component and multi-ring cases, Z ordinates, and subtype-preserving members and rings. WKB read and write for the corresponding SQL/MM type codes, with `WKBGeometryTypes` extended to match ISO/IEC 13249-3 §5.1.68 Table 15.

**`ILinearizable`** provides chord / control-point linearization as an explicit escape hatch. `Linearize()` is the only way to get an approximation; nothing produces one implicitly.

**Fail-closed metrics.** Every metric and analytic member on the curve types — `Length`, `Area`, `Envelope`, `IsSimple`, `Distance`, `Centroid`, `InteriorPoint` — throws `NotSupportedException` naming the type and the member, until the arc-aware follow-up lands. Empty geometries stay exact. This replaces the approximate/placeholder calculations the first revision carried; see the discussion below.

**Dedicated `SortIndexValue` entries** so mixed-type `CompareTo` and `Array.Sort` never reach a wrong `CompareToSameClass` cast.

## Base-class changes — the compatibility-relevant part

`LineString` now extends `Curve`, and `Polygon` extends `Surface<LineString>`. This is the highest-risk change here and the one most worth a careful look: it re-parents two of the most widely used types in the library.

The consequences are captured in `CompatibilitySuppressions.xml` (41 entries), the most notable being `LineString.IsClosed` becoming an `override` via `Curve` — CP0012, binary-compatible in practice. Package validation passes against the 2.6.0 baseline with those suppressions and no others.

## What changed during review

- **Approximate metrics removed.** Per @bjornharrtell: placeholder calculations that could return wrong or misleading results are gone, replaced by the fail-closed `NotSupportedException` behaviour above.
- **Test naming neutralised.** `CurveOracleRedTests` → `CurveMetricsContractTests`, `Curves.Oracle` → `Curves.MetricsContract`, and the assertion and header wording no longer says "Oracle". Tagged `[Category("FailureExpected")]`.

## Relation to existing work

- **[#849](https://github.com/NetTopologySuite/NetTopologySuite/pull/849)** is the design record: it settled in-tree versus out-of-tree, the `Triangle` sub-namespace naming, and the SQL/MM-versus-OGC-SFA attribution. Kept open as history, not for merge.
- **[#854](https://github.com/NetTopologySuite/NetTopologySuite/pull/854)** was the intermediate MVP from `mvp/curves-on-develop`, closed 2026-08-04 in favour of this PR.
- This PR is on current `develop` and adds SortIndex, `ILinearizable`, WKB I/O and the `MultiCurve` / `MultiSurface` types beyond that prototype.
- The [`NetTopologySuite.Curved`](https://github.com/NetTopologySuite/NetTopologySuite.Curved) repository and its fork [`grootstebozewolf/NetTopologySuite.Curve`](https://github.com/grootstebozewolf/NetTopologySuite.Curve) — the name drops the *d* — were the out-of-tree incubator, and remain the donor for follow-up ports rather than a competing home.

## Scope

| In scope | Out of scope |
|---|---|
| Structure, validation, type identity | Arc-aware spatial algorithms |
| WKT read and write | Analytic `Length` / `Area` (these throw) |
| WKB read and write for the SQL/MM type codes | Arc-tight envelopes — bounds are by control point |
| Explicit chord linearization via `Linearize()` | `PolyhedralSurface` (code 15) |
| Dedicated sort indices | Adjacency / shared-edge validity for `Tin` |

## Test plan

- [x] `dotnet build` of the main library and the NUnit test project — 0 errors
- [x] `dotnet test --filter FullyQualifiedName~Geometries.Curves` — structural, WKT, WKB, linearize, CompareTo and fail-closed suites
- [x] Structural: odd control-point count, contiguous `CompoundCurve` members, closed `CurvePolygon` rings
- [x] WKT round-trips with `EqualsExact`, correct keywords, preserved component and ring subtypes
- [x] WKB round-trips cross-checked against GEOS output
- [x] Mixed-type `CompareTo` / `Array.Sort` does not throw
- [x] Fail-closed metrics throw `NotSupportedException` on non-empty curve types; empty stays exact; `Linearize()` remains the only chord path
- [x] No `PackageReference`, `ProjectReference` or `.gitmodules` entry for `NetTopologySuite.Curve`
- [x] Package validation against the 2.6.0 baseline passes with the suppressions listed above

**AI-assisted contribution**, disclosed per [AI_POLICY.md](https://github.com/NetTopologySuite/NetTopologySuite/blob/develop/AI_POLICY.md). Claude assisted with both the code and this description. I have reviewed and tested the result, and I am responsible for its correctness and licensing under the project's usual terms and my signed CLA.
