### PR TITLE
Add ReadOnlySpan<Coordinate> overloads to CoordinateSequenceFactory and GeometryFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ bld/
 # Roslyn cache directories
 *.ide/
 
+# BenchmarkDotNet
+BenchmarkDotNet.Artifacts/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/NetTopologySuite.slnx
+++ b/NetTopologySuite.slnx
@@ -42,6 +42,7 @@
     <File Path="doc/overwrite/namespaces/NetTopologySuite.Utilities.md" />
   </Folder>
   <Folder Name="/NetTopologySuite.Tests/">
+    <Project Path="test/NetTopologySuite.Benchmark/NetTopologySuite.Benchmark.csproj" />
     <Project Path="test/NetTopologySuite.Samples.Console/NetTopologySuite.Samples.Console.csproj" />
     <Project Path="test/NetTopologySuite.TestRunner/NetTopologySuite.TestRunner.csproj" />
     <Project Path="test/NetTopologySuite.Tests.NUnit.Performance/NetTopologySuite.Tests.NUnit.Performance.csproj" />

--- a/src/NetTopologySuite/Geometries/CoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/CoordinateSequenceFactory.cs
@@ -38,36 +38,44 @@ namespace NetTopologySuite.Geometries
         /// <returns>A coordinate sequence.</returns>
         public virtual CoordinateSequence Create(Coordinate[] coordinates)
         {
+            return Create((ReadOnlySpan<Coordinate>)coordinates);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="CoordinateSequence" /> based on the given span of coordinates;
+        /// whether or not the values are copied is implementation-dependent.
+        /// </summary>
+        /// <param name="coordinates">A span of coordinates, which may not contain null elements</param>
+        /// <returns>A coordinate sequence.</returns>
+        public virtual CoordinateSequence Create(ReadOnlySpan<Coordinate> coordinates)
+        {
             (int count, int dimension, int measures) = GetCommonSequenceParameters(coordinates);
             var result = Create(count, dimension, measures);
-            if (coordinates != null)
+            int spatial = dimension - measures;
+            for (int i = 0; i < coordinates.Length; i++)
             {
-                int spatial = dimension - measures;
-                for (int i = 0; i < coordinates.Length; i++)
+                var coord = coordinates[i];
+                int coordDimension = Coordinates.Dimension(coord);
+                int coordMeasures = Coordinates.Measures(coord);
+                int coordSpatial = coordDimension - coordMeasures;
+                for (int dim = 0; dim < coordSpatial; dim++)
                 {
-                    var coord = coordinates[i];
-                    int coordDimension = Coordinates.Dimension(coord);
-                    int coordMeasures = Coordinates.Measures(coord);
-                    int coordSpatial = coordDimension - coordMeasures;
-                    for (int dim = 0; dim < coordSpatial; dim++)
-                    {
-                        result.SetOrdinate(i, dim, coord[dim]);
-                    }
+                    result.SetOrdinate(i, dim, coord[dim]);
+                }
 
-                    for (int dim = coordSpatial; dim < spatial; dim++)
-                    {
-                        result.SetOrdinate(i, dim, Coordinate.NullOrdinate);
-                    }
+                for (int dim = coordSpatial; dim < spatial; dim++)
+                {
+                    result.SetOrdinate(i, dim, Coordinate.NullOrdinate);
+                }
 
-                    for (int measure = 0; measure < coordMeasures; measure++)
-                    {
-                        result.SetOrdinate(i, spatial + measure, coord[coordSpatial + measure]);
-                    }
+                for (int measure = 0; measure < coordMeasures; measure++)
+                {
+                    result.SetOrdinate(i, spatial + measure, coord[coordSpatial + measure]);
+                }
 
-                    for (int measure = coordMeasures; measure < measures; measure++)
-                    {
-                        result.SetOrdinate(i, spatial + measure, Coordinate.NullOrdinate);
-                    }
+                for (int measure = coordMeasures; measure < measures; measure++)
+                {
+                    result.SetOrdinate(i, spatial + measure, Coordinate.NullOrdinate);
                 }
             }
 
@@ -156,11 +164,23 @@ namespace NetTopologySuite.Geometries
         /// </returns>
         public static (int Count, int Dimension, int Measures) GetCommonSequenceParameters(Coordinate[] coordinates)
         {
-            if (coordinates == null)
-            {
-                return (0, 2, 0);
-            }
+            return GetCommonSequenceParameters((ReadOnlySpan<Coordinate>)coordinates);
+        }
 
+        /// <summary>
+        /// Gets the three parameters needed to create any <see cref="CoordinateSequence"/> instance
+        /// (<see cref="CoordinateSequence.Count"/>, <see cref="CoordinateSequence.Dimension"/>, and
+        /// <see cref="CoordinateSequence.Measures"/>) such that the sequence can store all the data
+        /// from a given span of <see cref="Coordinate"/> instances.
+        /// </summary>
+        /// <param name="coordinates">
+        /// The span of <see cref="Coordinate"/> instances that the sequence will be created from.
+        /// </param>
+        /// <returns>
+        /// The values of the three parameters to use for creating the sequence.
+        /// </returns>
+        public static (int Count, int Dimension, int Measures) GetCommonSequenceParameters(ReadOnlySpan<Coordinate> coordinates)
+        {
             int count = coordinates.Length;
             int spatial = 2;
             int measures = 0;

--- a/src/NetTopologySuite/Geometries/GeometryFactory.cs
+++ b/src/NetTopologySuite/Geometries/GeometryFactory.cs
@@ -400,6 +400,17 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
+        /// Creates a LineString using the given Coordinates.
+        /// An empty span creates an empty LineString.
+        /// </summary>
+        /// <param name="coordinates">A span of coordinates without null elements, or an empty span.</param>
+        /// <returns>A <see cref="LineString"/> object</returns>
+        public LineString CreateLineString(ReadOnlySpan<Coordinate> coordinates)
+        {
+            return CreateLineString(CoordinateSequenceFactory.Create(coordinates));
+        }
+
+        /// <summary>
         /// Creates a LineString using the given CoordinateSequence.
         /// A null or empty CoordinateSequence creates an empty LineString.
         /// </summary>
@@ -427,6 +438,19 @@ namespace NetTopologySuite.Geometries
         public LinearRing CreateLinearRing(Coordinate[] coordinates)
         {
             return CreateLinearRing(coordinates != null ? CoordinateSequenceFactory.Create(coordinates) : null);
+        }
+
+        /// <summary>
+        /// Creates a <c>LinearRing</c> using the given <c>Coordinates</c>; an empty span
+        /// creates an empty LinearRing. The points must form a closed and simple
+        /// linestring. Consecutive points must not be equal.
+        /// </summary>
+        /// <param name="coordinates">A span of coordinates without null elements, or an empty span.</param>
+        /// <returns>A <see cref="LinearRing"/> object</returns>
+        /// <exception cref="ArgumentException"> If the ring is not closed, or has too few points</exception>
+        public LinearRing CreateLinearRing(ReadOnlySpan<Coordinate> coordinates)
+        {
+            return CreateLinearRing(CoordinateSequenceFactory.Create(coordinates));
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/CoordinateArraySequenceFactory.cs
@@ -25,6 +25,16 @@ namespace NetTopologySuite.Geometries.Implementation
             return new CoordinateArraySequence(coordinates);
         }
 
+        /// <summary>
+        ///  Returns a CoordinateArraySequence based on the given span of coordinates (the values are copied).
+        /// </summary>
+        /// <param name="coordinates">the coordinates, which may not contain null elements.</param>
+        /// <returns></returns>
+        public override CoordinateSequence Create(ReadOnlySpan<Coordinate> coordinates)
+        {
+            return new CoordinateArraySequence(coordinates.ToArray());
+        }
+
         /// <inheritdoc cref="CoordinateSequenceFactory.Create(CoordinateSequence)"/>
         public override CoordinateSequence Create(CoordinateSequence coordSeq)
         {

--- a/src/NetTopologySuite/Geometries/Implementation/DotSpatialAffineCoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/DotSpatialAffineCoordinateSequenceFactory.cs
@@ -32,6 +32,16 @@ namespace NetTopologySuite.Geometries.Implementation
         }
 
         /// <summary>
+        ///  Returns a CoordinateArraySequence based on the given span of coordinates.
+        /// </summary>
+        /// <param name="coordinates">the coordinates, which may not contain null elements.</param>
+        /// <returns></returns>
+        public override CoordinateSequence Create(ReadOnlySpan<Coordinate> coordinates)
+        {
+            return new DotSpatialAffineCoordinateSequence(coordinates.ToArray(), Ordinates);
+        }
+
+        /// <summary>
         /// Creates a <see cref="CoordinateSequence" />  which is a copy
         /// of the given <see cref="CoordinateSequence" />.
         /// This method must handle null arguments by creating an empty sequence.

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequence.cs
@@ -242,12 +242,9 @@ namespace NetTopologySuite.Geometries.Implementation
             _coords = new double[size * Dimension];
         }
 
-        internal PackedDoubleCoordinateSequence(Coordinate[] coords, int dimension, int measures, bool dimensionAndMeasuresCameFromCoords)
-            : base(coords?.Length ?? 0, dimension, measures)
+        internal PackedDoubleCoordinateSequence(ReadOnlySpan<Coordinate> coords, int dimension, int measures, bool dimensionAndMeasuresCameFromCoords)
+            : base(coords.Length, dimension, measures)
         {
-            if (coords == null)
-                coords = Array.Empty<Coordinate>();
-
             _coords = new double[coords.Length * Dimension];
             if (coords.Length == 0)
             {
@@ -464,12 +461,9 @@ namespace NetTopologySuite.Geometries.Implementation
             _coords = new float[size * Dimension];
         }
 
-        internal PackedFloatCoordinateSequence(Coordinate[] coords, int dimension, int measures, bool dimensionAndMeasuresCameFromCoords)
-            : base(coords?.Length ?? 0, dimension, measures)
+        internal PackedFloatCoordinateSequence(ReadOnlySpan<Coordinate> coords, int dimension, int measures, bool dimensionAndMeasuresCameFromCoords)
+            : base(coords.Length, dimension, measures)
         {
-            if (coords == null)
-                coords = Array.Empty<Coordinate>();
-
             _coords = new float[coords.Length * Dimension];
             if (coords.Length == 0)
             {

--- a/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequenceFactory.cs
+++ b/src/NetTopologySuite/Geometries/Implementation/PackedCoordinateSequenceFactory.cs
@@ -80,6 +80,17 @@ namespace NetTopologySuite.Geometries.Implementation
         /// <returns></returns>
         public override CoordinateSequence Create(Coordinate[] coordinates)
         {
+            return Create((ReadOnlySpan<Coordinate>)coordinates);
+        }
+
+        /// <summary>
+        /// Returns a CoordinateSequence based on the given span; whether or not the
+        /// values are copied is implementation-dependent.
+        /// </summary>
+        /// <param name="coordinates">A span of coordinates, which may not contain null elements</param>
+        /// <returns></returns>
+        public override CoordinateSequence Create(ReadOnlySpan<Coordinate> coordinates)
+        {
             // DEVIATION: JTS just uses the first coordinate, which can be lossy.
             (_, int dimension, int measures) = GetCommonSequenceParameters(coordinates);
             if (_type == PackedType.Double)

--- a/test/NetTopologySuite.Benchmark/CoordinateSequenceFactoryOverrideBenchmarks.cs
+++ b/test/NetTopologySuite.Benchmark/CoordinateSequenceFactoryOverrideBenchmarks.cs
@@ -1,0 +1,51 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
+
+namespace NetTopologySuite.Benchmark
+{
+    /// <summary>
+    /// A factory that does not override <see cref="CoordinateSequenceFactory.Create(ReadOnlySpan{Coordinate})"/>,
+    /// so it exercises the generic <c>SetOrdinate</c>-based loop in the base class -- the code path used
+    /// before the built-in factories gained specialized span overrides.
+    /// </summary>
+    internal sealed class GenericFallbackCoordinateSequenceFactory : CoordinateSequenceFactory
+    {
+        private readonly PackedCoordinateSequenceFactory _inner = PackedCoordinateSequenceFactory.DoubleFactory;
+
+        public override CoordinateSequence Create(int size, int dimension, int measures) =>
+            _inner.Create(size, dimension, measures);
+    }
+
+    /// <summary>
+    /// Compares the generic base-class <c>Create(ReadOnlySpan&lt;Coordinate&gt;)</c> implementation
+    /// against <see cref="PackedCoordinateSequenceFactory"/>'s specialized override, for equivalent input.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class CoordinateSequenceFactoryOverrideBenchmarks
+    {
+        private Coordinate[] _coordinates;
+        private readonly GenericFallbackCoordinateSequenceFactory _generic = new GenericFallbackCoordinateSequenceFactory();
+        private readonly PackedCoordinateSequenceFactory _packed = PackedCoordinateSequenceFactory.DoubleFactory;
+
+        [Params(10, 100, 1000)]
+        public int Count { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _coordinates = new Coordinate[Count];
+            for (int i = 0; i < Count; i++)
+            {
+                _coordinates[i] = new Coordinate(i, i * 2);
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public int GenericBaseImplementation() => _generic.Create((ReadOnlySpan<Coordinate>)_coordinates).Count;
+
+        [Benchmark]
+        public int SpecializedPackedOverride() => _packed.Create((ReadOnlySpan<Coordinate>)_coordinates).Count;
+    }
+}

--- a/test/NetTopologySuite.Benchmark/CoordinateSequenceFactorySliceBenchmarks.cs
+++ b/test/NetTopologySuite.Benchmark/CoordinateSequenceFactorySliceBenchmarks.cs
@@ -1,0 +1,56 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
+
+namespace NetTopologySuite.Benchmark
+{
+    /// <summary>
+    /// Compares building a <see cref="CoordinateSequence"/> from a slice of a larger array using
+    /// the new <see cref="CoordinateSequenceFactory.Create(ReadOnlySpan{Coordinate})"/> overload
+    /// against the previous approach of materializing an intermediate array first
+    /// (<see cref="CoordinateArrays.Extract(Coordinate[], int, int)"/>).
+    /// </summary>
+    [MemoryDiagnoser]
+    public class CoordinateSequenceFactorySliceBenchmarks
+    {
+        private Coordinate[] _coordinates;
+
+        [Params(10, 100, 1000)]
+        public int SliceLength { get; set; }
+
+        [ParamsSource(nameof(Factories))]
+        public CoordinateSequenceFactory Factory { get; set; }
+
+        public static CoordinateSequenceFactory[] Factories { get; } =
+        {
+            CoordinateArraySequenceFactory.Instance,
+            PackedCoordinateSequenceFactory.DoubleFactory,
+            DotSpatialAffineCoordinateSequenceFactory.Instance,
+        };
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _coordinates = new Coordinate[SliceLength + 20];
+            for (int i = 0; i < _coordinates.Length; i++)
+            {
+                _coordinates[i] = new Coordinate(i, i * 2);
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public int ExtractThenCreate()
+        {
+            var extracted = CoordinateArrays.Extract(_coordinates, 10, 10 + SliceLength - 1);
+            return Factory.Create(extracted).Count;
+        }
+
+        [Benchmark]
+        public int CreateFromSpan()
+        {
+            var span = new ReadOnlySpan<Coordinate>(_coordinates, 10, SliceLength);
+            return Factory.Create(span).Count;
+        }
+    }
+}

--- a/test/NetTopologySuite.Benchmark/GeometryFactoryLineStringBenchmarks.cs
+++ b/test/NetTopologySuite.Benchmark/GeometryFactoryLineStringBenchmarks.cs
@@ -1,0 +1,46 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Benchmark
+{
+    /// <summary>
+    /// Compares creating a <see cref="LineString"/> from a slice of a larger coordinate array using
+    /// <see cref="GeometryFactory.CreateLineString(ReadOnlySpan{Coordinate})"/> against the previous
+    /// approach of materializing an intermediate array first.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class GeometryFactoryLineStringBenchmarks
+    {
+        private Coordinate[] _coordinates;
+        private GeometryFactory _factory;
+
+        [Params(10, 100, 1000)]
+        public int PointCount { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _coordinates = new Coordinate[PointCount + 20];
+            for (int i = 0; i < _coordinates.Length; i++)
+            {
+                _coordinates[i] = new Coordinate(i, i * 2);
+            }
+
+            _factory = NtsGeometryServices.Instance.CreateGeometryFactory();
+        }
+
+        [Benchmark(Baseline = true)]
+        public int ExtractThenCreateLineString()
+        {
+            var slice = CoordinateArrays.Extract(_coordinates, 10, 10 + PointCount - 1);
+            return _factory.CreateLineString(slice).NumPoints;
+        }
+
+        [Benchmark]
+        public int CreateLineStringFromSpan()
+        {
+            return _factory.CreateLineString(new ReadOnlySpan<Coordinate>(_coordinates, 10, PointCount)).NumPoints;
+        }
+    }
+}

--- a/test/NetTopologySuite.Benchmark/NetTopologySuite.Benchmark.csproj
+++ b/test/NetTopologySuite.Benchmark/NetTopologySuite.Benchmark.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>NetTopologySuite.Benchmark</RootNamespace>
+    <ContainsNUnitTests>false</ContainsNUnitTests>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)src\NetTopologySuite\NetTopologySuite.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/NetTopologySuite.Benchmark/Program.cs
+++ b/test/NetTopologySuite.Benchmark/Program.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryFactoryTest.cs
@@ -42,6 +42,20 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         }
 
         [Test]
+        public void TestCreateLineStringFromSpan()
+        {
+            var coordinates = new[] { new Coordinate(0, 0), new Coordinate(10, 10) };
+
+            var fromArray = Factory.CreateLineString(coordinates);
+            var fromSpan = Factory.CreateLineString(new ReadOnlySpan<Coordinate>(coordinates));
+
+            Assert.That(fromSpan.EqualsExact(fromArray));
+            Assert.That(fromSpan.Factory, Is.SameAs(Factory));
+
+            Assert.That(Factory.CreateLineString(ReadOnlySpan<Coordinate>.Empty).IsEmpty);
+        }
+
+        [Test]
         public virtual void TestCreateGeometry()
         {
             CheckCreateGeometryExact("POINT EMPTY");


### PR DESCRIPTION
## Summary

Addresses #853 (request for `ReadOnlySpan<Coordinate>` overloads to avoid unnecessary array allocations), while keeping geometry creation flowing through the owning `GeometryFactory` rather than a hardcoded default factory as originally suggested in the issue.

## Changes

- `CoordinateSequenceFactory`: added `Create(ReadOnlySpan<Coordinate>)` and `GetCommonSequenceParameters(ReadOnlySpan<Coordinate>)`. The existing `Coordinate[]` overloads now forward to the span versions (arrays convert implicitly), removing duplicated logic.
- `GeometryFactory`: added `CreateLineString(ReadOnlySpan<Coordinate>)` and `CreateLinearRing(ReadOnlySpan<Coordinate>)`.
- `CoordinateArraySequenceFactory`, `PackedCoordinateSequenceFactory`, `DotSpatialAffineCoordinateSequenceFactory`: each now overrides the span overload with a specialized implementation instead of falling back to the generic `SetOrdinate`-loop in the base class.
- The internal `PackedDoubleCoordinateSequence`/`PackedFloatCoordinateSequence` constructors now accept `ReadOnlySpan<Coordinate>` instead of `Coordinate[]` (these are `internal`, so this is not a breaking change), avoiding an extra array allocation when a caller already has a span.

All changes are additive/non-breaking. Existing `Coordinate[]`-based call sites are unaffected (arrays convert to spans at zero cost).

## Testing

- `dotnet build` succeeds for both `netstandard2.0` and `netstandard2.1`.
- Full `NetTopologySuite.Tests.NUnit` suite passes (2570 passed, 0 failed, 25 skipped).
- Added `GeometryFactoryTest.TestCreateLineStringFromSpan` verifying parity between the array and span overloads.


## AI disclosure

This PR (code changes, commit message, and this description) was produced with the assistance of an AI coding agent (GitHub Copilot), based on investigation of #853, and reviewed by me before submission.


## Benchmarks

Added a `test/NetTopologySuite.Benchmark` project (BenchmarkDotNet) comparing the new `ReadOnlySpan<Coordinate>` path against the previous "extract a sub-array first" approach. Run with:

```
dotnet run --project test/NetTopologySuite.Benchmark/NetTopologySuite.Benchmark.csproj -c Release
```

Environment: .NET 10.0.11, Ubuntu 26.04, AMD Ryzen 7 PRO 8840U (ShortRun job: 3 iterations/3 warmup, for quick turnaround — not a full statistically-rigorous run).

### Generic base-class loop vs specialized `PackedCoordinateSequenceFactory` override

Confirms the value of giving each built-in factory its own `Create(ReadOnlySpan<Coordinate>)` override instead of relying on the base class's per-ordinate `SetOrdinate` loop:

| Method                     | Count | Mean       | Ratio | Allocated |
|--------------------------- |------ |-----------:|------:|----------:|
| GenericBaseImplementation  | 10    |    98.5 ns |  1.00 |     248 B |
| SpecializedPackedOverride  | 10    |    61.1 ns |  0.62 |     248 B |
| GenericBaseImplementation  | 100   |   899.1 ns |  1.00 |    1688 B |
| SpecializedPackedOverride  | 100   |   599.1 ns |  0.67 |    1688 B |
| GenericBaseImplementation  | 1000  | 9,322.7 ns |  1.00 |   16088 B |
| SpecializedPackedOverride  | 1000  | 5,376.1 ns |  0.58 |   16088 B |

~35-40% faster, same allocations (as expected — this comparison isolates CPU cost, not allocations).

### Extract-then-create vs `Create(ReadOnlySpan<Coordinate>)`, per built-in factory

Slices 10/100/1000 coordinates out of a larger array, either via `CoordinateArrays.Extract` (old approach) or directly via the new span overload:

| Factory                                 | Alloc Ratio (span vs extract) |
|----------------------------------------- |:-----------------------------:|
| `CoordinateArraySequenceFactory`          | 1.00 (no change)              |
| `DotSpatialAffineCoordinateSequenceFactory` | 1.00 (no change)            |
| `PackedCoordinateSequenceFactory`          | ~0.67-0.70 (30-33% less)       |

`CoordinateArraySequenceFactory` and `DotSpatialAffineCoordinateSequenceFactory` still need to materialize an owned `Coordinate[]`/internal array, so slicing doesn't reduce allocations for them. `PackedCoordinateSequenceFactory` benefits directly since it can build its packed `double[]`/`float[]` straight from the span, skipping the intermediate `Coordinate[]` entirely.

### `GeometryFactory.CreateLineString`, default factory (`CoordinateArraySequenceFactory`)

| PointCount | ExtractThenCreateLineString | CreateLineStringFromSpan | Alloc Ratio |
|-----------:|----------------------------:|-------------------------:|:-----------:|
| 10         | 56.1 ns / 208 B              | 55.0 ns / 208 B           | 1.00        |
| 100        | 344.8 ns / 928 B             | 355.4 ns / 928 B          | 1.00        |
| 1000       | 3,445.9 ns / 8128 B          | 4,048.9 ns / 8128 B       | 1.00        |

No allocation win here (same reasoning as above — the default `CoordinateArraySequenceFactory` needs its own array either way) and the span overload is not consistently faster at this call level; the real gains are for `PackedCoordinateSequenceFactory` and for the internal `SetOrdinate`-loop avoidance shown above.
