### PR TITLE
Add AI-assisted contribution policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,4 @@
+# AI-Assisted Contribution Policy
+
+Use of AI must be disclosed and must be reasonable, as judged by common sense. Contributors remain fully responsible for their contribution, including its correctness and licensing, regardless of how it was produced. Maintainers may reject AI contributions without further explanation or discussion of the subject.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ First of all don't be afraid to contribute. Most contributions are small but ver
   - All public or protected methods, functions and properties have sufficient code documentation
 - Verfiy that the code works as expected by providing adequate unit tests.
 - __Upon issueing a pull-request, you need to sign this [contributor license agreement](https://gist.github.com/FObermaier/2db0402438d23227ed66de0d2d4fbe78)__
+- If you use AI tools (e.g. Copilot, ChatGPT) to help write your contribution, see our [AI-assisted contribution policy](AI_POLICY.md) — disclosure and the usual quality/licensing rules apply.
 
 ## What can you do to help?
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NetTopologySuite/NetTopologySuite/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
<!--These follow strict Stylecop rules :cop:.-->
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR suggests to add a minimal policy on AI-assisted contributions.

Disclosure: I used AI-assistance to improve wording.