### PR TITLE
Fix PrecisionUtility.NumberOfDecimals fast path for .NET 11 decimal/double conversion change

### DIFF
--- a/src/NetTopologySuite/Operation/OverlayNG/PrecisionUtility.cs
+++ b/src/NetTopologySuite/Operation/OverlayNG/PrecisionUtility.cs
@@ -274,7 +274,22 @@ namespace NetTopologySuite.Operation.OverlayNG
                     // https://github.com/dotnet/runtime/blob/cd4cc97e4c099f637061afe2b6c546483ffd3073/src/libraries/System.Private.CoreLib/src/System/Decimal.cs#L104-L108
                     // so we can rely on the scale living at the same spot:
                     // https://github.com/dotnet/runtime/blob/cd4cc97e4c099f637061afe2b6c546483ffd3073/src/libraries/System.Private.CoreLib/src/System/Decimal.cs#L70-L76
-                    return ((byte*)&valueAsDecimal)[BitConverter.IsLittleEndian ? 2 : 1];
+                    int scale = ((byte*)&valueAsDecimal)[BitConverter.IsLittleEndian ? 2 : 1];
+
+                    // The scale above is only an upper bound on the number of decimal places
+                    // actually needed to round-trip back to the same double: the conversion above
+                    // is not guaranteed to produce the minimal round-tripping scale even when one
+                    // exists (dotnet/runtime#42775), and .NET 11 changed double-to-decimal
+                    // conversions to favor exactness over brevity (dotnet/runtime#131135), which can
+                    // inflate the scale considerably for large-magnitude values. Trim off any
+                    // trailing digits that aren't actually needed for the round trip; this is a
+                    // no-op (0 extra iterations) for values whose initial scale was already minimal.
+                    while (scale > 0 && value == (double)Math.Round(valueAsDecimal, scale - 1))
+                    {
+                        scale--;
+                    }
+
+                    return scale;
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixes #856.

.NET 11 changed `decimal`↔`double` conversions to be "correct" (round-trip
faithful) rather than favoring the shortest/nicest decimal representation
(see [dotnet/runtime#131135](https://github.com/dotnet/runtime/issues/131135),
[dotnet/runtime#130566](https://github.com/dotnet/runtime/pull/130566)).

`PrecisionUtility.NumberOfDecimals`'s fast path casts a `double` to `decimal`
and extracts the decimal's `Scale` byte directly to determine "the number of
decimal places represented in the double". That scale was never *guaranteed*
to be minimal (the existing comment already references
[dotnet/runtime#42775](https://github.com/dotnet/runtime/issues/42775)), it
just empirically was on older runtimes. On .NET 11, the scale can be
significantly inflated for large-magnitude values (e.g. reporting 27-28
decimal places instead of the true/minimal ~5-15), which breaks
`PrecisionUtilityTest` (`InherentScale`/`SafeScale` compute wildly wrong
scale factors) when targeting `net11.0`.

## Fix

Instead of trusting the decimal conversion's scale outright, treat it as an
upper bound and trim off any trailing decimal digits that aren't actually
needed to round-trip back to the original `double`. For inputs where the
initial scale was already minimal (all currently-supported runtimes), this
adds zero extra iterations, so there's no performance regression there. For
runtimes/values where the initial scale is inflated, this does a handful of
extra `decimal` rounding + comparison operations (still much cheaper than the
string-formatting slow path).

## Testing

Verified locally with the .NET 11 preview SDK (`11.0.100-preview.7.26381.103`)
by temporarily retargeting the test projects to `net11.0`:
- Before this fix: 9 failures in `PrecisionUtilityTest` under `net11.0`.
- After this fix: all tests pass under both `net10.0` and `net11.0`
  (`dotnet test test/NetTopologySuite.Tests.NUnit -c Release`, filtering out
  `LongRunning`/`Stress`/`FailureCase` categories as CI does).

## AI disclosure

Per [AI_POLICY.md](https://github.com/NetTopologySuite/NetTopologySuite/blob/develop/AI_POLICY.md):
this PR (root-cause investigation, the fix itself, and local .NET 11 preview
testing) was produced with AI assistance (GitHub Copilot, agent mode). I
reviewed and take full responsibility for the change.
