### PR TITLE
Fix dx computation in OffsetPointGenerator.ComputeOffsetPoints and add corresponding unit test

### DIFF
--- a/src/NetTopologySuite/Operation/Overlay/Validate/OffsetPointGenerator.cs
+++ b/src/NetTopologySuite/Operation/Overlay/Validate/OffsetPointGenerator.cs
@@ -77,7 +77,7 @@ namespace NetTopologySuite.Operation.Overlay.Validate
         /// <param name="offsetPts"></param>
         private void ComputeOffsetPoints(Coordinate p0, Coordinate p1, double offsetDistance, IList<Coordinate> offsetPts)
         {
-            double dx = p1.X - p0.Y;
+            double dx = p1.X - p0.X;
             double dy = p1.Y - p0.Y;
             double len = Mathematics.MathUtil.Hypot(dx, dy);
             // u is the vector that is the length of the offset, in the direction of the segment

--- a/test/NetTopologySuite.Tests.NUnit/Operation/Overlay/Validate/OffsetPointGeneratorTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/Overlay/Validate/OffsetPointGeneratorTest.cs
@@ -1,0 +1,45 @@
+﻿using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.Overlay.Validate;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Operation.Overlay.Validate
+{
+    /// <summary>
+    /// Tests for <see cref="OffsetPointGenerator"/>.
+    /// </summary>
+    /// <remarks>
+    /// See https://github.com/NetTopologySuite/NetTopologySuite/issues/879 -
+    /// <c>ComputeOffsetPoints</c> computed <c>dx</c> as <c>p1.X - p0.Y</c>
+    /// instead of <c>p1.X - p0.X</c>.
+    /// </remarks>
+    public class OffsetPointGeneratorTest : GeometryTestCase
+    {
+        [Test]
+        public void TestOffsetPointsForNonAxisAlignedSegment()
+        {
+            // Segment chosen so that p0.X != p0.Y, which exposes the bug where
+            // dx was computed as (p1.X - p0.Y) instead of (p1.X - p0.X).
+            var line = (LineString) Read("LINESTRING (0 5, 10 15)");
+            var generator = new OffsetPointGenerator(line);
+
+            var offsetPts = generator.GetPoints(1.0);
+
+            Assert.That(offsetPts.Count, Is.EqualTo(2));
+
+            double ux = 10.0 / System.Math.Sqrt(200);
+            double uy = 10.0 / System.Math.Sqrt(200);
+            var expectedLeft = new Coordinate(5 - uy, 10 + ux);
+            var expectedRight = new Coordinate(5 + uy, 10 - ux);
+
+            CheckEqualXY(expectedLeft, offsetPts[0]);
+            CheckEqualXY(expectedRight, offsetPts[1]);
+        }
+
+        private static void CheckEqualXY(Coordinate expected, Coordinate actual)
+        {
+            const double tolerance = 1e-9;
+            Assert.That(actual.X, Is.EqualTo(expected.X).Within(tolerance));
+            Assert.That(actual.Y, Is.EqualTo(expected.Y).Within(tolerance));
+        }
+    }
+}


### PR DESCRIPTION
Fix incorrect dx computation in OffsetPointGenerator.ComputeOffsetPoints

dx was computed as p1.X - p0.Y instead of p1.X - p0.X — a porting typo, not present in JTS's computeOffsetPoints, which has always used p1.x - p0.x. This rotated the perpendicular offset direction (and thus the "left"/"right" probe points) for any segment whose start point has X != Y.

Impact

This bug currently has no impact on any real overlay result. OverlayResultValidator (the sole consumer of OffsetPointGenerator) is only ever called from SnapIfNeededOverlayOp.cs, and that call is commented out — identically in upstream JTS's SnapIfNeededOverlayOp.java.

Its only other consumer is the JTS/NTS TestRunner's opt-in -geomop/OverlayValidatedGeometryOperation XML test hook — and even JTS's own TestOverlay.xml, the one file that references it, has that tag commented out. No XML test file in either repo currently activates it.

So the bug never corrupted a production overlay result; it only weakened an already-dormant, optional geometric self-check tool. We're fixing it anyway to keep this port faithful to JTS's algorithm, and to avoid latent risk if the validator is ever wired back in (as it is, unused, in JTS itself) or reused elsewhere.

Changes

Fix the dx computation.
Add OffsetPointGeneratorTest covering a non-axis-aligned segment (p0.X != p0.Y), which fails against the old code and passes with the fix.

Closes #879