### PR TITLE
Improve BufferOp robustness for artifacts and invalid coordinates (JTS #1161, #1165)

### DIFF
--- a/src/NetTopologySuite/Operation/Buffer/BufferBuilder.cs
+++ b/src/NetTopologySuite/Operation/Buffer/BufferBuilder.cs
@@ -137,8 +137,43 @@ namespace NetTopologySuite.Operation.Buffer
                 return CreateEmptyResultGeometry();
             }
 
+            /*
+             * Heuristic to remove artifacts caused by topology robustness problems
+             * or buffer curve generation anomalies.
+             * Uses fact that for distance > 0 single-element inputs must create single element buffers.
+             * This does not hold if distance <= 0;
+             * distance = 0 can create multipolygon results due to topology collapse,
+             * and distance < 0 may erode polygons so they are disconnected.
+             */
+            if (distance > 0 && g.NumGeometries == 1 && resultPolyList.Count > 1)
+            {
+                resultPolyList = KeepLargestArea(resultPolyList);
+            }
+
             var resultGeom = _geomFact.BuildGeometry(resultPolyList);
             return resultGeom;
+        }
+
+        private static IList<Geometry> KeepLargestArea(IList<Geometry> polyList)
+        {
+            var largest = FindLargestArea(polyList);
+            return new List<Geometry> { largest };
+        }
+
+        private static Geometry FindLargestArea(IList<Geometry> polyList)
+        {
+            double largestArea = 0;
+            Geometry largest = null;
+            foreach (var poly in polyList)
+            {
+                double polyArea = poly.Area;
+                if (largest == null || polyArea > largestArea)
+                {
+                    largest = poly;
+                    largestArea = polyArea;
+                }
+            }
+            return largest;
         }
 
         private INoder GetNoder(PrecisionModel precisionModel, ElevationModel em)

--- a/src/NetTopologySuite/Operation/Buffer/BufferCurveSetBuilder.cs
+++ b/src/NetTopologySuite/Operation/Buffer/BufferCurveSetBuilder.cs
@@ -166,6 +166,11 @@ namespace NetTopologySuite.Operation.Buffer
             if (_curveBuilder.IsLineOffsetEmpty(_distance)) return;
 
             var coord = Clean(line.Coordinates);
+
+            // skip if no valid coordinates
+            if (coord.Length == 0)
+                return;
+
             /*
              * Rings (closed lines) are generated with a continuous curve, 
              * with no end arcs. This produces better quality linework, 
@@ -210,10 +215,16 @@ namespace NetTopologySuite.Operation.Buffer
 
             var shell = p.Shell;
             var shellCoord = Clean(shell.Coordinates);
+
+            // skip if no valid coordinates
+            if (shellCoord.Length == 0)
+                return;
+
             // optimization - don't compute buffer
             // if the polygon would be completely eroded
             if (_distance < 0.0 && IsRingFullyEroded(shellCoord, shell.EnvelopeInternal, false, _distance))
                 return;
+
             // don't attempt to buffer a polygon with too few distinct vertices
             if (_distance <= 0.0 && shellCoord.Length < 3)
                 return;
@@ -225,6 +236,10 @@ namespace NetTopologySuite.Operation.Buffer
             {
                 var hole = (LinearRing)p.GetInteriorRingN(i);
                 var holeCoord = Clean(hole.Coordinates);
+
+                // skip if no valid coordinates
+                if (holeCoord.Length == 0)
+                    continue;
 
                 // optimization - don't compute buffer for this hole
                 // if the hole would be completely covered

--- a/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/BufferTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/BufferTest.cs
@@ -841,6 +841,98 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Buffer
                 "POLYGON ((48267.2218198241 -49049.37231112561, 44430.1 -55696.500291383236, 44430.1 -55107.58561879013, 44506.96594366424 -54974.50014155032, 44507.05088958367 -54974.309530288774, 44507.09442572395 -54974.10543945913, 44507.09465615313 -54973.896756903174, 44507.05157083636 -54973.69257042533, 44506.96704607295 -54973.50177203271, 44430.1 -54839.73314639927, 44430.1 -51569.2, 44430.08071956347 -51569.00457958696, 44430.02362172434 -51568.81669475566, 44429.93090822513 -51568.64359050924, 44429.80615417933 -51568.49194189856, 42172.42282165639 -49317.178566110095, 48267.2218198241 -49049.37231112561))");
         }
 
+        /// <summary>
+        /// Buffering a single-element LineString can produce spurious small extra
+        /// polygons due to topology robustness problems or curve generation anomalies.
+        /// The result should still be a single polygon.
+        /// </summary>
+        /// <remarks>
+        /// Ported from JTS commit
+        /// <see href="https://github.com/locationtech/jts/commit/727943b68cc36a9e395c28bfea9b40b720a4f971"/>
+        /// (JTS locationtech/jts#1161). See also https://github.com/libgeos/geos/issues/1321.
+        /// </remarks>
+        [Test]
+        public void TestArtifactsRemovedFromLineBuffer_JTS1161()
+        {
+            const string wkt = "LINESTRING (640734.77510795 216861.236982439, 640733.832969266 216862.938074642, 640732.814325629 216865.039674844, 640731.225095251 216869.012141189, 640729.979984761 216871.879095724, 640729.445974092 216873.02148841, 640729.002794006 216873.679857725, 640728.952197105 216873.745389857, 640728.676962154 216874.089814544)";
+            CheckBufferNumGeometries(wkt, 100, 1);
+        }
+
+        /// <inheritdoc cref="TestArtifactsRemovedFromLineBuffer_JTS1161"/>
+        /// <remarks>See also https://github.com/r-spatial/sf/issues/2552.</remarks>
+        [Test]
+        public void TestArtifactsRemovedFromLineBufferFlatEnd_JTS1161()
+        {
+            const string wkt = "LINESTRING (245184.6 6045650, 245193.3 6045649, 245201.7 6045651, 245204.3 6045653)";
+            var geom = Read(wkt);
+            var param = new BufferParameters { EndCapStyle = EndCapStyle.Flat };
+            var buf = BufferOp.Buffer(geom, 50, param);
+            Assert.That(buf.NumGeometries, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Buffering geometries whose coordinate list becomes empty after removing
+        /// invalid ordinates (NaN/Infinite) should produce an empty result,
+        /// instead of throwing or crashing.
+        /// </summary>
+        /// <remarks>
+        /// Ported from JTS commit
+        /// <see href="https://github.com/locationtech/jts/commit/fc9ed7dcb8921e7262633674e817a4f08a4ace25"/>
+        /// (JTS locationtech/jts#1165)
+        /// </remarks>
+        [Test]
+        public void TestInvalidCoordPoint_JTS1165()
+        {
+            var geom = Read("POINT (NaN NaN)");
+            CheckBufferPolygonEmpty(geom, 1, true);
+        }
+
+        [Test]
+        public void TestInvalidCoordsLine_JTS1165()
+        {
+            var geom = Read("LINESTRING (NaN NaN, NaN NaN)");
+            CheckBufferPolygonEmpty(geom, 1, true);
+        }
+
+        [Test]
+        public void TestInvalidCoordShell_JTS1165()
+        {
+            // using Inf ordinates creates a valid ring with equal endpoints
+            var geom = GeometryFactory.CreatePolygon(InfCoords(5));
+            CheckBufferPolygonEmpty(geom, 1, true);
+        }
+
+        [Test]
+        public void TestInvalidCoordHole_JTS1165()
+        {
+            var poly = (Polygon)Read("POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (3 7, 7 7, 7 3, 3 3, 3 7))");
+
+            var shell = poly.Shell;
+            var hole = (LinearRing)poly.GetInteriorRingN(0);
+            var infHole = GeometryFactory.CreateLinearRing(InfCoords(5));
+            var polyInfHole = GeometryFactory.CreatePolygon(shell, new[] { hole, infHole });
+
+            var bufferOrig = poly.Buffer(1);
+            var bufferInf = polyInfHole.Buffer(1);
+            // buffers should be same since inf hole is skipped
+            CheckEqual(bufferOrig, bufferInf);
+        }
+
+        private static Coordinate[] InfCoords(int size)
+        {
+            var coords = new Coordinate[size];
+            for (int i = 0; i < size; i++)
+                coords[i] = new Coordinate(double.PositiveInfinity, double.PositiveInfinity);
+            return coords;
+        }
+
+        private void CheckBufferPolygonEmpty(Geometry geom, double dist, bool isEmptyExpected)
+        {
+            var result = geom.Buffer(dist);
+            Assert.That(result, Is.InstanceOf<Polygon>());
+            Assert.That(result.IsEmpty, Is.EqualTo(isEmptyExpected));
+        }
+
         //===================================================
 
         private static BufferParameters BufParamRoundMitre(double mitreLimit)


### PR DESCRIPTION
## Summary

Two robustness fixes ported from JTS's buffer operation:

### 1. Artifact removal heuristic for single-element inputs (JTS #1161)

Topology robustness problems or buffer curve generation anomalies can occasionally produce spurious small extra polygons ("artifacts") when buffering a geometry. Since a single-element input geometry buffered with `distance > 0` must always produce a single-element result, `BufferBuilder` now keeps only the largest-area polygon when the result has more than one polygon in this case. This does not apply for `distance <= 0`, since `distance = 0` can legitimately produce a multipolygon due to topology collapse, and `distance < 0` may legitimately erode a polygon into disconnected pieces.

Ported from JTS commit [`727943b68`](https://github.com/locationtech/jts/commit/727943b68cc36a9e395c28bfea9b40b720a4f971) (locationtech/jts#1161).

### 2. Handle all-invalid coordinate lists (JTS #1165)

`BufferCurveSetBuilder` could throw/crash when a line, polygon shell, or polygon hole had all of its coordinates removed as invalid (NaN/Infinite) or repeated during cleaning, since it passed the resulting empty coordinate array on to curve generation. Now these elements are skipped instead.

Ported from JTS commit [`fc9ed7dcb`](https://github.com/locationtech/jts/commit/fc9ed7dcb8921e7262633674e817a4f08a4ace25) (locationtech/jts#1165).

## Tests

Added regression tests ported/adapted from JTS's `BufferTest`:
- Artifact removal for line buffers (round and flat end caps)
- All-invalid-coordinate points, lines, polygon shells, and polygon holes

Verified 4 of the 6 new tests fail without the fix (crash, or wrong polygon/geometry count) and pass with it. The other 2 (`TestInvalidCoordPoint_JTS1165`, `TestInvalidCoordHole_JTS1165`) already passed pre-fix due to pre-existing NTS guards not present in JTS (`AddPoint`'s invalid-coordinate check, and `IsRingFullyEroded` treating a degenerate/empty ring as fully eroded) — kept as regression coverage for the ported behavior. Full `Buffer` test suite (167 tests) passes with no regressions.

Closes #867

---

**AI disclosure:** This change was implemented with GitHub Copilot CLI assistance, based on a direct diff against the referenced JTS commits and manual verification against the corresponding NTS buffer code. Please review carefully before merging.