### PR TITLE
Perf: squared-distance LineStringSnapper and spatial index for PolygonBuilder.PlaceFreeHoles

### DIFF
--- a/src/NetTopologySuite/Algorithm/Distance.cs
+++ b/src/NetTopologySuite/Algorithm/Distance.cs
@@ -201,6 +201,59 @@ namespace NetTopologySuite.Algorithm
         }
 
         /// <summary>
+        /// Computes the squared distance from a point p to a line segment AB
+        /// <para/>
+        /// Note: NON-ROBUST!
+        /// </summary>
+        /// <param name="p">The point to compute the distance for</param>
+        /// <param name="A">The first point of the first line</param>
+        /// <param name="B">The second point of the first line (must be different to A)</param>
+        /// <returns>The squared distance from p to line segment AB</returns>
+        public static double PointToSegmentSquared(Coordinate p, Coordinate A,
+            Coordinate B)
+        {
+            // if start = end, then just compute distance to one of the endpoints
+            if (A.X == B.X && A.Y == B.Y)
+                return p.DistanceSquared(A);
+
+            // otherwise use comp.graphics.algorithms Frequently Asked Questions method
+            /*
+             * (1) r = AC dot AB
+             *         ---------
+             *         ||AB||^2
+             *
+             * r has the following meaning:
+             *   r=0 P = A
+             *   r=1 P = B
+             *   r<0 P is on the backward extension of AB
+             *   r>1 P is on the forward extension of AB
+             *   0<r<1 P is interior to AB
+             */
+
+            double len2 = (B.X - A.X) * (B.X - A.X) + (B.Y - A.Y) * (B.Y - A.Y);
+            double r = ((p.X - A.X) * (B.X - A.X) + (p.Y - A.Y) * (B.Y - A.Y))
+                / len2;
+
+            if (r <= 0.0)
+                return p.DistanceSquared(A);
+            if (r >= 1.0)
+                return p.DistanceSquared(B);
+
+            /*
+             * (2) s = (Ay-Cy)(Bx-Ax)-(Ax-Cx)(By-Ay)
+             *         -----------------------------
+             *                    L^2
+             *
+             * Then the distance from C to P = |s|*L.
+             *
+             * This is the same calculation as DistancePointLinePerpendicular.
+             * Unrolled here for performance.
+             */
+            double s = ((A.Y - p.Y) * (B.X - A.X) - (A.X - p.X) * (B.Y - A.Y)) / len2;
+            return s * s * len2;
+        }
+
+        /// <summary>
         /// Computes the perpendicular distance from a point p to the (infinite) line
         /// containing the points AB
         /// </summary>

--- a/src/NetTopologySuite/Geometries/Coordinate.cs
+++ b/src/NetTopologySuite/Geometries/Coordinate.cs
@@ -399,6 +399,19 @@ namespace NetTopologySuite.Geometries
             return Mathematics.MathUtil.Hypot(dx, dy);
         }
 
+        /// <summary>
+        /// Computes the 2-dimensional squared Euclidean distance to another location.
+        /// </summary>
+        /// <param name="c">A <see cref="Coordinate"/> with which to do the distance comparison.</param>
+        /// <returns>the 2-dimensional squared Euclidean distance between the locations.</returns>
+        /// <remarks>The Z-ordinate is ignored.</remarks>
+        public double DistanceSquared(Coordinate c)
+        {
+            double dx = X - c.X;
+            double dy = Y - c.Y;
+            return dx * dx + dy * dy;
+        }
+
 #region System.Object overrides
         /// <summary>
         /// Returns <c>true</c> if <c>other</c> has the same values for the x and y ordinates.

--- a/src/NetTopologySuite/Geometries/Coordinate.cs
+++ b/src/NetTopologySuite/Geometries/Coordinate.cs
@@ -400,10 +400,10 @@ namespace NetTopologySuite.Geometries
         }
 
         /// <summary>
-        /// Computes the 2-dimensional squared Euclidean distance to another location.
+        /// Computes the squared 2-dimensional Euclidean distance to another location.
         /// </summary>
         /// <param name="c">A <see cref="Coordinate"/> with which to do the distance comparison.</param>
-        /// <returns>the 2-dimensional squared Euclidean distance between the locations.</returns>
+        /// <returns>the squared 2-dimensional Euclidean distance between the locations.</returns>
         /// <remarks>The Z-ordinate is ignored.</remarks>
         public double DistanceSquared(Coordinate c)
         {

--- a/src/NetTopologySuite/Operation/Overlay/Snap/LineStringSnapper.cs
+++ b/src/NetTopologySuite/Operation/Overlay/Snap/LineStringSnapper.cs
@@ -1,3 +1,4 @@
+using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.Operation.Overlay.Snap
@@ -11,9 +12,9 @@ namespace NetTopologySuite.Operation.Overlay.Snap
     public class LineStringSnapper
     {
         private readonly double _snapTolerance;
+        private readonly double _snapToleranceSq;
 
         private readonly Coordinate[] _srcPts;
-        private readonly LineSegment _seg = new LineSegment(); // for reuse during snapping
         private bool _allowSnappingToSourceVertices;
         private readonly bool _isClosed;
 
@@ -37,6 +38,7 @@ namespace NetTopologySuite.Operation.Overlay.Snap
             _srcPts = srcPts;
             _isClosed = IsClosed(_srcPts);// srcPts[0].Equals2D(srcPts[srcPts.Length - 1]);
             _snapTolerance = snapTolerance;
+            _snapToleranceSq = snapTolerance * snapTolerance;
         }
 
         public bool AllowSnappingToSourceVertices
@@ -171,23 +173,23 @@ namespace NetTopologySuite.Operation.Overlay.Snap
             int snapIndex = -1;
             for (int i = 0; i < srcCoords.Count - 1; i++)
             {
-                _seg.P0 = srcCoords[i];
-                _seg.P1 = srcCoords[i + 1];
+                var p0 = srcCoords[i];
+                var p1 = srcCoords[i + 1];
 
                 /*
                  * Check if the snap pt is equal to one of the segment endpoints.
                  *
                  * If the snap pt is already in the src list, don't snap at all.
                  */
-                if (_seg.P0.Equals2D(snapPt) || _seg.P1.Equals2D(snapPt))
+                if (p0.Equals2D(snapPt) || p1.Equals2D(snapPt))
                 {
                     if (_allowSnappingToSourceVertices)
                         continue;
                     return -1;
                 }
 
-                double dist = _seg.Distance(snapPt);
-                if (dist < _snapTolerance && dist < minDist)
+                double dist = DistanceComputer.PointToSegmentSquared(snapPt, p0, p1);
+                if (dist < _snapToleranceSq && dist < minDist)
                 {
                     minDist = dist;
                     snapIndex = i;

--- a/src/NetTopologySuite/Operation/OverlayNG/PolygonBuilder.cs
+++ b/src/NetTopologySuite/Operation/OverlayNG/PolygonBuilder.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Index;
+using NetTopologySuite.Index.HPRtree;
 using NetTopologySuite.Utilities;
 
 namespace NetTopologySuite.Operation.OverlayNG
@@ -177,13 +179,19 @@ namespace NetTopologySuite.Operation.OverlayNG
         /// <exception cref="TopologyException">If a hole cannot be assigned to a shell</exception>
         private void PlaceFreeHoles(IReadOnlyCollection<OverlayEdgeRing> shellList, IEnumerable<OverlayEdgeRing> freeHoleList)
         {
-            // TODO: use a spatial index to improve performance
+            var index = new HPRtree<OverlayEdgeRing>();
+            foreach (var shell in shellList)
+            {
+                index.Insert(shell.Ring.EnvelopeInternal, shell);
+            }
+
             foreach (var hole in freeHoleList)
             {
                 // only place this hole if it doesn't yet have a shell
                 if (hole.Shell == null)
                 {
-                    var shell = hole.FindEdgeRingContaining(shellList);
+                    var shellListOverlaps = index.Query(hole.Ring.EnvelopeInternal);
+                    var shell = hole.FindEdgeRingContaining(shellListOverlaps);
                     // only when building a polygon-valid result
                     if (_isEnforcePolygonal && shell == null)
                     {


### PR DESCRIPTION
Fixes #868

Ports two JTS 1.21 performance improvements not yet present in NTS:

- **[locationtech/jts#1111](https://github.com/locationtech/jts/pull/1111)** — `LineStringSnapper.FindSegmentIndexToSnap` now compares squared distances instead of calling `Distance()`, avoiding the `sqrt` in the hot comparison loop.
  - Added `Coordinate.DistanceSquared(Coordinate)`.
  - Added `DistanceComputer.PointToSegmentSquared(Coordinate, Coordinate, Coordinate)`.
  - `LineStringSnapper` now precomputes `_snapToleranceSq` and uses the squared-distance comparison; removed the reused `LineSegment` field which is no longer needed.

- **[locationtech/jts#1173](https://github.com/locationtech/jts/pull/1173)** — `PolygonBuilder.PlaceFreeHoles` now builds an `HPRtree<OverlayEdgeRing>` spatial index over the shell rings and queries it per free hole instead of doing a full linear scan (`FindEdgeRingContaining` over the complete shell list), removing the `TODO: use a spatial index to improve performance` comment.

## Testing
- `dotnet build src/NetTopologySuite/NetTopologySuite.csproj -c Debug` — succeeds.
- `dotnet test test/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj -c Debug` — all 2570 tests pass (25 skipped as before), 0 failures.