### PR TITLE
Make HalfEdge.CompareAngularDirection / Quadrant computation more robust (JTS #1224, #1226)

### DIFF
--- a/src/NetTopologySuite/Algorithm/PolygonNodeTopology.cs
+++ b/src/NetTopologySuite/Algorithm/PolygonNodeTopology.cs
@@ -133,8 +133,8 @@ namespace NetTopologySuite.Algorithm
         /// <returns><c>true</c> if vector P has angle greater than Q</returns>
         private static bool IsAngleGreater(Coordinate origin, Coordinate p, Coordinate q)
         {
-            var quadrantP = Quadrant(origin, p);
-            var quadrantQ = Quadrant(origin, q);
+            var quadrantP = new Quadrant(origin, p);
+            var quadrantQ = new Quadrant(origin, q);
 
             /*
              * If the vectors are in different quadrants, 
@@ -163,8 +163,8 @@ namespace NetTopologySuite.Algorithm
         /// </returns>
         public static int CompareAngle(Coordinate origin, Coordinate p, Coordinate q)
         {
-            var quadrantP = Quadrant(origin, p);
-            var quadrantQ = Quadrant(origin, q);
+            var quadrantP = new Quadrant(origin, p);
+            var quadrantQ = new Quadrant(origin, q);
 
             /*
              * If the vectors are in different quadrants, 
@@ -183,14 +183,6 @@ namespace NetTopologySuite.Algorithm
                 case OrientationIndex.Clockwise: return -1;
                 default: return 0;
             }
-        }
-
-
-        private static Quadrant Quadrant(Coordinate origin, Coordinate p)
-        {
-            double dx = p.X - origin.X;
-            double dy = p.Y - origin.Y;
-            return new Quadrant(dx, dy);
         }
 
     }

--- a/src/NetTopologySuite/EdgeGraph/HalfEdge.cs
+++ b/src/NetTopologySuite/EdgeGraph/HalfEdge.cs
@@ -403,17 +403,13 @@ namespace NetTopologySuite.EdgeGraph
         /// </remarks>
         public int CompareAngularDirection(HalfEdge e)
         {
-            double dx = DirectionX;
-            double dy = DirectionY;
-            double dx2 = e.DirectionX;
-            double dy2 = e.DirectionY;
-
+            // assert: orig() == e.orig()
             // same vector
-            if (dx == dx2 && dy == dy2)
+            if (DirectionPt.Equals2D(e.DirectionPt))
                 return 0;
 
-            var quadrant = new Quadrant(dx, dy);
-            var quadrant2 = new Quadrant(dx2, dy2);
+            var quadrant = new Quadrant(Orig, DirectionPt);
+            var quadrant2 = new Quadrant(e.Orig, e.DirectionPt);
 
             /*
              * if the vectors are in different quadrants,

--- a/src/NetTopologySuite/Geometries/Quadrant.cs
+++ b/src/NetTopologySuite/Geometries/Quadrant.cs
@@ -60,6 +60,10 @@ namespace NetTopologySuite.Geometries
         /// Creates a quadrant of a directed line segment (specified as x and y
         /// displacements, which cannot both be 0).
         /// </summary>
+        /// <remarks>
+        /// If the segment coordinates are available it is more robust
+        /// to use <see cref="Quadrant(Coordinate, Coordinate)"/>.
+        /// </remarks>
         /// <param name="dx"></param>
         /// <param name="dy"></param>
         /// <exception cref="ArgumentException">If the displacements are both 0</exception>
@@ -77,6 +81,10 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Returns the quadrant of a directed line segment from p0 to p1.
         /// </summary>
+        /// <remarks>
+        /// This method is more robust than <see cref="Quadrant(double, double)"/>
+        /// if using that requires subtractions to compute vector components.
+        /// </remarks>
         /// <param name="p0"></param>
         /// <param name="p1"></param>
         /// <exception cref="ArgumentException"> if the points are equal</exception>

--- a/src/NetTopologySuite/GeometriesGraph/EdgeEnd.cs
+++ b/src/NetTopologySuite/GeometriesGraph/EdgeEnd.cs
@@ -71,9 +71,9 @@ namespace NetTopologySuite.GeometriesGraph
         {
             _p0 = p0;
             _p1 = p1;
+            _quadrant = new Quadrant(p0, p1);
             _dx = p1.X - p0.X;
             _dy = p1.Y - p0.Y;
-            _quadrant = new Quadrant(_dx, _dy);
             Assert.IsTrue(! (_dx == 0 && _dy == 0), "EdgeEnd with identical endpoints found");
         }
 

--- a/src/NetTopologySuite/Planargraph/DirectedEdge.cs
+++ b/src/NetTopologySuite/Planargraph/DirectedEdge.cs
@@ -63,9 +63,9 @@ namespace NetTopologySuite.Planargraph
             this.EdgeDirection = edgeDirection;
             p0 = from.Coordinate;
             p1 = directionPt;
+            _quadrant = new Quadrant(p0, p1);
             double dx = p1.X - p0.X;
             double dy = p1.Y - p0.Y;
-            _quadrant = new Quadrant(dx, dy);
             _angle = Math.Atan2(dy, dx);
         }
 

--- a/test/NetTopologySuite.Tests.NUnit/EdgeGraph/EdgeGraphTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/EdgeGraph/EdgeGraphTest.cs
@@ -85,6 +85,35 @@ namespace NetTopologySuite.Tests.NUnit.EdgeGraph
             CheckNodeValid(e1);
         }
 
+        /// <summary>
+        /// Tests that <see cref="HalfEdge.CompareAngularDirection"/> is robust against
+        /// roundoff error when comparing near-collinear direction vectors, and that the
+        /// comparison is antisymmetric.
+        /// </summary>
+        /// <remarks>
+        /// Ported from JTS commit
+        /// <see href="https://github.com/locationtech/jts/commit/a3927e635dfae12853f423db2ee137905f94f1a1"/>
+        /// (JTS locationtech/jts#1224)
+        /// </remarks>
+        [Test]
+        public void TestCompareRobust_JTS1224()
+        {
+            var graph = new NetTopologySuite.EdgeGraph.EdgeGraph();
+            var e1 = AddEdge(graph, 1, 1, 0, 0.5);
+            AddEdge(graph, 1, 1, 0, 0.49999999999999994);
+            AddEdge(graph, 1, 1, 0, 1);
+
+            var eUpper = FindEdge(graph, 1, 1, 0, 0.5);
+            var eLower = FindEdge(graph, 1, 1, 0, 0.49999999999999994);
+            Assert.That(eUpper.CompareTo(eLower), Is.Not.EqualTo(0),
+                "edges with distinct direction points must not compare equal");
+            Assert.That(eUpper.CompareTo(eLower), Is.EqualTo(-eLower.CompareTo(eUpper)),
+                "edge comparison must be antisymmetric");
+
+            CheckNodeValid(e1);
+            CheckNextPrev(graph);
+        }
+
         //==================================================
 
         private static void CheckEdgeRing(EGraph graph, Coordinate p, Coordinate[] dest)


### PR DESCRIPTION
Closes #864.

Ports JTS commits [`a3927e635`](https://github.com/locationtech/jts/commit/a3927e635dfae12853f423db2ee137905f94f1a1) (#1224) and [`bc1be3d42`](https://github.com/locationtech/jts/commit/bc1be3d420005de2e402bf2e1daa6f8989557626) (#1226).

## Problem
Several call sites computed a direction vector `(dx, dy)` via subtraction before determining its `Quadrant` and/or comparing it for equality. The subtraction can introduce roundoff error, so two direction points that are extremely close (but distinct) can end up comparing as equal / same quadrant when they shouldn't — breaking the total order that `HalfEdge.CompareAngularDirection` (and `IComparable`) are supposed to provide.

## Fix
NTS's `Quadrant` struct already has the endpoint-based constructor `Quadrant(Coordinate p0, Coordinate p1)` (JTS added the equivalent overload in an earlier PR), so this is a call-site-only port:

- `HalfEdge.CompareAngularDirection`: compare `DirectionPt` for equality directly (`Equals2D`) instead of comparing derived `(dx, dy)`, and derive quadrants from `(Orig, DirectionPt)` endpoints instead of `(dx, dy)`.
- `PolygonNodeTopology`: removed the private dx/dy-based `Quadrant(...)` helper, call sites now use `new Quadrant(origin, p)` directly.
- `GeometriesGraph.EdgeEnd.Init`: compute `_quadrant` from `(p0, p1)` *before* computing `_dx`/`_dy`.
- `Planargraph.DirectedEdge` constructor: compute `_quadrant` from `(p0, p1)` before computing `dx`/`dy`.

`GeometriesGraph.DirectedEdge` inherits from `EdgeEnd` and needed no separate change.

## Tests
Ported JTS's regression test as `TestCompareRobust_JTS1224` in `EdgeGraphTest.cs` — adds three near-collinear edges (`(0, 0.5)`, `(0, 0.49999999999999994)`, `(0, 1)`) from a common origin and asserts the two closest direction points don't compare equal and the comparison is antisymmetric.

Verified this test **fails with the old dx/dy-based algorithm** (`eUpper.CompareTo(eLower)` returns `0` instead of a non-zero value) and passes with the fix.

Full `EdgeGraph`/`Planargraph`/`PolygonNodeTopology`/`Overlay`/`RelateNG`/`Noding` test suites: 521 passed, 12 pre-existing skips, 0 failures.

---
**AI disclosure:** This fix was ported and this PR prepared with AI assistance (GitHub Copilot CLI), based on a direct diff against JTS commits a3927e635 and bc1be3d42. Please review before merging.